### PR TITLE
ci(#56): automate project board column transitions on PR events

### DIFF
--- a/.github/workflows/project-board-automation.yml
+++ b/.github/workflows/project-board-automation.yml
@@ -1,0 +1,113 @@
+name: Project Board Automation
+
+on:
+  pull_request:
+    types: [opened, closed]
+
+# repository-projects: write covers Projects v2 for user-owned repos.
+# If mutations fail with a 403, store a PAT with 'project' scope as
+# secrets.GH_PROJECT_TOKEN and replace secrets.GITHUB_TOKEN below.
+permissions:
+  issues: read
+  pull-requests: read
+  repository-projects: write
+
+env:
+  PROJECT_ID: PVT_kwHOA5k0b84BVFTy
+  STATUS_FIELD_ID: PVTSSF_lAHOA5k0b84BVFTyzhQjgPk
+  IN_REVIEW_OPTION_ID: df73e18b
+  DONE_OPTION_ID: "98236657"
+
+jobs:
+  update-project-board:
+    # Trigger on PR open OR on PR merge (not plain close)
+    if: >
+      github.event.action == 'opened' ||
+      (github.event.action == 'closed' && github.event.pull_request.merged == true)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Move linked issues on project board
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const action = context.payload.action;
+            const pr     = context.payload.pull_request;
+
+            const optionId   = action === 'opened' ? process.env.IN_REVIEW_OPTION_ID : process.env.DONE_OPTION_ID;
+            const columnName = action === 'opened' ? 'In Review' : 'Done';
+
+            // Parse "Closes #N", "Fixes #N", "Resolves #N" (case-insensitive)
+            const body         = pr.body || '';
+            const issueNumbers = [...body.matchAll(/(?:closes|fixes|resolves)\s+#(\d+)/gi)]
+                                   .map(m => parseInt(m[1]));
+
+            if (issueNumbers.length === 0) {
+              core.info(`PR #${pr.number}: no linked issues found — skipping`);
+              return;
+            }
+
+            core.info(`PR #${pr.number} (${action}): moving issues [${issueNumbers.join(', ')}] → ${columnName}`);
+
+            for (const issueNumber of issueNumbers) {
+              // Resolve issue node ID
+              let issueNodeId;
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo:  context.repo.repo,
+                  issue_number: issueNumber,
+                });
+                issueNodeId = issue.node_id;
+              } catch (err) {
+                core.warning(`Could not fetch issue #${issueNumber}: ${err.message}`);
+                continue;
+              }
+
+              // Find the project item for this issue in the MyBlog project board
+              const projectQuery = await github.graphql(`
+                query($nodeId: ID!) {
+                  node(id: $nodeId) {
+                    ... on Issue {
+                      projectItems(first: 20) {
+                        nodes {
+                          id
+                          project { id }
+                        }
+                      }
+                    }
+                  }
+                }
+              `, { nodeId: issueNodeId });
+
+              const projectItem = projectQuery.node?.projectItems?.nodes?.find(
+                item => item.project.id === process.env.PROJECT_ID
+              );
+
+              if (!projectItem) {
+                core.warning(`Issue #${issueNumber} is not on the MyBlog project board — skipping`);
+                continue;
+              }
+
+              // Update the Status field
+              await github.graphql(`
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $projectId
+                    itemId:    $itemId
+                    fieldId:   $fieldId
+                    value:     { singleSelectOptionId: $optionId }
+                  }) {
+                    projectV2Item { id }
+                  }
+                }
+              `, {
+                projectId: process.env.PROJECT_ID,
+                itemId:    projectItem.id,
+                fieldId:   process.env.STATUS_FIELD_ID,
+                optionId:  optionId,
+              });
+
+              core.info(`✅ Issue #${issueNumber} → ${columnName}`);
+            }

--- a/.squad/playbooks/sprint-planning.md
+++ b/.squad/playbooks/sprint-planning.md
@@ -111,7 +111,7 @@ gh project list --owner mpaulosky
 gh project item-add 4 --owner mpaulosky --url {issue-url}
 ```
 
-New items land in **Backlog** automatically. Move to **In Sprint** when the sprint begins:
+New items land in **Backlog** automatically. Move each item to **In Sprint** when the sprint begins — this is a **manual action** performed at sprint kickoff:
 
 ```bash
 # Update item status to "In Sprint"
