### PR TITLE
ci: add PR build and test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,105 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'squad/**'
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+          dotnet-quality: 'preview'
+      
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+      
+      - name: Restore dependencies
+        run: dotnet restore MyBlog.slnx
+      
+      - name: Build solution
+        run: dotnet build MyBlog.slnx --configuration Release --no-restore
+        env:
+          CI: true
+      
+      - name: Run Architecture Tests
+        run: |
+          dotnet test tests/Architecture.Tests/Architecture.Tests.csproj \
+            --configuration Release \
+            --no-build \
+            --logger "trx;LogFileName=architecture-tests.trx" \
+            --collect:"XPlat Code Coverage" \
+            --results-directory ./test-results/architecture
+      
+      - name: Run Unit Tests
+        run: |
+          dotnet test tests/Unit.Tests/Unit.Tests.csproj \
+            --configuration Release \
+            --no-build \
+            --logger "trx;LogFileName=unit-tests.trx" \
+            --collect:"XPlat Code Coverage" \
+            --results-directory ./test-results/unit
+      
+      - name: Run Integration Tests
+        run: |
+          dotnet test tests/Integration.Tests/Integration.Tests.csproj \
+            --configuration Release \
+            --no-build \
+            --logger "trx;LogFileName=integration-tests.trx" \
+            --collect:"XPlat Code Coverage" \
+            --results-directory ./test-results/integration
+      
+      - name: Publish Test Results
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: Test Results
+          path: 'test-results/**/*.trx'
+          reporter: dotnet-trx
+          fail-on-error: true
+      
+      - name: Upload Coverage Reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-reports
+          path: test-results/**/coverage.cobertura.xml
+          retention-days: 30
+      
+      - name: Code Coverage Summary
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        if: always()
+        with:
+          filename: 'test-results/**/coverage.cobertura.xml'
+          badge: true
+          format: markdown
+          output: both
+      
+      - name: Add Coverage Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request' && always()
+        with:
+          recreate: true
+          path: code-coverage-results.md

--- a/.squad/agents/boromir/history.md
+++ b/.squad/agents/boromir/history.md
@@ -25,3 +25,41 @@
 - Merged PR #4 with squash + deleted branch
 - Verified main branch updated successfully
 
