### PR TITLE
refactor: consolidate common @using directives into _Imports.razor files

### DIFF
--- a/.squad/agents/legolas/history.md
+++ b/.squad/agents/legolas/history.md
@@ -212,3 +212,63 @@ bg-primary-hover  # Old custom hover state (now use dark: variant)
 
 **Filed:** `.squad/decisions/inbox/legolas-simplified-theme-architecture.md`
 
+---
+
+## 2025-01-29 — Razor @using Directives Consolidation
+
+### What I Learned
+
+**_Imports.razor files provide namespace inheritance for directory subtrees:**
+- `src/Web/Components/_Imports.razor` applies to all files under `Components/` (Pages/, Layout/, Shared/)
+- `src/Web/Features/_Imports.razor` applies to all files under `Features/` (BlogPosts/, UserManagement/)
+- These are hierarchical — child directories inherit parent _Imports directives
+- Common pattern: base framework usings in root _Imports, feature-specific in subdirectory _Imports
+
+**Common usings identified across Feature pages:**
+- `@using MediatR` appeared in 4 files (Create.razor, Index.razor, Edit.razor, ManageRoles.razor) — all Feature pages use MediatR for CQRS commands/queries
+- `@using Microsoft.AspNetCore.Authorization` appeared in 4 files (Create.razor, Edit.razor, ManageRoles.razor, Profile.razor) — auth attributes are common
+- `@using MyBlog.Web.Data` was already in Features/_Imports.razor, found redundantly in Index.razor and Edit.razor
+- `@using Microsoft.AspNetCore.Components.Authorization` appeared in Index.razor and NavMenu.razor — already in both _Imports files
+
+**File-specific usings should NOT be centralized:**
+- Feature namespace usings like `@using MyBlog.Web.Features.BlogPosts.Create` are unique to that page
+- Specialized types like `@using System.Security.Claims` in Profile.razor only used there
+- Component-specific usings like `@using MyBlog.Web.Security` for helper classes
+- These provide no DRY benefit and make dependencies less obvious
+
+**ConfirmDeleteDialog.razor had redundant using:**
+- `@using Microsoft.AspNetCore.Components` was present but unnecessary
+- Base component types (RenderFragment, EventCallback, Parameter attribute) are automatically available
+- Removing it didn't break the build — Blazor provides these by default
+
+**Components/_Imports.razor already comprehensive:**
+- Already included MediatR, Authorization, Components.Authorization, and other commonly-used namespaces
+- NavMenu.razor and Routes.razor both had redundant `@using Microsoft.AspNetCore.Components.Authorization`
+- No changes needed to Components/_Imports.razor itself
+
+**Updated files pattern:**
+1. Added common usings to Features/_Imports.razor (MediatR, Authorization)
+2. Removed those usings from individual feature pages
+3. Kept feature-namespace and specialized usings in individual files
+4. Verified build succeeded with 0 errors
+
+**Build verification critical for Razor changes:**
+- `dotnet build MyBlog.slnx --configuration Release` confirms no missing usings
+- Razor compiler errors are clear when a namespace is missing
+- Fast feedback loop (8 seconds for full build)
+
+**Files changed (9 total):**
+- `Features/_Imports.razor` — added MediatR and Authorization
+- `Features/BlogPosts/Create/Create.razor` — removed 2 usings
+- `Features/BlogPosts/List/Index.razor` — removed 3 usings
+- `Features/BlogPosts/Edit/Edit.razor` — removed 3 usings
+- `Features/UserManagement/ManageRoles.razor` — removed 2 usings
+- `Features/UserManagement/Profile.razor` — removed 1 using
+- `Features/BlogPosts/Delete/ConfirmDeleteDialog.razor` — removed 1 using
+- `Components/Layout/NavMenu.razor` — removed 1 using
+- `Components/Routes.razor` — removed 1 using
+
+**Total reduction: 14 redundant @using directives eliminated**
+
+**Filed:** `.squad/decisions/inbox/legolas-razor-imports.md`
+

--- a/src/Web/Components/Layout/NavMenu.razor
+++ b/src/Web/Components/Layout/NavMenu.razor
@@ -1,4 +1,3 @@
-@using Microsoft.AspNetCore.Components.Authorization
 @inject IJSRuntime Js
 @inject NavigationManager Nav
 @inject ILogger<NavMenu> Logger

--- a/src/Web/Components/Routes.razor
+++ b/src/Web/Components/Routes.razor
@@ -1,6 +1,4 @@
-﻿@using Microsoft.AspNetCore.Components.Authorization
-
-<Router AppAssembly="typeof(Program).Assembly" NotFoundPage="typeof(Pages.NotFound)">
+﻿<Router AppAssembly="typeof(Program).Assembly" NotFoundPage="typeof(Pages.NotFound)">
     <Found Context="routeData">
         <AuthorizeRouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)">
             <NotAuthorized>

