### PR TITLE
feat(squad): add sprint planning workflow

### DIFF
--- a/.squad/playbooks/sprint-planning.md
+++ b/.squad/playbooks/sprint-planning.md
@@ -1,0 +1,303 @@
+# Sprint Planning Playbook
+
+**Owner:** Ralph (decomposition) + Aragorn (GH artifacts) + Boromir (worktrees)
+**Ref:** `.squad/ceremonies.md` (Sprint Planning ceremony)
+**Last Updated:** 2026-04-19
+
+---
+
+## Overview
+
+This playbook converts a `plan.md` into a full GitHub tracking structure:
+one milestone per sprint, issues per task, a project board entry per issue,
+and an isolated git worktree per sprint.
+
+**Trigger:** Auto — runs whenever `plan.md` is created or materially updated.
+
+| Agent | Responsibility |
+|-------|---------------|
+| Ralph | Reviews plan, decomposes into sprints, triggers ceremony |
+| Aragorn | Creates GH milestones, issues, project assignments, sprint close PR |
+| Boromir | Creates sprint branches and worktrees, tears down after sprint close |
+
+---
+
+## Step 1 — Ralph: Decompose the Plan
+
+Read `plan.md` and the SQL `todos` table. Group todos into logical sprints:
+
+- **By dependency:** todos that must precede others → earlier sprints
+- **By theme:** related work (e.g., all auth tasks) in one sprint
+- **By size:** target 3–6 issues per sprint
+
+Name each sprint with a short descriptive theme:
+
+| Sprint | Example Theme |
+|--------|--------------|
+| 1 | Foundation |
+| 2 | Auth & Security |
+| 3 | UI Polish |
+| 4 | Performance & Observability |
+
+Update `plan.md` with a Sprint Breakdown section before proceeding:
+
+```markdown
+## Sprint Breakdown
+- **Sprint 1 — Foundation:** todo-1, todo-2, todo-3
+- **Sprint 2 — Auth:** todo-4, todo-5
+```
+
+---
+
+## Step 2 — Aragorn: Create GitHub Milestones
+
+One milestone per sprint. Create via GitHub API:
+
+```bash
+gh api repos/mpaulosky/MyBlog/milestones \
+  -f title="Sprint N: {Theme}" \
+  -f description="{Sprint goal in one sentence}" \
+  -f due_on="{YYYY-MM-DDT00:00:00Z}" \
+  -f state="open"
+```
+
+**Naming convention:** `Sprint {N}: {Theme}` (e.g., `Sprint 1: Foundation`)
+
+Note the milestone number returned — you will need it for Step 5 and Step 7.
+
+---
+
+## Step 3 — Aragorn: Create GitHub Issues
+
+One issue per todo/unit of work within each sprint:
+
+```bash
+gh issue create \
+  --title "[Sprint N] {Verb} {Noun}" \
+  --milestone "Sprint N: {Theme}" \
+  --label "squad" \
+  --body "## Goal
+{Description from plan.md todo}
+
+## Acceptance Criteria
+- [ ] {criterion 1}
+- [ ] {criterion 2}
+
+## Sprint
+Sprint N: {Theme}
+
+## Plan Reference
+Todo ID: {todo-id}"
+```
+
+**Issue title convention:** `[Sprint N] {Verb} {Noun}`
+(e.g., `[Sprint 1] Add BlogPost entity and repository`)
+
+After creating each issue, **Aragorn immediately triages** it:
+- Replace `squad` label with `squad:{member}` (e.g., `squad:sam`)
+- This triggers normal issue routing for that member
+
+---
+
+## Step 4 — Aragorn: Add Issues to Project Board
+
+Add each new issue to the **MyBlog** GitHub Project:
+
+```bash
+# Find the project number
+gh project list --owner mpaulosky
+
+# Add issue to project (use the URL returned by `gh issue create`)
+gh project item-add {PROJECT_NUMBER} --owner mpaulosky --url {issue-url}
+```
+
+New items land in **Backlog** automatically. Move to **In Sprint** when the sprint begins:
+
+```bash
+# Update item status to "In Sprint"
+# (requires field ID and option ID — retrieve once and store)
+gh project item-edit \
+  --id {ITEM_ID} \
+  --field-id {STATUS_FIELD_ID} \
+  --project-id {PROJECT_ID} \
+  --single-select-option-id {IN_SPRINT_OPTION_ID}
+```
+
+---
+
+## Step 5 — Boromir: Create Sprint Branches and Worktrees
+
+For each sprint, create a long-lived sprint branch and a local worktree:
+
+```bash
+# Always start from latest dev
+git checkout dev && git pull origin dev
+
+# Create sprint branch
+git checkout -b sprint/{N}-{slug}
+git push -u origin sprint/{N}-{slug}
+git checkout dev
+
+# Create worktree (one directory up from repo root)
+git worktree add ../MyBlog-sprint-{N} sprint/{N}-{slug}
+```
+
+**Example — Sprint 1 "Foundation":**
+
+```bash
+git checkout dev && git pull origin dev
+git checkout -b sprint/1-foundation
+git push -u origin sprint/1-foundation
+git checkout dev
+git worktree add ../MyBlog-sprint-1 sprint/1-foundation
+```
+
+**Naming:**
+
+| Item | Convention |
+|------|-----------|
+| Sprint branch | `sprint/{N}-{slug}` |
+| Worktree directory | `../MyBlog-sprint-{N}/` |
+
+---
+
+## Step 6 — Working a Sprint
+
+Squad members working Sprint N:
+
+```bash
+# Enter the sprint worktree
+cd ../MyBlog-sprint-{N}
+
+# Create a feature branch FROM the sprint branch
+git checkout -b squad/{issue}-{slug}
+
+# ... do work, commit, push ...
+
+# Open PR targeting the SPRINT branch, NOT dev
+gh pr create \
+  --base sprint/{N}-{slug} \
+  --title "feat(scope): description (#issue)" \
+  --body "Closes #{issue-number}" \
+  --assignee @me
+```
+
+The standard **PR merge process** (`pr-merge-process.md`) applies normally,
+but the base branch is `sprint/{N}-{slug}` instead of `dev`.
+
+Move the project board item to **In Review** when the PR is open.
+Move to **Done** after it merges into the sprint branch.
+
+---
+
+## Step 7 — Sprint Close
+
+When all issues in the sprint milestone are resolved:
+
+### 7a — Ralph verifies 100% completion
+
+```bash
+gh api repos/mpaulosky/MyBlog/milestones/{milestone_number} \
+  | jq '{title, open_issues, closed_issues}'
+# open_issues must be 0 before proceeding
+```
+
+### 7b — Aragorn opens Sprint → dev PR
+
+```bash
+gh pr create \
+  --base dev \
+  --head sprint/{N}-{slug} \
+  --title "sprint({N}): merge sprint {N} — {theme} (#milestone)" \
+  --body "Closes milestone: Sprint {N}: {Theme}
+
+## Sprint Summary
+- {list of key changes}
+
+## Issues Closed
+- Closes #{issue-1}
+- Closes #{issue-2}
+
+## Checklist
+- [ ] All sprint issues closed
+- [ ] CI green
+- [ ] Milestone at 100%"
+```
+
+Full PR review process applies (pr-merge-process.md). Squash merge into `dev`.
+
+### 7c — Close the milestone
+
+```bash
+gh api -X PATCH repos/mpaulosky/MyBlog/milestones/{milestone_number} \
+  -f state="closed"
+```
+
+### 7d — Boromir removes the worktree
+
+```bash
+git worktree remove ../MyBlog-sprint-{N}
+git push origin --delete sprint/{N}-{slug}
+git branch -d sprint/{N}-{slug}
+```
+
+---
+
+## Step 8 — Release Gate (all sprints done)
+
+When **all** sprint milestones are closed:
+
+1. **Aragorn** reviews the project board — all issues in `Done` column
+2. **Aragorn** initiates the release playbook: `.squad/playbooks/release-myblog.md`
+3. **Release PR:** `dev` → `main` (standard release flow)
+4. After merge, move all project board items to `Released`
+
+---
+
+## Project Board Reference
+
+| Column | Meaning |
+|--------|---------|
+| `Backlog` | Created, not yet in an active sprint |
+| `In Sprint` | Assigned to the current active sprint |
+| `In Review` | PR open, CI running |
+| `Done` | Merged into sprint branch or dev |
+| `Released` | Merged into main |
+
+---
+
+## Conventions Summary
+
+| Item | Convention |
+|------|-----------|
+| Milestone name | `Sprint N: {Theme}` |
+| Issue title | `[Sprint N] {Verb} {Noun}` |
+| Sprint branch | `sprint/{N}-{slug}` |
+| Worktree directory | `../MyBlog-sprint-{N}/` |
+| Feature branch (in sprint) | `squad/{issue}-{slug}` (targets sprint branch) |
+| Sprint PR base | `sprint/{N}-{slug}` |
+| Sprint close PR base | `dev` |
+| Release PR base | `main` |
+| GH Project name | `MyBlog` |
+
+---
+
+## Anti-Patterns
+
+- ❌ **Opening `squad/{issue}` PRs directly to `dev`** during an active sprint
+- ❌ **Skipping worktree** — always work in `../MyBlog-sprint-{N}/` for isolation
+- ❌ **Closing milestone before all issues resolve** — Ralph confirms 0 open issues
+- ❌ **Releasing from a sprint branch** — only `dev` → `main` releases
+- ❌ **Starting sprint N+1 before sprint N PR merges to dev** — sequential sprint close
+- ❌ **Deleting worktree before sprint PR merges** — leads to lost work
+
+---
+
+## Related Documents
+
+- **Ceremony:** `.squad/ceremonies.md` (Sprint Planning)
+- **Skill:** `.squad/skills/sprint-planning/SKILL.md`
+- **PR merge process:** `.squad/playbooks/pr-merge-process.md`
+- **Pre-push gate:** `.squad/playbooks/pre-push-process.md`
+- **Release process:** `.squad/playbooks/release-myblog.md`
+- **Routing:** `.squad/routing.md` (sprint planning trigger)