+### 2025-01-29 — Created CI/CD Workflow for Pull Requests
+
+**Project context:**
+- MyBlog solution uses .NET 10 (net10.0) with .slnx format (not .sln)
+- Three test projects: Architecture.Tests (6 tests), Unit.Tests (61 tests, 92.04% coverage), Integration.Tests (9 tests)
+- Unit tests use coverlet.msbuild with cobertura output format and 89% threshold
+- Integration tests use Testcontainers.MongoDb for MongoDB dependencies
+- Web project has custom Tailwind build target that skips when CI=true
+
+**Workflow features built:**
+1. **Triggers** — pull_request to main/squad/**, push to main
+2. **Build** — dotnet build MyBlog.slnx in Release mode with CI=true env var
+3. **Test execution** — all three test suites with TRX output + code coverage
+4. **Test reporting** — dorny/test-reporter@v1 for inline PR annotations
+5. **Coverage reporting** — irongut/CodeCoverageSummary@v1.3.0 for PR comments
+6. **NuGet caching** — caches ~/.nuget/packages keyed by csproj + Directory.Packages.props
+
+**Key decisions:**
+- Used .NET 10.x preview quality in setup-dotnet (global.json specifies 10.0.100)
+- Set CI=true environment variable for build to skip Tailwind compilation
+- Ran tests with --no-build to avoid double compilation
+- Used separate test result directories per suite for clean artifact organization
+- Applied permissions: contents:read, checks:write, pull-requests:write
+- Used marocchino/sticky-pull-request-comment for coverage to avoid comment spam
+
+**Integration test considerations:**
+- Testcontainers.MongoDb package detected — no special CI setup needed
+- GitHub Actions runner has Docker pre-installed, Testcontainers will pull images automatically
+- No external MongoDB service configuration required
+
+**Files created:**
+- `.github/workflows/ci.yml` — full CI pipeline with build, test, coverage
+
+**Next steps:**
+- Monitor first workflow run on PR #5 to verify all steps execute successfully
+- May need to adjust coverage thresholds or exclusions based on actual coverage data
+- Consider adding caching for Docker images if Testcontainers startup becomes slow
+

--- a/.squad/agents/boromir/history.md
+++ b/.squad/agents/boromir/history.md
@@ -1,1 +1,27 @@
 
+## Learnings
+
+### 2025-01-29 — PR #4 Review: Razor @using Consolidation
+
+**Review process for application code PRs:**
+- Always check for `.squad/` file modifications — they are only allowed in `squad/*` branches
+- Verify branch name matches pattern before flagging protected branch violation
+- Build verification is critical for Razor changes — missing usings are immediately caught by Razor compiler
+- Run full test suite (Architecture + Unit + Integration) to ensure no regressions
+
+**What was reviewed:**
+- PR #4 from Legolas: consolidated 14 redundant `@using` directives from 9 Razor files into `Features/_Imports.razor`
+- Added `@using Microsoft.AspNetCore.Authorization` and `@using MediatR` to Features/_Imports.razor
+- Branch: `squad/razor-imports-consolidation` (permitted .squad/ changes)
+
+**Build & test results:**
+- Build: ✅ 0 errors, 0 warnings
+- Architecture.Tests: ✅ 6 passed
+- Unit.Tests: ✅ 61 passed (92.04% coverage)
+- Integration.Tests: ✅ 9 passed
+- All tests: ✅ 76/76 passing
+
+**Action taken:**
+- Merged PR #4 with squash + deleted branch
+- Verified main branch updated successfully
+

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2,7 +2,45 @@
 
 ## Active Decisions
 
-No decisions recorded yet.
+### 1. Consolidate Common @using Directives into _Imports.razor Files
+
+**Date:** 2025-01-29  
+**Author:** Legolas (Frontend Developer)  
+**Status:** ✅ Implemented & Merged  
+**PR:** #4
+
+#### Decision
+
+Consolidate common `@using` directives into the appropriate `_Imports.razor` files while keeping file-specific usings in individual components.
+
+#### Implementation Details
+
+**Features/_Imports.razor** — Added:
+- `@using Microsoft.AspNetCore.Authorization`
+- `@using MediatR`
+
+**Removed from 9 files:** 14 redundant @using directives
+
+**Criteria for centralization:**
+- Appears in 2+ files under same `_Imports.razor` scope
+- Represents common framework dependency
+- Not tied to specific feature implementation
+
+#### Verification
+
+✅ Build passed (Release config, 0 errors, 0 warnings)  
+✅ 76/76 tests passing  
+✅ Code review approved  
+✅ Main updated to commit 60426b1
+
+#### Impact
+
+- **Code maintainability:** Improved (less duplication)
+- **Readability:** Slightly reduced (must reference _Imports for context)
+- **Developer experience:** Improved (new pages inherit common usings)
+- **Build time:** No change
+
+---
 
 ## Governance
 


### PR DESCRIPTION
Adds GitHub Actions CI workflow that runs on PRs with build checks, test results reporting, and code coverage.

## What this adds
- **Build validation** — compiles the solution in Release mode
- **Test execution** — runs all three test suites (Architecture, Unit, Integration)
- **Code coverage** — collects coverage metrics using coverlet
- **PR annotations** — test failures appear inline on PR diff via dorny/test-reporter
- **Coverage reports** — posts coverage summary as PR comment using irongut/CodeCoverageSummary
- **NuGet caching** — speeds up builds by caching packages

## Workflow triggers
- Pull requests targeting `main`
- Pushes to `main`

## Notes
- Integration tests use Testcontainers for MongoDB (handled automatically in CI)
- Unit tests already have 92.04% coverage with threshold enforcement
- Build skips Tailwind CSS compilation in CI (see Web.csproj target)

Closes no issue — infrastructure improvement requested by @mpaulosky.