--- a/src/Web/Features/BlogPosts/Create/Create.razor
+++ b/src/Web/Features/BlogPosts/Create/Create.razor
@@ -1,7 +1,5 @@
 @page "/blog/create"
-@using MediatR
 @using MyBlog.Web.Features.BlogPosts.Create
-@using Microsoft.AspNetCore.Authorization
 @inject ISender Sender
 @inject NavigationManager Navigation
 @rendermode InteractiveServer

--- a/src/Web/Features/BlogPosts/Delete/ConfirmDeleteDialog.razor
+++ b/src/Web/Features/BlogPosts/Delete/ConfirmDeleteDialog.razor
@@ -1,5 +1,3 @@
-@using Microsoft.AspNetCore.Components
-
 @if (_isVisible)
 {
     <div class="fixed inset-0 z-[100] flex items-center justify-center bg-black/50" @onclick="OnCancel">

--- a/src/Web/Features/BlogPosts/Edit/Edit.razor
+++ b/src/Web/Features/BlogPosts/Edit/Edit.razor
@@ -1,8 +1,5 @@
 @page "/blog/edit/{Id:guid}"
-@using MediatR
-@using MyBlog.Web.Data
 @using MyBlog.Web.Features.BlogPosts.Edit
-@using Microsoft.AspNetCore.Authorization
 @inject ISender Sender
 @inject NavigationManager Navigation
 @rendermode InteractiveServer

--- a/src/Web/Features/BlogPosts/List/Index.razor
+++ b/src/Web/Features/BlogPosts/List/Index.razor
@@ -1,9 +1,6 @@
 @page "/blog"
-@using MediatR
-@using MyBlog.Web.Data
 @using MyBlog.Web.Features.BlogPosts.Delete
 @using MyBlog.Web.Features.BlogPosts.List
-@using Microsoft.AspNetCore.Components.Authorization
 @inject ISender Sender
 @rendermode InteractiveServer
 @attribute [StreamRendering]

--- a/src/Web/Features/UserManagement/ManageRoles.razor
+++ b/src/Web/Features/UserManagement/ManageRoles.razor
@@ -1,7 +1,5 @@
 @page "/admin/users"
-@using MediatR
 @using MyBlog.Web.Features.UserManagement
-@using Microsoft.AspNetCore.Authorization
 @inject ISender Sender
 @rendermode InteractiveServer
 @attribute [Authorize(Roles = "Admin")]

--- a/src/Web/Features/UserManagement/Profile.razor
+++ b/src/Web/Features/UserManagement/Profile.razor
@@ -1,6 +1,5 @@
 @page "/profile"
 @using System.Security.Claims
-@using Microsoft.AspNetCore.Authorization
 @using MyBlog.Web.Security
 @attribute [Authorize]
 

--- a/src/Web/Features/_Imports.razor
+++ b/src/Web/Features/_Imports.razor
@@ -2,4 +2,6 @@
 @using Microsoft.AspNetCore.Components.Web
 @using static Microsoft.AspNetCore.Components.Web.RenderMode
 @using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Authorization
+@using MediatR
 @using MyBlog.Web.Data


### PR DESCRIPTION
## Summary
This PR consolidates common `@using` directives from individual `.razor` files into the appropriate `_Imports.razor` files to reduce duplication and improve maintainability.

## Changes

### Features/_Imports.razor
Added:
- `@using Microsoft.AspNetCore.Authorization`
- `@using MediatR`

### Removed redundant usings from:

**Features/BlogPosts/Create/Create.razor**
- Removed `@using MediatR`
- Removed `@using Microsoft.AspNetCore.Authorization`

**Features/BlogPosts/List/Index.razor**
- Removed `@using MediatR`
- Removed `@using MyBlog.Web.Data`
- Removed `@using Microsoft.AspNetCore.Components.Authorization`

**Features/BlogPosts/Edit/Edit.razor**
- Removed `@using MediatR`
- Removed `@using MyBlog.Web.Data`
- Removed `@using Microsoft.AspNetCore.Authorization`

**Features/UserManagement/ManageRoles.razor**
- Removed `@using MediatR`
- Removed `@using Microsoft.AspNetCore.Authorization`

**Features/UserManagement/Profile.razor**
- Removed `@using Microsoft.AspNetCore.Authorization`
- Kept file-specific usings: `System.Security.Claims`, `MyBlog.Web.Security`

**Features/BlogPosts/Delete/ConfirmDeleteDialog.razor**
- Removed `@using Microsoft.AspNetCore.Components`

**Components/Layout/NavMenu.razor**
- Removed `@using Microsoft.AspNetCore.Components.Authorization`

**Components/Routes.razor**
- Removed `@using Microsoft.AspNetCore.Components.Authorization`

## Verification
✅ Build succeeded with 0 errors: `dotnet build MyBlog.slnx --configuration Release`

## Notes
- All common usings are now centralized in appropriate `_Imports.razor` files
- File-specific usings (feature namespaces, specialized types) remain in individual files
- No functional changes, purely code organization improvement