### PR TITLE
fix(auth): support Auth0 role claim namespace variations

### DIFF
--- a/src/Web/Security/RoleClaimsHelper.cs
+++ b/src/Web/Security/RoleClaimsHelper.cs
@@ -32,6 +32,38 @@ public static class RoleClaimsHelper
             : DefaultRoleClaimTypes;
     }
 
+    public static bool IsRoleClaimType(string? claimType)
+    {
+        if (string.IsNullOrWhiteSpace(claimType))
+        {
+            return false;
+        }
+
+        if (claimType.Equals(ClaimTypes.Role, StringComparison.OrdinalIgnoreCase)
+            || claimType.Equals("roles", StringComparison.OrdinalIgnoreCase)
+            || claimType.Equals("role", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        var lastSlash = claimType.LastIndexOf('/');
+        var lastColon = claimType.LastIndexOf(':');
+        var separatorIndex = Math.Max(lastSlash, lastColon);
+        var tail = separatorIndex >= 0 ? claimType[(separatorIndex + 1)..] : claimType;
+
+        return tail.Equals("roles", StringComparison.OrdinalIgnoreCase)
+            || tail.Equals("role", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static IReadOnlyList<string> GetEffectiveRoleClaimTypes(IEnumerable<Claim> claims, IEnumerable<string>? roleClaimTypes)
+    {
+        return (roleClaimTypes ?? DefaultRoleClaimTypes)
+            .Append(ClaimTypes.Role)
+            .Concat(claims.Select(claim => claim.Type).Where(IsRoleClaimType))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
     public static IReadOnlyList<string> ExpandRoleValues(string? claimValue)
     {
         if (string.IsNullOrWhiteSpace(claimValue))
@@ -73,7 +105,7 @@ public static class RoleClaimsHelper
 
     public static void AddRoleClaims(ClaimsIdentity identity, IEnumerable<string> roleClaimTypes)
     {
-        foreach (var roleClaimType in roleClaimTypes)
+        foreach (var roleClaimType in GetEffectiveRoleClaimTypes(identity.Claims, roleClaimTypes))
         {
             foreach (var claim in identity.FindAll(roleClaimType).ToList())
             {
@@ -90,10 +122,7 @@ public static class RoleClaimsHelper
 
     public static IReadOnlyList<string> GetRoles(ClaimsPrincipal user, IEnumerable<string>? roleClaimTypes = null)
     {
-        var types = (roleClaimTypes ?? DefaultRoleClaimTypes)
-            .Append(ClaimTypes.Role)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
+        var types = GetEffectiveRoleClaimTypes(user.Claims, roleClaimTypes);
 
         return user.Claims
             .Where(claim => types.Contains(claim.Type, StringComparer.OrdinalIgnoreCase))

--- a/src/Web/appsettings.json
+++ b/src/Web/appsettings.json
@@ -10,6 +10,7 @@
     "Domain": "",
     "ClientId": "",
     "RoleClaimTypes": [
+      "https://articlesite.com/roles",
       "https://myblog/roles",
       "roles",
       "role"

--- a/tests/Unit.Tests/Features/UserManagement/ProfileTests.cs
+++ b/tests/Unit.Tests/Features/UserManagement/ProfileTests.cs
@@ -109,7 +109,7 @@ public class ProfileTests : BunitContext
 
 		if (!string.IsNullOrWhiteSpace(rolesJson))
 		{
-			claims.Add(new Claim("https://myblog/roles", rolesJson));
+			claims.Add(new Claim("https://articlesite.com/roles", rolesJson));
 		}
 
 		claims.AddRange(extraClaims);

--- a/tests/Unit.Tests/Security/RoleClaimsHelperTests.cs
+++ b/tests/Unit.Tests/Security/RoleClaimsHelperTests.cs
@@ -30,9 +30,10 @@ public class RoleClaimsHelperTests
 		var configuration = new ConfigurationBuilder()
 				.AddInMemoryCollection(new Dictionary<string, string?>
 				{
-					["Auth0:RoleClaimTypes:0"] = "roles",
+					["Auth0:RoleClaimTypes:0"] = "https://articlesite.com/roles",
 					["Auth0:RoleClaimTypes:1"] = "https://myblog/roles",
-					["Auth0:RoleClaimTypes:2"] = "roles"
+					["Auth0:RoleClaimTypes:2"] = "roles",
+					["Auth0:RoleClaimTypes:3"] = "roles"
 				})
 				.Build();
 
@@ -40,7 +41,7 @@ public class RoleClaimsHelperTests
 		var result = RoleClaimsHelper.GetRoleClaimTypes(configuration);
 
 		// Assert
-		result.Should().BeEquivalentTo(["roles", "https://myblog/roles"]);
+		result.Should().BeEquivalentTo(["https://articlesite.com/roles", "https://myblog/roles", "roles"]);
 	}
 
 	[Fact]
@@ -68,18 +69,33 @@ public class RoleClaimsHelperTests
 		result.Should().BeEquivalentTo(expected);
 	}
 
+	[Theory]
+	[InlineData("roles", true)]
+	[InlineData("role", true)]
+	[InlineData("https://articlesite.com/roles", true)]
+	[InlineData("http://schemas.microsoft.com/ws/2008/06/identity/claims/role", true)]
+	[InlineData("https://articlesite.com/app_metadata", false)]
+	public void IsRoleClaimType_DetectsExpectedClaimTypes(string claimType, bool expected)
+	{
+		// Act
+		var result = RoleClaimsHelper.IsRoleClaimType(claimType);
+
+		// Assert
+		result.Should().Be(expected);
+	}
+
 	[Fact]
 	public void AddRoleClaims_AddsExpandedRoleClaimsWithoutDuplicates()
 	{
 		// Arrange
 		var identity = new ClaimsIdentity(new[]
 		{
-						new Claim("roles", "Admin,Author"),
+						new Claim("https://articlesite.com/roles", "Admin,Author"),
 						new Claim(ClaimTypes.Role, "Admin")
 				}, "TestAuth", ClaimTypes.Name, ClaimTypes.Role);
 
 		// Act
-		RoleClaimsHelper.AddRoleClaims(identity, ["roles"]);
+		RoleClaimsHelper.AddRoleClaims(identity, ["https://articlesite.com/roles"]);
 
 		// Assert
 		identity.FindAll(ClaimTypes.Role)
@@ -89,12 +105,32 @@ public class RoleClaimsHelperTests
 	}
 
 	[Fact]
+	public void AddRoleClaims_InfersNamespacedRoleClaims_WhenConfiguredTypesDoNotMatch()
+	{
+		// Arrange
+		var identity = new ClaimsIdentity(new[]
+		{
+						new Claim("https://articlesite.com/roles", "[\"Admin\",\"User\"]")
+				}, "TestAuth", ClaimTypes.Name, ClaimTypes.Role);
+
+		// Act
+		RoleClaimsHelper.AddRoleClaims(identity, ["https://myblog/roles"]);
+
+		// Assert
+		identity.FindAll(ClaimTypes.Role)
+				.Select(claim => claim.Value)
+				.Should()
+				.BeEquivalentTo(["Admin", "User"]);
+	}
+
+	[Fact]
 	public void GetRoles_CollectsDistinctRolesAcrossMultipleClaimTypes()
 	{
 		// Arrange
 		var principal = new ClaimsPrincipal(new ClaimsIdentity(new[]
 		{
 						new Claim(ClaimTypes.Role, "Admin"),
+						new Claim("https://articlesite.com/roles", "Admin"),
 						new Claim("https://myblog/roles", "[\"Author\",\"Admin\"]"),
 						new Claim("roles", "Editor,Author")
 				}, "TestAuth", ClaimTypes.Name, ClaimTypes.Role));
@@ -104,5 +140,22 @@ public class RoleClaimsHelperTests
 
 		// Assert
 		result.Should().Equal("Admin", "Author", "Editor");
+	}
+
+	[Fact]
+	public void GetRoles_IncludesNamespacedRoleClaims_WhenRoleClaimTypeWasNotConfigured()
+	{
+		// Arrange
+		var principal = new ClaimsPrincipal(new ClaimsIdentity(new[]
+		{
+						new Claim("https://articlesite.com/roles", "Admin"),
+						new Claim("https://articlesite.com/roles", "User")
+				}, "TestAuth", ClaimTypes.Name, ClaimTypes.Role));
+
+		// Act
+		var result = RoleClaimsHelper.GetRoles(principal, ["https://myblog/roles"]);
+
+		// Assert
+		result.Should().Equal("Admin", "User");
 	}
 }


### PR DESCRIPTION
## Overview

Fixes admin role display in Profile and NavMenu when Auth0 uses production namespace.

## Changes

- **RoleClaimsHelper**: Added namespace inference to detect role claims ending with `role` or `roles`
- **GetEffectiveRoleClaimTypes()**: Infers namespaced role claim types from authenticated user's actual claims
- **appsettings.json**: Updated to include production Auth0 namespace `https://articlesite.com/roles`
- **Tests**: Comprehensive coverage of namespace variations and inference behavior

## Technical Details

Auth0 exposes roles under `https://articlesite.com/roles` in production, but the app only recognized `https://myblog/roles`. Now the app automatically detects any claim type ending in 'role' or 'roles' and treats it as a role claim.

## Verification

- Release build passed ✓
- All 4 files staged with meaningful changes ✓
- Namespace inference enabled for Profile.razor and NavMenu ✓