### PR TITLE
Add E2E.Tests Aspire xUnit project

### DIFF
--- a/MyBlog.slnx
+++ b/MyBlog.slnx
@@ -7,6 +7,7 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Architecture.Tests/Architecture.Tests.csproj" />
+    <Project Path="tests/E2E.Tests/E2E.Tests.csproj" />
     <Project Path="tests/Integration.Tests/Integration.Tests.csproj" />
     <Project Path="tests/Unit.Tests/Unit.Tests.csproj" />
   </Folder>

--- a/tests/E2E.Tests/E2E.Tests.csproj
+++ b/tests/E2E.Tests/E2E.Tests.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>MyBlog.E2E.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.Testing" Version="13.2.2" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0" />
+    <PackageReference Include="FluentAssertions" Version="8.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System.Net" />
+    <Using Include="Aspire.Hosting.ApplicationModel" />
+    <Using Include="Aspire.Hosting.Testing" />
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AppHost\AppHost.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/tests/E2E.Tests/GlobalUsings.cs
+++ b/tests/E2E.Tests/GlobalUsings.cs
@@ -1,0 +1,13 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     GlobalUsings.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  E2E.Tests
+//=======================================================
+
+global using FluentAssertions;
+global using Aspire.Hosting.ApplicationModel;
+global using Aspire.Hosting.Testing;
+global using Xunit;

--- a/tests/E2E.Tests/WebAppTests.cs
+++ b/tests/E2E.Tests/WebAppTests.cs
@@ -1,0 +1,44 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     WebAppTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  E2E.Tests
+//=======================================================
+
+namespace MyBlog.E2E.Tests;
+
+public class WebAppTests
+{
+    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(60);
+
+    [Fact]
+    public async Task GetWebResourceRootReturnsOkStatusCode()
+    {
+        // Arrange
+        var cancellationToken = new CancellationTokenSource(DefaultTimeout).Token;
+
+        var appHost = await DistributedApplicationTestingBuilder
+            .CreateAsync<Projects.MyBlog_AppHost>(cancellationToken);
+
+        appHost.Services.ConfigureHttpClientDefaults(clientBuilder =>
+        {
+            clientBuilder.AddStandardResilienceHandler();
+        });
+
+        await using var app = await appHost.BuildAsync(cancellationToken).WaitAsync(DefaultTimeout, cancellationToken);
+        await app.StartAsync(cancellationToken).WaitAsync(DefaultTimeout, cancellationToken);
+
+        // Act
+        using var httpClient = app.CreateHttpClient("webfrontend");
+        await app.ResourceNotifications
+            .WaitForResourceHealthyAsync("webfrontend", cancellationToken)
+            .WaitAsync(DefaultTimeout, cancellationToken);
+
+        using var response = await httpClient.GetAsync("/", cancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+    }
+}

--- a/tests/E2E.Tests/xunit.runner.json
+++ b/tests/E2E.Tests/xunit.runner.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "methodDisplay": "method",
+  "methodDisplayOptions": "all",
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": true
+}


### PR DESCRIPTION
## Summary

Adds `tests/E2E.Tests` — an Aspire xUnit project that spins up the full application via `DistributedApplicationTestingBuilder` and validates HTTP-level behavior.

Closes #48

Working as Pippin (test specialist)

## Changes

| File | Action |
|------|--------|
| `tests/E2E.Tests/E2E.Tests.csproj` | Created — `net10.0` xUnit project referencing AppHost |
| `tests/E2E.Tests/GlobalUsings.cs` | Created — standard header + global usings |
| `tests/E2E.Tests/xunit.runner.json` | Created — `parallelizeAssembly=false` |
| `tests/E2E.Tests/WebAppTests.cs` | Created — smoke test: `GET /` → `200 OK` |
| `MyBlog.slnx` | Updated — E2E.Tests added under `/tests/` folder |

## Testing

- Smoke test uses `DistributedApplicationTestingBuilder<Projects.MyBlog_AppHost>` to start the full Aspire stack
- Waits for `webfrontend` resource healthy (60s timeout)
- Asserts `GET /` returns `200 OK`
- No Testcontainers needed — Aspire manages MongoDB + Redis infra

## Process Note

⚠️ This task was flagged as "needs review" — initial implementation bypassed the plan workflow (no issue/branch/project tracking). Remediated: issue #48 created, added to Project #4, work moved to proper `squad/48-add-e2e-tests` branch.