### PR TITLE
chore: harden plan workflow — no-code-before-issue gate

### DIFF
--- a/.squad/playbooks/pr-merge-process.md
+++ b/.squad/playbooks/pr-merge-process.md
@@ -53,12 +53,15 @@ gh pr checks <PR-number> --watch --interval 5
 
 Ralph MUST verify ALL of the following before spawning reviewers. Any failing gate blocks review:
 
-| Gate                | Command                                             | Expected                   |
-| ------------------- | --------------------------------------------------- | -------------------------- |
-| CI green            | `gh pr checks <N> --watch --interval 5`             | All passing                |
-| No conflicts        | `gh pr view <N> --json mergeable -q .mergeable`     | `MERGEABLE`                |
-| PR template filled  | `gh pr view <N> --json body`                        | Contains filled checkboxes |
-| Branch is `squad/*` | `gh pr view <N> --json headRefName -q .headRefName` | Starts with `squad/`       |
+| Gate                      | Command                                                          | Expected                        |
+| ------------------------- | ---------------------------------------------------------------- | ------------------------------- |
+| GitHub issue exists       | `gh pr view <N> --json body -q .body \| grep -E "Closes #[0-9]+"` | Contains `Closes #N`            |
+| CI green                  | `gh pr checks <N> --watch --interval 5`                          | All passing                     |
+| No conflicts              | `gh pr view <N> --json mergeable -q .mergeable`                  | `MERGEABLE`                     |
+| PR template filled        | `gh pr view <N> --json body`                                     | Contains filled checkboxes      |
+| Branch is `squad/*`       | `gh pr view <N> --json headRefName -q .headRefName`              | Starts with `squad/`            |
+
+> **If `Closes #N` is missing**, the PR was opened without a GitHub issue. Ralph must STOP, create the issue, link it in the PR body, assign it to the correct milestone and Project #4, then re-run this gate.
 
 ## Step 4 — Spawn Reviewers
 
@@ -180,6 +183,7 @@ echo "✅ Orphan branch cleanup complete."
 
 ## Anti-Patterns
 
+- ❌ **Opening a PR without a `Closes #N` link** — Every PR must reference a GitHub issue
 - ❌ **Requesting review while CI is failing** — Wait for green first
 - ❌ **PR author fixing their own rejected code** — Lockout enforced per rejection protocol
 - ❌ **Merge commit instead of squash** — Use `--squash` for clean history

--- a/.squad/playbooks/sprint-planning.md
+++ b/.squad/playbooks/sprint-planning.md
@@ -282,8 +282,33 @@ When **all** sprint milestones are closed:
 
 ---
 
+## Hard Gate — No Code Before Issue
+
+> **This rule is absolute and has no exceptions.**
+
+Before any agent writes, modifies, or commits code, a GitHub issue **must** exist for the work. This gate applies to every work request regardless of how it arrives — `[[PLAN]]`, direct user instruction, or agent initiative.
+
+**Enforcement sequence (runs before Step 1):**
+
+```
+1. Does a GitHub issue exist for this work?
+   YES → confirm it is assigned to the correct milestone + Project #4, then proceed to Step 1
+   NO  → CREATE the issue now before touching any file
+         → Assign to milestone, add to Project #4
+         → Create squad/{issue}-{slug} branch
+         → THEN and only then begin writing code
+```
+
+If you skip this gate and write code without an issue, you have violated the squad's process.
+The work must be stashed, the issue created retroactively, a proper branch checked out, and
+the stash re-applied before committing. This costs time — follow the gate.
+
+---
+
 ## Anti-Patterns
 
+- ❌ **Writing any code before a GitHub issue exists** — always create the issue first
+- ❌ **Implementing a `[[PLAN]]` request without first running the sprint planning ceremony** — plan → issue → branch → code
 - ❌ **Opening `squad/{issue}` PRs directly to `dev`** during an active sprint
 - ❌ **Skipping worktree** — always work in `../MyBlog-sprint-{N}/` for isolation
 - ❌ **Closing milestone before all issues resolve** — Ralph confirms 0 open issues

--- a/.squad/routing.md
+++ b/.squad/routing.md
@@ -62,22 +62,30 @@ spawn prompt:
 
 After Sprint 1.1, these process assets are part of normal squad flow:
 
-1. **Before any push-ready handoff**, route through the pre-push gate skill and
+1. **Before writing any code**, a GitHub issue MUST exist for the work. This is an
+   absolute gate with no exceptions. If no issue exists, create it first — assign
+   to the correct milestone, add to Project #4 — then create the `squad/{issue}-{slug}`
+   branch, and only then write code. See the Hard Gate section in
+   `.squad/playbooks/sprint-planning.md`.
+2. **Before any push-ready handoff**, route through the pre-push gate skill and
    pre-push playbook so agents respect the live MyBlog hook: `squad/{issue}-{slug}`
    branch naming, Release build, `Architecture.Tests`, `Unit.Tests`, and
    `Integration.Tests`.
-2. **When build or test health is red**, route through build repair first. Do not
+3. **When build or test health is red**, route through build repair first. Do not
    treat a broken branch as normal feature work.
-3. **When PR work starts**, Aragorn and any spawned reviewers use the PR merge
+4. **When PR work starts**, Aragorn and any spawned reviewers use the PR merge
    playbook as the governing checklist.
-4. **When a session resumes on an older squad branch**, apply the merged-PR guard
+5. **When a session resumes on an older squad branch**, apply the merged-PR guard
    before committing so work does not strand on a merged branch.
-5. **Do not reintroduce deleted imports.** Only route assets with an explicit
+6. **Do not reintroduce deleted imports.** Only route assets with an explicit
    MyBlog owner, fit, and usage rule.
-6. **When any `plan.md` is created or materially updated**, Ralph and Aragorn run
+7. **When any `plan.md` is created or materially updated**, Ralph and Aragorn run
    the Sprint Planning ceremony: decompose into sprints, create milestones + issues,
    add to the MyBlog project board, and Boromir sets up worktrees. See
    `.squad/playbooks/sprint-planning.md`.
+8. **When a user makes any coding request** (direct instruction, `[[PLAN]]`, or
+   follow-on work), the very first agent action is to check whether a GitHub issue
+   exists. If not, create it before any file is opened or modified.
 
 ## Rules
 


### PR DESCRIPTION
## Summary

Closes #50

Adds an explicit **"no code before issue"** hard gate to prevent future process violations where implementation starts before a GitHub issue is created.

## Changes

### `routing.md`
- **Guardrail #1** (new): Absolute pre-code issue check — any work must have an existing GitHub issue before any file is touched
- **Guardrail #8** (new): Direct user coding requests trigger the same issue-first check

### `sprint-planning.md`
- **New section: Hard Gate — No Code Before Issue** — enforcement sequence with explicit YES/NO decision tree
- **Anti-patterns**: Added `❌ Writing any code before a GitHub issue exists` and `❌ Implementing a [[PLAN]] request without running the sprint planning ceremony`

### `pr-merge-process.md`
- **Ralph's Pre-Review Gate**: Added `GitHub issue exists` row — PR body must contain `Closes #N`; if missing, Ralph creates the issue before review proceeds
- **Anti-patterns**: Added `❌ Opening a PR without a Closes #N link`

## Testing

This is a documentation/process change. No code was modified; no build/test verification needed.