--- a/.squad/playbooks/sprint-planning.md
+++ b/.squad/playbooks/sprint-planning.md
@@ -108,7 +108,7 @@ Add each new issue to the **MyBlog** GitHub Project:
 gh project list --owner mpaulosky
 
 # Add issue to project (use the URL returned by `gh issue create`)
-gh project item-add {PROJECT_NUMBER} --owner mpaulosky --url {issue-url}
+gh project item-add 4 --owner mpaulosky --url {issue-url}
 ```
 
 New items land in **Backlog** automatically. Move to **In Sprint** when the sprint begins:

--- a/.squad/routing.md
+++ b/.squad/routing.md
@@ -7,6 +7,7 @@ How to decide who handles what.
 | Work Type | Route To | Examples |
 |-----------|----------|----------|
 | Architecture decisions, ADRs, PR gates, triage | Aragorn | Solution design, dependency rules, PR review, breaking changes |
+| Sprint planning, GH milestone/issue creation, project board | Aragorn + Ralph | Plan decomposition, milestone creation, issue triage, project assignments |
 | Domain model, backend services, data layer | Sam | BlogPost entity, repositories, EF Core, caching, Aspire wiring |
 | Blazor UI, components, features, layout | Legolas | Feature slices, pages, components, Auth UI, NavMenu |
 | Unit, Architecture & Integration tests | Gimli | xUnit, FluentAssertions, NSubstitute, NetArchTest, coverage |
@@ -49,6 +50,7 @@ spawn prompt:
 | MongoDB filter patterns, list queries, caching | `.squad/skills/mongodb-filter-pattern/SKILL.md` | Any Sam or Gimli task touching query contracts, cache-key changes, list filtering, repository standardization, or handler-level caching. Owner: Sam (Backend). Supporting: Gimli (Tester). |
 | Mongo-backed integration tests | `.squad/skills/testcontainers-shared-fixture/SKILL.md` | Any Gimli or Sam task touching `tests/Integration.Tests/`, `MongoDbFixture`, collection definitions, or new repository/handler integration coverage against MongoDB. Owner: Gimli (Tester). |
 | Running-browser UI verification | `.squad/skills/webapp-testing/SKILL.md` | Any Gimli or Legolas task that already has bUnit coverage but still needs runtime verification of JS interop, Auth0 redirects, or AppHost smoke behavior. Do **not** inject this for ordinary unit/bUnit work or to create a new browser-test project. Owner: Gimli (Tester). |
+| Sprint planning, worktrees, sprint branch lifecycle | `.squad/playbooks/sprint-planning.md` + `.squad/skills/sprint-planning/SKILL.md` | Any Ralph or Aragorn task triggered by plan creation, milestone creation, sprint issue creation, project board updates, or worktree setup/teardown. Inject both assets into the spawn prompt. |
 | Push-capable squad work | `.squad/skills/pre-push-test-gate/SKILL.md` + `.squad/playbooks/pre-push-process.md` | Any task expected to end in `git push`, branch handoff, or local gate validation. This is the default for normal `squad/{issue}-{slug}` delivery after Sprint 1.1. |
 | Build/test gate failures | `.squad/skills/build-repair/SKILL.md` + `.squad/skills/pre-push-test-gate/SKILL.md` | Any task blocked by Release build failures, warning cleanup, failing tests, or a rejected pre-push Gates 2–4 run. Aragorn owns this route and can delegate the repair. |
 | PR review, approval, merge, and post-merge cleanup | `.squad/playbooks/pr-merge-process.md` | Any Aragorn-led PR gate once CI is green, including Copilot-review read, parallel reviewer fan-out, CHANGES_REQUESTED lockout, squash merge, and cleanup. |
@@ -72,6 +74,10 @@ After Sprint 1.1, these process assets are part of normal squad flow:
    before committing so work does not strand on a merged branch.
 5. **Do not reintroduce deleted imports.** Only route assets with an explicit
    MyBlog owner, fit, and usage rule.
+6. **When any `plan.md` is created or materially updated**, Ralph and Aragorn run
+   the Sprint Planning ceremony: decompose into sprints, create milestones + issues,
+   add to the MyBlog project board, and Boromir sets up worktrees. See
+   `.squad/playbooks/sprint-planning.md`.
 
 ## Rules
 

--- a/.squad/skills/sprint-planning/SKILL.md
+++ b/.squad/skills/sprint-planning/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: "sprint-planning"
+description: "Convert a plan.md into GitHub milestones, sprint issues, a project board, and worktrees for isolated sprint execution"
+domain: "planning, sprint, github-projects, worktrees"
+confidence: "high"
+source: "manual"
+tools:
+  - name: "gh api"
+    description: "Create milestones and update project board items via GitHub REST/GraphQL"
+    when: "Creating milestones or moving issues between project columns"
+  - name: "gh issue create"
+    description: "Create GitHub issues for each sprint todo"
+    when: "Aragorn creates sprint issues from plan.md todos"
+  - name: "gh project"
+    description: "Manage GitHub Projects v2 — add/update items, move columns"
+    when: "Adding sprint issues to the MyBlog project board"
+  - name: "git worktree"
+    description: "Manage isolated sprint working directories"
+    when: "Boromir sets up or tears down sprint worktrees"
+---
+
+## Context
+
+This skill applies whenever a `plan.md` is created or materially updated. Sprint
+Planning is **mandatory for ALL plans** — see `.squad/ceremonies.md` (Sprint
+Planning ceremony) for the trigger and participants.
+
+**Agents involved:**
+- **Ralph** — decomposes `plan.md` into logical sprints
+- **Aragorn** — creates GH milestones, issues, and project assignments
+- **Boromir** — creates sprint branches and worktrees
+
+**Full process:** `.squad/playbooks/sprint-planning.md`
+
+---
+
+## Patterns
+
+### Decomposition (Ralph)
+
+- Read `plan.md` and the SQL `todos` table
+- Group todos by dependency, theme, or size into sprints
+- Target **3–6 issues per sprint**
+- Earlier dependencies → earlier sprints
+- Document sprint groupings before Aragorn creates GH artifacts
+
+### Milestone Creation (Aragorn)
+
+```bash
+gh api repos/mpaulosky/MyBlog/milestones \
+  -f title="Sprint N: {Theme}" \
+  -f description="{sprint goal}" \
+  -f due_on="{YYYY-MM-DDT00:00:00Z}" \
+  -f state="open"
+```
+
+Naming: `Sprint N: {Theme}` (e.g., `Sprint 1: Foundation`)
+
+### Issue Creation (Aragorn)
+
+```bash
+gh issue create \
+  --title "[Sprint N] {Verb} {Noun}" \
+  --milestone "Sprint N: {Theme}" \
+  --label "squad" \
+  --body "## Goal
+{description from plan.md}
+
+## Acceptance Criteria
+- [ ] {criteria}
+
+## Sprint
+Sprint N: {Theme}
+
+## Plan Reference
+Todo: {todo-id}"
+```
+
+Triage immediately: remove `squad` label, add `squad:{member}` label.
+
+### Project Board (Aragorn)
+
+```bash
+# List projects to find the MyBlog project number
+gh project list --owner mpaulosky
+
+# Add an issue to the project
+gh project item-add {PROJECT_NUMBER} --owner mpaulosky --url {issue-url}
+```
+
+New items land in **Backlog**. Move to **In Sprint** when sprint starts.
+
+### Worktree Setup (Boromir)
+
+```bash
+git checkout dev && git pull origin dev
+git checkout -b sprint/{N}-{slug}
+git push -u origin sprint/{N}-{slug}
+git checkout dev
+git worktree add ../MyBlog-sprint-{N} sprint/{N}-{slug}
+```
+
+### Sprint Work (all squad members)
+
+```bash
+cd ../MyBlog-sprint-{N}           # enter sprint worktree
+git checkout -b squad/{issue}-{slug}   # feature branch from sprint branch
+# ... do work ...
+gh pr create --base sprint/{N}-{slug}  # PR targets sprint branch, NOT dev
+```
+
+### Sprint Close (Ralph → Aragorn → Boromir)
+
+```bash
+# 1. Ralph verifies 100% milestone completion
+gh api repos/mpaulosky/MyBlog/milestones/{N} | jq '{title,open_issues,closed_issues}'
+
+# 2. Aragorn opens sprint → dev PR (standard PR review applies)
+gh pr create --base dev --head sprint/{N}-{slug}
+
+# 3. After merge, close milestone
+gh api -X PATCH repos/mpaulosky/MyBlog/milestones/{N} -f state="closed"
+
+# 4. Boromir removes worktree
+git worktree remove ../MyBlog-sprint-{N}
+git push origin --delete sprint/{N}-{slug}
+git branch -d sprint/{N}-{slug}
+```
+
+---
+
+## Anti-Patterns
+
+- ❌ **Skipping sprint planning** when a plan is created — it is mandatory
+- ❌ **`squad/{issue}` PRs targeting `dev`** during a sprint — must target the sprint branch
+- ❌ **Starting sprint N+1** before sprint N's PR merges to `dev`
+- ❌ **Deleting worktree** before sprint PR merges
+- ❌ **Releasing from a sprint branch** — only release from `dev` → `main`
+- ❌ **Skipping worktree** — always work inside `../MyBlog-sprint-{N}/` for isolation

--- a/.squad/skills/sprint-planning/SKILL.md
+++ b/.squad/skills/sprint-planning/SKILL.md
@@ -85,7 +85,7 @@ Triage immediately: remove `squad` label, add `squad:{member}` label.
 gh project list --owner mpaulosky
 
 # Add an issue to the project
-gh project item-add {PROJECT_NUMBER} --owner mpaulosky --url {issue-url}
+gh project item-add 4 --owner mpaulosky --url {issue-url}
 ```
 
 New items land in **Backlog**. Move to **In Sprint** when sprint starts.