@@ -122,6 +122,9 @@ gh project item-edit \
   --project-id {PROJECT_ID} \
   --single-select-option-id {IN_SPRINT_OPTION_ID}
 ```
+
+> **Note:** "In Review" and "Done" transitions are **automated** by
+> `.github/workflows/project-board-automation.yml` — see Step 6.
 
 ---
 
@@ -185,8 +188,12 @@ gh pr create \
 The standard **PR merge process** (`pr-merge-process.md`) applies normally,
 but the base branch is `sprint/{N}-{slug}` instead of `dev`.
 
-Move the project board item to **In Review** when the PR is open.
-Move to **Done** after it merges into the sprint branch.
+**Project board transitions are automated** by `.github/workflows/project-board-automation.yml`:
+- PR opened → issue moves to **In Review** automatically
+- PR merged → issue moves to **Done** automatically
+
+The PR body must include `Closes #{issue-number}` (or `Fixes`/`Resolves`) for the
+automation to find and update the linked issue. No manual board moves are needed.
 
 ---
 

--- a/.squad/playbooks/sprint-planning.md
+++ b/.squad/playbooks/sprint-planning.md
@@ -69,7 +69,13 @@ Note the milestone number returned — you will need it for Step 5 and Step 7.
 
 ## Step 3 — Aragorn: Create GitHub Issues
 
-One issue per todo/unit of work within each sprint:
+One issue per todo/unit of work within each sprint.
+
+**Every issue MUST have:**
+- A title prefixed with `[Sprint N]`
+- A milestone set to `Sprint N: {Theme}`
+
+No issue may be created, referenced in a branch, or linked in a PR without both.
 
 ```bash
 gh issue create \
@@ -91,7 +97,7 @@ Todo ID: {todo-id}"
 ```
 
 **Issue title convention:** `[Sprint N] {Verb} {Noun}`
-(e.g., `[Sprint 1] Add BlogPost entity and repository`)
+(e.g., `[Sprint 2] Add ValidationBehavior pipeline`)
 
 After creating each issue, **Aragorn immediately triages** it:
 - Replace `squad` label with `squad:{member}` (e.g., `squad:sam`)
@@ -289,25 +295,35 @@ When **all** sprint milestones are closed:
 
 ---
 
-## Hard Gate — No Code Before Issue
+## Hard Gate — No Code Before Issue / No Issue Without Sprint
 
 > **This rule is absolute and has no exceptions.**
 