--- a/.squad/templates/ceremonies.md
+++ b/.squad/templates/ceremonies.md
@@ -22,6 +22,29 @@
 
 ---
 
+## Sprint Planning
+
+| Field | Value |
+|-------|-------|
+| **Trigger** | auto |
+| **When** | on plan creation or material update |
+| **Condition** | any `plan.md` created or materially updated |
+| **Facilitator** | Ralph (decompose) + Aragorn (GH artifacts) |
+| **Participants** | Ralph, Aragorn, Boromir |
+| **Time budget** | focused |
+| **Enabled** | ✅ yes |
+
+**Agenda:**
+1. Ralph reviews `plan.md` and SQL todos, groups into logical sprints (3–6 issues each)
+2. Aragorn creates one GitHub milestone per sprint (`Sprint N: {Theme}`)
+3. Aragorn creates GitHub issues per todo, assigned to milestones, triaged with `squad:{member}` label
+4. Aragorn adds all issues to the **MyBlog** GitHub Project board (Backlog column)
+5. Boromir creates `sprint/{N}-{slug}` branch and `../MyBlog-sprint-{N}/` worktree per sprint
+
+**See:** `.squad/playbooks/sprint-planning.md`
+
+---
+
 ## Retrospective
 
 | Field | Value |


### PR DESCRIPTION
## Summary

Implements the standard sprint planning workflow decided in session, triggered on every `plan.md` creation or material update.

## Changes

| File | Change |
|------|--------|
| `.squad/templates/ceremonies.md` | Added Sprint Planning ceremony |
| `.squad/routing.md` | Added planning route (Ralph + Aragorn), skill injection row, guardrail #6 |
| `.squad/playbooks/sprint-planning.md` | New — 8-step authoritative playbook |
| `.squad/skills/sprint-planning/SKILL.md` | New — skill for agent injection |

## Workflow Added

On every `plan.md` creation or material update:
1. **Ralph** decomposes todos → logical sprints (3–6 issues each)
2. **Aragorn** creates GitHub milestones (`Sprint N: {Theme}`)
3. **Aragorn** creates GitHub issues, assigns milestones + `squad:{member}` labels
4. **Aragorn** adds issues to GitHub Project board (Backlog column)
5. **Boromir** creates `sprint/{N}-{slug}` branch + `../MyBlog-sprint-{N}/` worktree

## ⚠️ Manual Step Required

**GitHub Project board** ("MyBlog" with columns: Backlog → In Sprint → In Review → Done → Released) cannot be created headlessly — it requires the `project` OAuth scope via browser flow.

To create it:
```sh
gh auth refresh -s project
gh project create --owner mpaulosky --title "MyBlog"
# Then add columns: Backlog, In Sprint, In Review, Done, Released
```

Closes #28