-Before any agent writes, modifies, or commits code, a GitHub issue **must** exist for the work. This gate applies to every work request regardless of how it arrives — `[[PLAN]]`, direct user instruction, or agent initiative.
+Before any agent writes, modifies, or commits code, a GitHub issue **must** exist for the work **and that issue must be fully sprint-stamped**. This gate applies to every work request regardless of how it arrives — `[[PLAN]]`, direct user instruction, or agent initiative.
+
+A **sprint-stamped issue** satisfies all three conditions:
+1. Title begins with `[Sprint N]` — e.g. `[Sprint 2] Add ValidationBehavior pipeline`
+2. Milestone is set to `Sprint N: {Theme}` — e.g. `Sprint 2: Domain Restructure (CQRS/MediatR)`
+3. Item is added to the MyBlog project board (Project #4)
 
 **Enforcement sequence (runs before Step 1):**
 
 ```
 1. Does a GitHub issue exist for this work?
-   YES → confirm it is assigned to the correct milestone + Project #4, then proceed to Step 1
    NO  → CREATE the issue now before touching any file
-         → Assign to milestone, add to Project #4
+         → Title MUST start with [Sprint N]
+         → Milestone MUST be set to "Sprint N: {Theme}"
+         → Add to Project #4, move to "In Sprint"
          → Create squad/{issue}-{slug} branch
          → THEN and only then begin writing code
+
+   YES → Is it sprint-stamped (title prefix + milestone + project)?
+         NO  → Fix it now: rename title, set milestone, add to board
+         YES → Proceed to Step 1
 ```
 
-If you skip this gate and write code without an issue, you have violated the squad's process.
-The work must be stashed, the issue created retroactively, a proper branch checked out, and
+If you skip this gate and write code without a sprint-stamped issue, you have violated the squad's process.
+The work must be stashed, the issue corrected retroactively, a proper branch checked out, and
 the stash re-applied before committing. This costs time — follow the gate.
 
 ---
@@ -315,6 +331,8 @@ the stash re-applied before committing. This costs time — follow the gate.
 ## Anti-Patterns
 
 - ❌ **Writing any code before a GitHub issue exists** — always create the issue first
+- ❌ **Creating an issue without a `[Sprint N]` title prefix** — every issue title must begin with `[Sprint N]`
+- ❌ **Creating an issue without a milestone** — every issue must be assigned to `Sprint N: {Theme}` before any branch or PR references it
 - ❌ **Implementing a `[[PLAN]]` request without first running the sprint planning ceremony** — plan → issue → branch → code
 - ❌ **Opening `squad/{issue}` PRs directly to `dev`** during an active sprint
 - ❌ **Skipping worktree** — always work in `../MyBlog-sprint-{N}/` for isolation

--- a/.squad/routing.md
+++ b/.squad/routing.md
@@ -62,11 +62,12 @@ spawn prompt:
 
 After Sprint 1.1, these process assets are part of normal squad flow:
 
-1. **Before writing any code**, a GitHub issue MUST exist for the work. This is an
-   absolute gate with no exceptions. If no issue exists, create it first — assign
-   to the correct milestone, add to Project #4 — then create the `squad/{issue}-{slug}`
-   branch, and only then write code. See the Hard Gate section in
-   `.squad/playbooks/sprint-planning.md`.
+1. **Before writing any code**, a GitHub issue MUST exist for the work AND it must be
+   **sprint-stamped** — title starts with `[Sprint N]`, milestone is set to
+   `Sprint N: {Theme}`, and it is added to Project #4. This is an absolute gate with
+   no exceptions. If no issue exists, create it now; if an issue exists but lacks the
+   sprint prefix or milestone, correct it before touching any file. See the Hard Gate
+   section in `.squad/playbooks/sprint-planning.md`.
 2. **Before any push-ready handoff**, route through the pre-push gate skill and
    pre-push playbook so agents respect the live MyBlog hook: `squad/{issue}-{slug}`
    branch naming, Release build, `Architecture.Tests`, `Unit.Tests`, and
@@ -85,7 +86,8 @@ After Sprint 1.1, these process assets are part of normal squad flow:
    `.squad/playbooks/sprint-planning.md`.
 8. **When a user makes any coding request** (direct instruction, `[[PLAN]]`, or
    follow-on work), the very first agent action is to check whether a GitHub issue
-   exists. If not, create it before any file is opened or modified.
+   exists AND is sprint-stamped (title `[Sprint N] …` + milestone). If not, create
+   or correct the issue before any file is opened or modified.
 
 ## Rules
 

--- a/.squad/templates/issue-lifecycle.md
+++ b/.squad/templates/issue-lifecycle.md
@@ -2,6 +2,34 @@
 
 Reference for connecting Squad to a repository and managing the issue→branch→PR→merge lifecycle.
 
+## Mandatory Issue Format
+
+> **Every issue must satisfy all three requirements before any branch or PR may reference it.**
+
+| Requirement | Rule |
+|-------------|------|
+| **Title prefix** | Must begin with `[Sprint N]` — e.g. `[Sprint 2] Add ValidationBehavior pipeline` |
+| **Milestone** | Must be set to `Sprint N: {Theme}` — e.g. `Sprint 2: Domain Restructure (CQRS/MediatR)` |
+| **Project board** | Must be added to Project #4 (MyBlog) and moved to **In Sprint** |
+
+**Creating an issue (canonical command):**
+
+```bash
+gh issue create \
+  --title "[Sprint N] {Verb} {Noun}" \
+  --milestone "Sprint N: {Theme}" \
+  --label "squad" \
+  --body "..."
+```
+
+An issue that lacks the `[Sprint N]` prefix or the milestone is **not sprint-stamped**
+and must be corrected before it is acted upon. No agent may create a branch, write code,
+or open a PR for an issue that is not sprint-stamped. See also: the Hard Gate in
+`.squad/playbooks/sprint-planning.md` and Workflow Guardrails #1 and #8 in
+`.squad/routing.md`.
+
+---
+
 ## Repo Connection Format
 
 When connecting Squad to an issue tracker, store the connection in `.squad/team.md`:


### PR DESCRIPTION
Working as Ralph (meta-coordinator / orchestrator)

Closes #56

## Summary

Adds a GitHub Actions workflow that automatically moves project board
items when PRs are opened or merged — eliminating the manual column
transitions Ralph was doing on behalf of squad agents.

## Changes

### `.github/workflows/project-board-automation.yml` (new)
- Triggers on `pull_request` events: `opened` and `closed`
- Parses `Closes/Fixes/Resolves #N` from the PR body
- On **PR opened** → moves linked issue's project item to **In Review**
- On **PR merged** → moves linked issue's project item to **Done**
- Uses `GITHUB_TOKEN` with `repository-projects: write` permission
- Skips gracefully if the issue is not on the project board

> **Permissions note:** If the workflow returns 403 on the GraphQL mutation,
> create a PAT with `project` scope stored as `secrets.GH_PROJECT_TOKEN`
> and substitute it for `secrets.GITHUB_TOKEN` in the workflow.

### `.squad/playbooks/sprint-planning.md` (updated)
- **Step 4:** Clarifies "In Sprint" remains a manual action at sprint kickoff; notes that In Review/Done are now automated
- **Step 6:** Replaces manual board-move instructions with a reference to the new automation; documents the `Closes #N` requirement

## Dogfood test
This PR itself links `Closes #56` — if the workflow has the necessary
permissions, opening this PR will move issue #56 → **In Review** automatically.