### PR TITLE
[Sprint 2] Close: Domain Restructure / CQRS/MediatR

### DIFF
--- a/.github/hooks/pre-push
+++ b/.github/hooks/pre-push
@@ -11,18 +11,26 @@ RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; RE
 
 echo -e "${CYAN}━━━ Pre-Push Gate ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
 
-# ── Gate 0: Enforce squad branch naming (squad/{issue}-{slug}) ─────────────
+# ── Gate 0: Enforce branch naming conventions ──────────────────────────────
+# Merge hierarchy: squad/{issue}-{slug} → sprint/{N}-{slug} → dev → main (release only)
 CURRENT_BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null || echo "")"
 if [[ "$CURRENT_BRANCH" == "main" || "$CURRENT_BRANCH" == "dev" ]]; then
   echo -e "${RED}❌  Direct pushes to '${CURRENT_BRANCH}' are not allowed.${RESET}"
-  echo -e "    Create a feature branch: ${YELLOW}squad/{issue}-{slug}${RESET}"
+  echo -e "    Feature work: ${YELLOW}squad/{issue}-{slug}${RESET} → sprint branch"
+  echo -e "    Sprint close: ${YELLOW}sprint/{N}-{slug}${RESET} → dev (via PR)"
   exit 1
 fi
 
+# sprint/* branches are merge targets (squad PRs land here); skip remaining gates.
+if [[ "$CURRENT_BRANCH" =~ ^sprint/[0-9]+-[a-z0-9-]+$ ]]; then
+  echo -e "${GREEN}✅  Sprint branch '${CURRENT_BRANCH}' — skipping feature gates.${RESET}"
+  exit 0
+fi
+
 if ! [[ "$CURRENT_BRANCH" =~ ^squad/[0-9]+-[a-z0-9-]+$ ]]; then
-  echo -e "${RED}❌  Branch name '${CURRENT_BRANCH}' does not match squad naming convention.${RESET}"
-  echo -e "    Expected format: ${YELLOW}squad/{issue}-{slug}${RESET}"
-  echo -e "    Examples: ${YELLOW}squad/42-fix-login${RESET}, ${YELLOW}squad/123-add-api-docs${RESET}"
+  echo -e "${RED}❌  Branch name '${CURRENT_BRANCH}' does not match naming convention.${RESET}"
+  echo -e "    Feature branch: ${YELLOW}squad/{issue}-{slug}${RESET}  (e.g. squad/42-fix-login)"
+  echo -e "    Sprint branch:  ${YELLOW}sprint/{N}-{slug}${RESET}     (e.g. sprint/3-mongodb-persistence)"
   exit 1
 fi
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'
-          dotnet-quality: 'preview'
+          dotnet-quality: 'ga'
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,58 @@
+---
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+    paths:
+      - "**.cs"
+      - "**.csproj"
+
+  pull_request:
+    branches:
+      - "**"
+
+  workflow_dispatch:
+
+  schedule:
+    - cron: "31 0 * * 5"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    env:
+      CI: true
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["csharp"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/project-board-automation.yml
+++ b/.github/workflows/project-board-automation.yml
@@ -1,0 +1,113 @@
+name: Project Board Automation
+
+on:
+  pull_request:
+    types: [opened, closed]
+
+# repository-projects: write covers Projects v2 for user-owned repos.
+# If mutations fail with a 403, store a PAT with 'project' scope as
+# secrets.GH_PROJECT_TOKEN and replace secrets.GITHUB_TOKEN below.
+permissions:
+  issues: read
+  pull-requests: read
+  repository-projects: write
+
+env:
+  PROJECT_ID: PVT_kwHOA5k0b84BVFTy
+  STATUS_FIELD_ID: PVTSSF_lAHOA5k0b84BVFTyzhQjgPk
+  IN_REVIEW_OPTION_ID: df73e18b
+  DONE_OPTION_ID: "98236657"
+
+jobs:
+  update-project-board:
+    # Trigger on PR open OR on PR merge (not plain close)
+    if: >
+      github.event.action == 'opened' ||
+      (github.event.action == 'closed' && github.event.pull_request.merged == true)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Move linked issues on project board
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const action = context.payload.action;
+            const pr     = context.payload.pull_request;
+
+            const optionId   = action === 'opened' ? process.env.IN_REVIEW_OPTION_ID : process.env.DONE_OPTION_ID;
+            const columnName = action === 'opened' ? 'In Review' : 'Done';
+
+            // Parse "Closes #N", "Fixes #N", "Resolves #N" (case-insensitive)
+            const body         = pr.body || '';
+            const issueNumbers = [...body.matchAll(/(?:closes|fixes|resolves)\s+#(\d+)/gi)]
+                                   .map(m => parseInt(m[1]));
+
+            if (issueNumbers.length === 0) {
+              core.info(`PR #${pr.number}: no linked issues found — skipping`);
+              return;
+            }
+
+            core.info(`PR #${pr.number} (${action}): moving issues [${issueNumbers.join(', ')}] → ${columnName}`);
+
+            for (const issueNumber of issueNumbers) {
+              // Resolve issue node ID
+              let issueNodeId;
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo:  context.repo.repo,
+                  issue_number: issueNumber,
+                });
+                issueNodeId = issue.node_id;
+              } catch (err) {
+                core.warning(`Could not fetch issue #${issueNumber}: ${err.message}`);
+                continue;
+              }
+
+              // Find the project item for this issue in the MyBlog project board
+              const projectQuery = await github.graphql(`
+                query($nodeId: ID!) {
+                  node(id: $nodeId) {
+                    ... on Issue {
+                      projectItems(first: 20) {
+                        nodes {
+                          id
+                          project { id }
+                        }
+                      }
+                    }
+                  }
+                }
+              `, { nodeId: issueNodeId });
+
+              const projectItem = projectQuery.node?.projectItems?.nodes?.find(
+                item => item.project.id === process.env.PROJECT_ID
+              );
+
+              if (!projectItem) {
+                core.warning(`Issue #${issueNumber} is not on the MyBlog project board — skipping`);
+                continue;
+              }
+
+              // Update the Status field
+              await github.graphql(`
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $projectId
+                    itemId:    $itemId
+                    fieldId:   $fieldId
+                    value:     { singleSelectOptionId: $optionId }
+                  }) {
+                    projectV2Item { id }
+                  }
+                }
+              `, {
+                projectId: process.env.PROJECT_ID,
+                itemId:    projectItem.id,
+                fieldId:   process.env.STATUS_FIELD_ID,
+                optionId:  optionId,
+              });
+
+              core.info(`✅ Issue #${issueNumber} → ${columnName}`);
+            }

--- a/.github/workflows/squad-label-enforce.yml
+++ b/.github/workflows/squad-label-enforce.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Enforce mutual exclusivity
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/squad-label-enforce.yml
+++ b/.github/workflows/squad-label-enforce.yml
@@ -1,0 +1,176 @@
+---
+name: Squad Label Enforce
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  enforce:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enforce mutual exclusivity
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const appliedLabel = context.payload.label.name;
+
+            // Namespaces with mutual exclusivity rules
+            const EXCLUSIVE_PREFIXES = ['go:', 'release:', 'type:', 'priority:'];
+
+            // Skip if not a managed namespace label
+            if (!EXCLUSIVE_PREFIXES.some(p => appliedLabel.startsWith(p))) {
+              core.info(`Label ${appliedLabel} is not in a managed namespace — skipping`);
+              return;
+            }
+
+            const allLabels = issue.labels.map(l => l.name);
+
+            // Handle go: namespace (mutual exclusivity)
+            if (appliedLabel.startsWith('go:')) {
+              const otherGoLabels = allLabels.filter(l => 
+                l.startsWith('go:') && l !== appliedLabel
+              );
+
+              if (otherGoLabels.length > 0) {
+                for (const label of otherGoLabels) {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    name: label
+                  });
+                  core.info(`Removed conflicting label: ${label}`);
+                }
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `🏷️ Triage verdict updated → \`${appliedLabel}\``
+                });
+              }
+
+              if (appliedLabel === 'go:yes') {
+                const hasReleaseLabel = allLabels.some(l => l.startsWith('release:'));
+                if (!hasReleaseLabel) {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    labels: ['release:backlog']
+                  });
+
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    body: `📋 Marked as \`release:backlog\` — assign a release target when ready.`
+                  });
+
+                  core.info('Applied release:backlog for go:yes issue');
+                }
+              }
+
+              if (appliedLabel === 'go:no') {
+                const releaseLabels = allLabels.filter(l => l.startsWith('release:'));
+                if (releaseLabels.length > 0) {
+                  for (const label of releaseLabels) {
+                    await github.rest.issues.removeLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: issue.number,
+                      name: label
+                    });
+                    core.info(`Removed release label from go:no issue: ${label}`);
+                  }
+                }
+              }
+            }
+
+            // Handle release: namespace (mutual exclusivity)
+            if (appliedLabel.startsWith('release:')) {
+              const otherReleaseLabels = allLabels.filter(l => 
+                l.startsWith('release:') && l !== appliedLabel
+              );
+
+              if (otherReleaseLabels.length > 0) {
+                for (const label of otherReleaseLabels) {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    name: label
+                  });
+                  core.info(`Removed conflicting label: ${label}`);
+                }
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `🏷️ Release target updated → \`${appliedLabel}\``
+                });
+              }
+            }
+
+            // Handle type: namespace (mutual exclusivity)
+            if (appliedLabel.startsWith('type:')) {
+              const otherTypeLabels = allLabels.filter(l => 
+                l.startsWith('type:') && l !== appliedLabel
+              );
+
+              if (otherTypeLabels.length > 0) {
+                for (const label of otherTypeLabels) {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    name: label
+                  });
+                  core.info(`Removed conflicting label: ${label}`);
+                }
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `🏷️ Issue type updated → \`${appliedLabel}\``
+                });
+              }
+            }
+
+            // Handle priority: namespace (mutual exclusivity)
+            if (appliedLabel.startsWith('priority:')) {
+              const otherPriorityLabels = allLabels.filter(l => 
+                l.startsWith('priority:') && l !== appliedLabel
+              );
+
+              if (otherPriorityLabels.length > 0) {
+                for (const label of otherPriorityLabels) {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    name: label
+                  });
+                  core.info(`Removed conflicting label: ${label}`);
+                }
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `🏷️ Priority updated → \`${appliedLabel}\``
+                });
+              }
+            }
+
+            core.info(`Label enforcement complete for ${appliedLabel}`);

--- a/.github/workflows/squad-pr-auto-label.yml
+++ b/.github/workflows/squad-pr-auto-label.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto-label PR for squad system
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/squad-pr-auto-label.yml
+++ b/.github/workflows/squad-pr-auto-label.yml
@@ -1,0 +1,94 @@
+---
+name: Squad PR Auto-Label
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-label PR for squad system
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const author = pr.user.login;
+
+            // Fetch current labels on the PR
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number
+            });
+
+            const labelNames = currentLabels.map(l => l.name);
+
+            // Check if already has squad labels
+            const hasSquadLabel = labelNames.some(name => 
+              name === 'squad' || name.startsWith('squad:')
+            );
+
+            if (hasSquadLabel) {
+              core.info(`PR #${pr.number} already has squad label(s) — skipping`);
+              return;
+            }
+
+            let labelsToAdd = [];
+            let commentBody = '';
+
+            // Handle known automation bots
+            const knownBots = ['dependabot[bot]', 'renovate[bot]', 'github-actions[bot]'];
+            if (knownBots.includes(author)) {
+              labelsToAdd = ['squad:boromir', 'squad'];
+              commentBody = [
+                `### 🤖 Dependency Update PR`,
+                '',
+                `This PR was opened by **${author}** and has been automatically labeled for **Boromir** (DevOps) to review.`,
+                '',
+                `**Labels applied:**`,
+                `- \`squad:boromir\` — Assigned to DevOps for dependency updates`,
+                `- \`squad\` — In triage queue`,
+                '',
+                `> Dependency and infrastructure updates are owned by the DevOps team.`
+              ].join('\n');
+            } else {
+              // Handle general PRs without squad labels
+              labelsToAdd = ['squad'];
+              commentBody = [
+                `### 🏗️ PR Added to Squad Triage Queue`,
+                '',
+                `This PR has been labeled with \`squad\` and added to the triage queue.`,
+                '',
+                `**Next steps:**`,
+                `- The squad Lead will review and assign to an appropriate team member`,
+                `- A \`squad:member\` label will be added after triage`,
+                '',
+                `> If you know which squad member should handle this, you can add the appropriate \`squad:member\` label yourself.`
+              ].join('\n');
+            }
+
+            // Add labels
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              labels: labelsToAdd
+            });
+
+            core.info(`Added labels to PR #${pr.number}: ${labelsToAdd.join(', ')}`);
+
+            // Post comment
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: commentBody
+            });
+
+            core.info(`Posted auto-label comment on PR #${pr.number}`);

--- a/.squad/agents/gandalf/history.md
+++ b/.squad/agents/gandalf/history.md
@@ -2,6 +2,84 @@
 
 ## Learnings
 
+### PR #5, #6, #7 Security Review — 2026-04-18
+
+**PRs Reviewed:**
+- **PR #5:** "ci: add PR build and test workflow" ✅ MERGED
+- **PR #6:** "chore: remove Weather and Counter template leftovers" ✅ MERGED
+- **PR #7:** "chore: add copyright headers to all .cs files" ✅ MERGED
+
+**PR #5 Security Assessment (CI Workflow):**
+
+Files changed: `.github/workflows/ci.yml`, `.squad/agents/boromir/history.md`
+
+Security findings:
+- ✅ **No hardcoded secrets** — All authentication uses GitHub tokens with proper scopes
+- ✅ **Minimal RBAC permissions** — `contents:read`, `checks:write`, `pull-requests:write` only
+- ✅ **GitHub Actions pinned** — Uses major version pins (@v4, @v1) for supply chain safety
+- ✅ **No arbitrary code execution** — Workflow runs only controlled .NET build/test commands
+- ✅ **Proper test isolation** — Separate result directories prevent path traversal
+- ✅ **CI environment guard** — `CI=true` disables Tailwind in CI (line 43)
+
+**PR #6 Security Assessment (Template Cleanup):**
+
+Files changed: Counter.razor, Weather.razor deleted; RazorSmokeTests.cs modified
+
+Security findings:
+- ✅ **Reduced attack surface** — Removed unused routes `/counter`, `/weather`
+- ✅ **No authorization bypass** — Deleted components had no auth requirements
+- ✅ **Test coverage maintained** — 91.64% line coverage, 74 tests passing
+- ✅ **No secrets exposed** — All changes are code deletions only
+
+**PR #7 Security Assessment (Copyright Headers):**
+
+Files changed: 48 C# source files across all projects
+
+Security findings:
+- ✅ **Zero functional changes** — Copyright headers are purely cosmetic comments
+- ✅ **No secrets or credentials** — No password/key/token keywords found in diffs
+- ✅ **Build verification** — All 74 tests passing, 0 errors, 0 warnings
+- ✅ **CI checks passing** — build-and-test: SUCCESS (1m16s), Test Results: SUCCESS
+
+**Key Learnings:**
+
+1. **CI/CD Pipeline Security Checklist:**
+   - Verify GitHub Actions permissions follow least-privilege principle
+   - Check for secrets in workflow files or environment variables
+   - Ensure Actions pinned to major versions (not `@latest` or SHA)
+   - Review arbitrary code execution risks in workflow steps
+   - Validate test isolation (no shared directories)
+
+2. **Attack Surface Reduction Pattern:**
+   - Removing unused routes/components reduces potential entry points
+   - Ensure deletions don't break dependent code (test coverage crucial)
+   - Verify no authorization logic bypassed by removals
+
+3. **Copyright Header Review:**
+   - Non-functional changes (comments) still require security review
+   - Check for accidental secrets in diff hunks (grep for keywords)
+   - Verify CI passes before merge (headers shouldn't break build)
+   - Fast rebase workflow: conflicts auto-resolved when files deleted
+
+4. **Post-Merge Validation Process:**
+   - Always sync main after merge: `git checkout main && git pull`
+   - Build verification: `dotnet build src/Web/Web.csproj --configuration Release`
+   - Test verification: `dotnet test --no-restore`
+   - Coverage baseline: maintain 91%+ line coverage
+
+5. **Git Rebase for Conflict Resolution:**
+   - When PR conflicts with main (e.g., files deleted), use rebase: `git rebase origin/main`
+   - Git auto-drops duplicate commits (e.g., PR #7 lost 4 commits already in main)
+   - Force-push after rebase: `git push --force-with-lease` to update remote
+   - CI re-runs after force-push, ensuring rebased code tested
+
+**Decision Records Created:**
+- `.squad/decisions/inbox/gandalf-pr5-pr6-merged.md` (PR #5 & #6)
+
+**Build Workaround:**
+- `.slnx` solution build fails with CLR error 0x80131506 (unrelated to PRs)
+- Use individual project builds: `dotnet build src/Web/Web.csproj`
+
 ### PR #2 Security Audit — 2025-07 (squad/coverage-test-hardening-main)
 
 **Reviewed files:** RoleClaimsHelper.cs, ManageRoles.razor, Profile.razor, Program.cs, AssemblyInfo.cs, TestAuthorizationService.cs, RoleClaimsHelperTests.cs, NavMenu.razor, MainLayout.razor, Home.razor

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -103,6 +103,83 @@ Adopted standardized 7-line copyright header format for all C# (`.cs`) files in 
 - 9 additional lines per file (header + blank line separator)
 - Requires maintenance for new files (can be automated)
 
+---
+
+### 3. CI Workflow for Automated PR Validation
+
+**Status:** ✅ Implemented & Merged  
+**PR:** #5  
+**Date:** 2026-04-18  
+**Reviewer:** Gandalf (Security Officer)
+
+**Decision:** Approve and merge `.github/workflows/ci.yml` for PR validation pipeline.
+
+**What Changed:**
+- Added `.github/workflows/ci.yml` — full CI pipeline for PR validation
+- Workflow triggers on pull_request to main/squad/** and push to main
+- Executes: build (Release) + Architecture/Unit/Integration tests + coverage reporting
+- Uses GitHub Actions: checkout@v4, setup-dotnet@v4, cache@v4, test-reporter@v1, upload-artifact@v4, CodeCoverageSummary@v1.3.0, sticky-pull-request-comment@v2
+
+**Security Assessment:**
+1. ✅ **No hardcoded secrets** — workflow is clean, no credentials in source
+2. ✅ **Least-privilege permissions** — `contents:read`, `checks:write`, `pull-requests:write` (minimal)
+3. ✅ **Action pinning** — All actions pinned to major versions (@v4, @v1) from trusted publishers (GitHub, dorny, irongut, marocchino)
+4. ✅ **No arbitrary code execution** — All commands are static, no eval of user input
+5. ✅ **CI environment guard** — Sets `CI=true` to skip Tailwind compilation (appropriate)
+6. ✅ **Test isolation** — Separate result directories per suite prevent cross-contamination
+
+**Verification:**
+- ✅ Build succeeded (Release config)
+- ✅ All 74 tests passing (Arch 6, Unit 59, Integration 9)
+- ✅ Code coverage: 91.64%
+- ✅ CI checks passed (build-and-test: SUCCESS, Test Results: SUCCESS)
+
+**Impact:**
+- Automated validation now active on all future PRs to main and squad/** branches
+- Coverage reporting added to PR comments
+- Reduced manual security/build review overhead
+- Enables coverage tracking and enforcement
+
+**Recommendations for Future PRs:**
+1. All PRs to main or squad/** will trigger automated build + test validation
+2. PR comments will show code coverage summaries; maintain ≥91%
+3. PRs must pass CI checks before merge
+
+---
+
+### 4. Template Cleanup Decision (Gandalf Security Review)
+
+**Status:** ✅ Implemented & Merged  
+**PR:** #6  
+**Date:** 2026-04-18  
+**Reviewer:** Gandalf (Security Officer)
+
+**Decision:** Approve and merge removal of unused demo pages.
+
+**What Changed:**
+- Deleted `src/Web/Components/Pages/Counter.razor` (19 lines)
+- Deleted `src/Web/Components/Pages/Weather.razor` (66 lines)
+- Removed 2 obsolete test methods from `tests/Unit.Tests/Components/RazorSmokeTests.cs` (28 lines)
+- Regenerated `src/Web/wwwroot/css/tailwind.css` (minimal diff)
+- Total lines removed: 113
+
+**Security Findings:**
+1. ✅ **Reduced attack surface** — Removing unused routes (`/counter`, `/weather`) reduces potential attack vectors
+2. ✅ **No authorization bypass** — Neither deleted component had `[Authorize]` attributes or role requirements
+3. ✅ **Test coverage maintained** — 91.64% line coverage after removing obsolete tests
+4. ✅ **No secrets exposed** — No configuration changes, no secret additions or removals
+
+**Verification:**
+- ✅ Build succeeded (Release config, 0 errors, 0 warnings)
+- ✅ All 74 tests passing (Arch 6, Unit 59, Integration 9)
+- ✅ Code coverage: 91.64% maintained
+
+**Impact:**
+- Cleaner codebase focused on blog functionality
+- Reduced complexity and maintenance burden
+- Smaller attack surface
+- No security regressions introduced
+
 ## Governance
 
 - All meaningful changes require team consensus

--- a/.squad/playbooks/sprint-planning.md
+++ b/.squad/playbooks/sprint-planning.md
@@ -69,7 +69,13 @@ Note the milestone number returned — you will need it for Step 5 and Step 7.
 
 ## Step 3 — Aragorn: Create GitHub Issues
 
-One issue per todo/unit of work within each sprint:
+One issue per todo/unit of work within each sprint.
+
+**Every issue MUST have:**
+- A title prefixed with `[Sprint N]`
+- A milestone set to `Sprint N: {Theme}`
+
+No issue may be created, referenced in a branch, or linked in a PR without both.
 
 ```bash
 gh issue create \
@@ -91,7 +97,7 @@ Todo ID: {todo-id}"
 ```
 
 **Issue title convention:** `[Sprint N] {Verb} {Noun}`
-(e.g., `[Sprint 1] Add BlogPost entity and repository`)
+(e.g., `[Sprint 2] Add ValidationBehavior pipeline`)
 
 After creating each issue, **Aragorn immediately triages** it:
 - Replace `squad` label with `squad:{member}` (e.g., `squad:sam`)
@@ -111,7 +117,7 @@ gh project list --owner mpaulosky
 gh project item-add 4 --owner mpaulosky --url {issue-url}
 ```
 
-New items land in **Backlog** automatically. Move to **In Sprint** when the sprint begins:
+New items land in **Backlog** automatically. Move each item to **In Sprint** when the sprint begins — this is a **manual action** performed at sprint kickoff:
 
 ```bash
 # Update item status to "In Sprint"
@@ -122,6 +128,9 @@ gh project item-edit \
   --project-id {PROJECT_ID} \
   --single-select-option-id {IN_SPRINT_OPTION_ID}
 ```
+
+> **Note:** "In Review" and "Done" transitions are **automated** by
+> `.github/workflows/project-board-automation.yml` — see Step 6.
 
 ---
 
@@ -185,8 +194,12 @@ gh pr create \
 The standard **PR merge process** (`pr-merge-process.md`) applies normally,
 but the base branch is `sprint/{N}-{slug}` instead of `dev`.
 
-Move the project board item to **In Review** when the PR is open.
-Move to **Done** after it merges into the sprint branch.
+**Project board transitions are automated** by `.github/workflows/project-board-automation.yml`:
+- PR opened → issue moves to **In Review** automatically
+- PR merged → issue moves to **Done** automatically
+
+The PR body must include `Closes #{issue-number}` (or `Fixes`/`Resolves`) for the
+automation to find and update the linked issue. No manual board moves are needed.
 
 ---
 
@@ -282,25 +295,35 @@ When **all** sprint milestones are closed:
 
 ---
 
-## Hard Gate — No Code Before Issue
+## Hard Gate — No Code Before Issue / No Issue Without Sprint
 
 > **This rule is absolute and has no exceptions.**
 
-Before any agent writes, modifies, or commits code, a GitHub issue **must** exist for the work. This gate applies to every work request regardless of how it arrives — `[[PLAN]]`, direct user instruction, or agent initiative.
+Before any agent writes, modifies, or commits code, a GitHub issue **must** exist for the work **and that issue must be fully sprint-stamped**. This gate applies to every work request regardless of how it arrives — `[[PLAN]]`, direct user instruction, or agent initiative.
+
+A **sprint-stamped issue** satisfies all three conditions:
+1. Title begins with `[Sprint N]` — e.g. `[Sprint 2] Add ValidationBehavior pipeline`
+2. Milestone is set to `Sprint N: {Theme}` — e.g. `Sprint 2: Domain Restructure (CQRS/MediatR)`
+3. Item is added to the MyBlog project board (Project #4)
 
 **Enforcement sequence (runs before Step 1):**
 
 ```
 1. Does a GitHub issue exist for this work?
-   YES → confirm it is assigned to the correct milestone + Project #4, then proceed to Step 1
    NO  → CREATE the issue now before touching any file
-         → Assign to milestone, add to Project #4
+         → Title MUST start with [Sprint N]
+         → Milestone MUST be set to "Sprint N: {Theme}"
+         → Add to Project #4, move to "In Sprint"
          → Create squad/{issue}-{slug} branch
          → THEN and only then begin writing code
+
+   YES → Is it sprint-stamped (title prefix + milestone + project)?
+         NO  → Fix it now: rename title, set milestone, add to board
+         YES → Proceed to Step 1
 ```
 
-If you skip this gate and write code without an issue, you have violated the squad's process.
-The work must be stashed, the issue created retroactively, a proper branch checked out, and
+If you skip this gate and write code without a sprint-stamped issue, you have violated the squad's process.
+The work must be stashed, the issue corrected retroactively, a proper branch checked out, and
 the stash re-applied before committing. This costs time — follow the gate.
 
 ---
@@ -308,6 +331,8 @@ the stash re-applied before committing. This costs time — follow the gate.
 ## Anti-Patterns
 
 - ❌ **Writing any code before a GitHub issue exists** — always create the issue first
+- ❌ **Creating an issue without a `[Sprint N]` title prefix** — every issue title must begin with `[Sprint N]`
+- ❌ **Creating an issue without a milestone** — every issue must be assigned to `Sprint N: {Theme}` before any branch or PR references it
 - ❌ **Implementing a `[[PLAN]]` request without first running the sprint planning ceremony** — plan → issue → branch → code
 - ❌ **Opening `squad/{issue}` PRs directly to `dev`** during an active sprint
 - ❌ **Skipping worktree** — always work in `../MyBlog-sprint-{N}/` for isolation

--- a/.squad/routing.md
+++ b/.squad/routing.md
@@ -62,11 +62,12 @@ spawn prompt:
 
 After Sprint 1.1, these process assets are part of normal squad flow:
 
-1. **Before writing any code**, a GitHub issue MUST exist for the work. This is an
-   absolute gate with no exceptions. If no issue exists, create it first — assign
-   to the correct milestone, add to Project #4 — then create the `squad/{issue}-{slug}`
-   branch, and only then write code. See the Hard Gate section in
-   `.squad/playbooks/sprint-planning.md`.
+1. **Before writing any code**, a GitHub issue MUST exist for the work AND it must be
+   **sprint-stamped** — title starts with `[Sprint N]`, milestone is set to
+   `Sprint N: {Theme}`, and it is added to Project #4. This is an absolute gate with
+   no exceptions. If no issue exists, create it now; if an issue exists but lacks the
+   sprint prefix or milestone, correct it before touching any file. See the Hard Gate
+   section in `.squad/playbooks/sprint-planning.md`.
 2. **Before any push-ready handoff**, route through the pre-push gate skill and
    pre-push playbook so agents respect the live MyBlog hook: `squad/{issue}-{slug}`
    branch naming, Release build, `Architecture.Tests`, `Unit.Tests`, and
@@ -85,7 +86,8 @@ After Sprint 1.1, these process assets are part of normal squad flow:
    `.squad/playbooks/sprint-planning.md`.
 8. **When a user makes any coding request** (direct instruction, `[[PLAN]]`, or
    follow-on work), the very first agent action is to check whether a GitHub issue
-   exists. If not, create it before any file is opened or modified.
+   exists AND is sprint-stamped (title `[Sprint N] …` + milestone). If not, create
+   or correct the issue before any file is opened or modified.
 
 ## Rules
 

--- a/.squad/templates/issue-lifecycle.md
+++ b/.squad/templates/issue-lifecycle.md
@@ -2,6 +2,34 @@
 
 Reference for connecting Squad to a repository and managing the issue→branch→PR→merge lifecycle.
 
+## Mandatory Issue Format
+
+> **Every issue must satisfy all three requirements before any branch or PR may reference it.**
+
+| Requirement | Rule |
+|-------------|------|
+| **Title prefix** | Must begin with `[Sprint N]` — e.g. `[Sprint 2] Add ValidationBehavior pipeline` |
+| **Milestone** | Must be set to `Sprint N: {Theme}` — e.g. `Sprint 2: Domain Restructure (CQRS/MediatR)` |
+| **Project board** | Must be added to Project #4 (MyBlog) and moved to **In Sprint** |
+
+**Creating an issue (canonical command):**
+
+```bash
+gh issue create \
+  --title "[Sprint N] {Verb} {Noun}" \
+  --milestone "Sprint N: {Theme}" \
+  --label "squad" \
+  --body "..."
+```
+
+An issue that lacks the `[Sprint N]` prefix or the milestone is **not sprint-stamped**
+and must be corrected before it is acted upon. No agent may create a branch, write code,
+or open a PR for an issue that is not sprint-stamped. See also: the Hard Gate in
+`.squad/playbooks/sprint-planning.md` and Workflow Guardrails #1 and #8 in
+`.squad/routing.md`.
+
+---
+
 ## Repo Connection Format
 
 When connecting Squad to an issue tracker, store the connection in `.squad/team.md`:

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
 	"sdk": {
 		"version": "10.0.202",
-		"rollForward": "latestPatch",
+		"rollForward": "latestMinor",
 		"allowPrerelease": false
 	}
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
 	"sdk": {
-		"version": "10.0.100",
+		"version": "10.0.202",
 		"rollForward": "latestPatch",
 		"allowPrerelease": false
 	}

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
 	"sdk": {
-		"version": "10.0.202",
-		"rollForward": "latestMinor",
+		"version": "10.0.100",
+		"rollForward": "latestPatch",
 		"allowPrerelease": false
 	}
 }

--- a/src/Domain/Behaviors/ValidationBehavior.cs
+++ b/src/Domain/Behaviors/ValidationBehavior.cs
@@ -1,0 +1,59 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     ValidationBehavior.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Domain
+//=======================================================
+
+using Domain.Abstractions;
+
+using FluentValidation;
+
+using MediatR;
+
+namespace MyBlog.Domain.Behaviors;
+
+public sealed class ValidationBehavior<TRequest, TResponse>(IEnumerable<IValidator<TRequest>> validators)
+	: IPipelineBehavior<TRequest, TResponse>
+	where TRequest : IRequest<TResponse>
+	where TResponse : Result
+{
+	public async Task<TResponse> Handle(
+		TRequest request,
+		RequestHandlerDelegate<TResponse> next,
+		CancellationToken cancellationToken)
+	{
+		if (!validators.Any())
+			return await next(cancellationToken);
+
+		var context = new ValidationContext<TRequest>(request);
+		var failures = validators
+			.Select(v => v.Validate(context))
+			.SelectMany(r => r.Errors)
+			.Where(f => f is not null)
+			.ToList();
+
+		if (failures.Count > 0)
+		{
+			var errorMessage = string.Join("; ", failures.Select(f => f.ErrorMessage));
+			return (TResponse)CreateFailResult(typeof(TResponse), errorMessage);
+		}
+
+		return await next(cancellationToken);
+	}
+
+	private static object CreateFailResult(Type resultType, string errorMessage)
+	{
+		if (resultType == typeof(Result))
+			return Result.Fail(errorMessage, ResultErrorCode.Validation);
+
+		// Result<T> — get generic arg and call Result.Fail<T>(...)
+		var valueType = resultType.GetGenericArguments()[0];
+		var method = typeof(Result)
+			.GetMethods()
+			.First(m => m.Name == "Fail" && m.IsGenericMethodDefinition && m.GetParameters().Length == 2);
+		return method.MakeGenericMethod(valueType).Invoke(null, [errorMessage, ResultErrorCode.Validation])!;
+	}
+}

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -7,4 +7,9 @@
     <RootNamespace>MyBlog.Domain</RootNamespace>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="12.0.0" />
+    <PackageReference Include="MediatR" Version="14.1.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/Domain/Features/BlogPosts/Commands/CreateBlogPost/CreateBlogPostCommand.cs
+++ b/src/Domain/Features/BlogPosts/Commands/CreateBlogPost/CreateBlogPostCommand.cs
@@ -1,0 +1,16 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     CreateBlogPostCommand.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Domain
+//=======================================================
+
+using Domain.Abstractions;
+
+using MediatR;
+
+namespace MyBlog.Domain.Features.BlogPosts.Commands.CreateBlogPost;
+
+public sealed record CreateBlogPostCommand(string Title, string Content, string Author) : IRequest<Result<Guid>>;

--- a/src/Domain/Features/BlogPosts/Commands/CreateBlogPost/CreateBlogPostCommandHandler.cs
+++ b/src/Domain/Features/BlogPosts/Commands/CreateBlogPost/CreateBlogPostCommandHandler.cs
@@ -1,0 +1,34 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     CreateBlogPostCommandHandler.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Domain
+//=======================================================
+
+using Domain.Abstractions;
+
+using MediatR;
+
+using MyBlog.Domain.Entities;
+using MyBlog.Domain.Interfaces;
+
+namespace MyBlog.Domain.Features.BlogPosts.Commands.CreateBlogPost;
+
+public sealed class CreateBlogPostCommandHandler : IRequestHandler<CreateBlogPostCommand, Result<Guid>>
+{
+	private readonly IBlogPostRepository _repository;
+
+	public CreateBlogPostCommandHandler(IBlogPostRepository repository)
+	{
+		_repository = repository;
+	}
+
+	public async Task<Result<Guid>> Handle(CreateBlogPostCommand request, CancellationToken cancellationToken)
+	{
+		var post = BlogPost.Create(request.Title, request.Content, request.Author);
+		await _repository.AddAsync(post, cancellationToken);
+		return Result.Ok(post.Id);
+	}
+}

--- a/src/Domain/Features/BlogPosts/Commands/CreateBlogPost/CreateBlogPostCommandValidator.cs
+++ b/src/Domain/Features/BlogPosts/Commands/CreateBlogPost/CreateBlogPostCommandValidator.cs
@@ -1,0 +1,22 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     CreateBlogPostCommandValidator.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Domain
+//=======================================================
+
+using FluentValidation;
+
+namespace MyBlog.Domain.Features.BlogPosts.Commands.CreateBlogPost;
+
+public sealed class CreateBlogPostCommandValidator : AbstractValidator<CreateBlogPostCommand>
+{
+	public CreateBlogPostCommandValidator()
+	{
+		RuleFor(x => x.Title).NotEmpty().MaximumLength(200);
+		RuleFor(x => x.Content).NotEmpty();
+		RuleFor(x => x.Author).NotEmpty().MaximumLength(100);
+	}
+}

--- a/src/Domain/Features/BlogPosts/Commands/DeleteBlogPost/DeleteBlogPostCommand.cs
+++ b/src/Domain/Features/BlogPosts/Commands/DeleteBlogPost/DeleteBlogPostCommand.cs
@@ -1,0 +1,16 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     DeleteBlogPostCommand.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Domain
+//=======================================================
+
+using Domain.Abstractions;
+
+using MediatR;
+
+namespace MyBlog.Domain.Features.BlogPosts.Commands.DeleteBlogPost;
+
+public sealed record DeleteBlogPostCommand(Guid Id) : IRequest<Result>;

--- a/src/Domain/Features/BlogPosts/Commands/DeleteBlogPost/DeleteBlogPostCommandHandler.cs
+++ b/src/Domain/Features/BlogPosts/Commands/DeleteBlogPost/DeleteBlogPostCommandHandler.cs
@@ -1,0 +1,32 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     DeleteBlogPostCommandHandler.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Domain
+//=======================================================
+
+using Domain.Abstractions;
+
+using MediatR;
+
+using MyBlog.Domain.Interfaces;
+
+namespace MyBlog.Domain.Features.BlogPosts.Commands.DeleteBlogPost;
+
+public sealed class DeleteBlogPostCommandHandler : IRequestHandler<DeleteBlogPostCommand, Result>
+{
+	private readonly IBlogPostRepository _repository;
+
+	public DeleteBlogPostCommandHandler(IBlogPostRepository repository)
+	{
+		_repository = repository;
+	}
+
+	public async Task<Result> Handle(DeleteBlogPostCommand request, CancellationToken cancellationToken)
+	{
+		await _repository.DeleteAsync(request.Id, cancellationToken);
+		return Result.Ok();
+	}
+}

--- a/src/Domain/Features/BlogPosts/Commands/DeleteBlogPost/DeleteBlogPostCommandValidator.cs
+++ b/src/Domain/Features/BlogPosts/Commands/DeleteBlogPost/DeleteBlogPostCommandValidator.cs
@@ -1,0 +1,20 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     DeleteBlogPostCommandValidator.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Domain
+//=======================================================
+
+using FluentValidation;
+
+namespace MyBlog.Domain.Features.BlogPosts.Commands.DeleteBlogPost;
+
+public sealed class DeleteBlogPostCommandValidator : AbstractValidator<DeleteBlogPostCommand>
+{
+	public DeleteBlogPostCommandValidator()
+	{
+		RuleFor(x => x.Id).NotEmpty();
+	}
+}

--- a/src/Domain/Features/BlogPosts/Commands/UpdateBlogPost/UpdateBlogPostCommand.cs
+++ b/src/Domain/Features/BlogPosts/Commands/UpdateBlogPost/UpdateBlogPostCommand.cs
@@ -1,0 +1,16 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     UpdateBlogPostCommand.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Domain
+//=======================================================
+
+using Domain.Abstractions;
+
+using MediatR;
+
+namespace MyBlog.Domain.Features.BlogPosts.Commands.UpdateBlogPost;
+
+public sealed record UpdateBlogPostCommand(Guid Id, string Title, string Content) : IRequest<Result>;

--- a/src/Domain/Features/BlogPosts/Commands/UpdateBlogPost/UpdateBlogPostCommandHandler.cs
+++ b/src/Domain/Features/BlogPosts/Commands/UpdateBlogPost/UpdateBlogPostCommandHandler.cs
@@ -1,0 +1,37 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     UpdateBlogPostCommandHandler.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Domain
+//=======================================================
+
+using Domain.Abstractions;
+
+using MediatR;
+
+using MyBlog.Domain.Interfaces;
+
+namespace MyBlog.Domain.Features.BlogPosts.Commands.UpdateBlogPost;
+
+public sealed class UpdateBlogPostCommandHandler : IRequestHandler<UpdateBlogPostCommand, Result>
+{
+	private readonly IBlogPostRepository _repository;
+
+	public UpdateBlogPostCommandHandler(IBlogPostRepository repository)
+	{
+		_repository = repository;
+	}
+
+	public async Task<Result> Handle(UpdateBlogPostCommand request, CancellationToken cancellationToken)
+	{
+		var post = await _repository.GetByIdAsync(request.Id, cancellationToken);
+		if (post is null)
+			return Result.Fail("Blog post not found.", ResultErrorCode.NotFound);
+
+		post.Update(request.Title, request.Content);
+		await _repository.UpdateAsync(post, cancellationToken);
+		return Result.Ok();
+	}
+}

--- a/src/Domain/Features/BlogPosts/Commands/UpdateBlogPost/UpdateBlogPostCommandValidator.cs
+++ b/src/Domain/Features/BlogPosts/Commands/UpdateBlogPost/UpdateBlogPostCommandValidator.cs
@@ -1,0 +1,22 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     UpdateBlogPostCommandValidator.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Domain
+//=======================================================
+
+using FluentValidation;
+
+namespace MyBlog.Domain.Features.BlogPosts.Commands.UpdateBlogPost;
+
+public sealed class UpdateBlogPostCommandValidator : AbstractValidator<UpdateBlogPostCommand>
+{
+	public UpdateBlogPostCommandValidator()
+	{
+		RuleFor(x => x.Id).NotEmpty();
+		RuleFor(x => x.Title).NotEmpty().MaximumLength(200);
+		RuleFor(x => x.Content).NotEmpty();
+	}
+}

--- a/src/Domain/Features/BlogPosts/Queries/GetAllBlogPosts/GetAllBlogPostsQuery.cs
+++ b/src/Domain/Features/BlogPosts/Queries/GetAllBlogPosts/GetAllBlogPostsQuery.cs
@@ -1,0 +1,18 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     GetAllBlogPostsQuery.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Domain
+//=======================================================
+
+using Domain.Abstractions;
+
+using MediatR;
+
+using MyBlog.Domain.Entities;
+
+namespace MyBlog.Domain.Features.BlogPosts.Queries.GetAllBlogPosts;
+
+public sealed record GetAllBlogPostsQuery : IRequest<Result<IReadOnlyList<BlogPost>>>;

--- a/src/Domain/Features/BlogPosts/Queries/GetAllBlogPosts/GetAllBlogPostsQueryHandler.cs
+++ b/src/Domain/Features/BlogPosts/Queries/GetAllBlogPosts/GetAllBlogPostsQueryHandler.cs
@@ -1,0 +1,33 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     GetAllBlogPostsQueryHandler.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Domain
+//=======================================================
+
+using Domain.Abstractions;
+
+using MediatR;
+
+using MyBlog.Domain.Entities;
+using MyBlog.Domain.Interfaces;
+
+namespace MyBlog.Domain.Features.BlogPosts.Queries.GetAllBlogPosts;
+
+public sealed class GetAllBlogPostsQueryHandler : IRequestHandler<GetAllBlogPostsQuery, Result<IReadOnlyList<BlogPost>>>
+{
+	private readonly IBlogPostRepository _repository;
+
+	public GetAllBlogPostsQueryHandler(IBlogPostRepository repository)
+	{
+		_repository = repository;
+	}
+
+	public async Task<Result<IReadOnlyList<BlogPost>>> Handle(GetAllBlogPostsQuery request, CancellationToken cancellationToken)
+	{
+		var posts = await _repository.GetAllAsync(cancellationToken);
+		return Result.Ok(posts);
+	}
+}

--- a/src/Domain/Features/BlogPosts/Queries/GetBlogPostById/GetBlogPostByIdQuery.cs
+++ b/src/Domain/Features/BlogPosts/Queries/GetBlogPostById/GetBlogPostByIdQuery.cs
@@ -1,0 +1,18 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     GetBlogPostByIdQuery.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Domain
+//=======================================================
+
+using Domain.Abstractions;
+
+using MediatR;
+
+using MyBlog.Domain.Entities;
+
+namespace MyBlog.Domain.Features.BlogPosts.Queries.GetBlogPostById;
+
+public sealed record GetBlogPostByIdQuery(Guid Id) : IRequest<Result<BlogPost>>;

--- a/src/Domain/Features/BlogPosts/Queries/GetBlogPostById/GetBlogPostByIdQueryHandler.cs
+++ b/src/Domain/Features/BlogPosts/Queries/GetBlogPostById/GetBlogPostByIdQueryHandler.cs
@@ -1,0 +1,35 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     GetBlogPostByIdQueryHandler.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Domain
+//=======================================================
+
+using Domain.Abstractions;
+
+using MediatR;
+
+using MyBlog.Domain.Entities;
+using MyBlog.Domain.Interfaces;
+
+namespace MyBlog.Domain.Features.BlogPosts.Queries.GetBlogPostById;
+
+public sealed class GetBlogPostByIdQueryHandler : IRequestHandler<GetBlogPostByIdQuery, Result<BlogPost>>
+{
+	private readonly IBlogPostRepository _repository;
+
+	public GetBlogPostByIdQueryHandler(IBlogPostRepository repository)
+	{
+		_repository = repository;
+	}
+
+	public async Task<Result<BlogPost>> Handle(GetBlogPostByIdQuery request, CancellationToken cancellationToken)
+	{
+		var post = await _repository.GetByIdAsync(request.Id, cancellationToken);
+		if (post is null)
+			return Result.Fail<BlogPost>("Blog post not found.", ResultErrorCode.NotFound);
+		return Result.Ok(post);
+	}
+}

--- a/src/Web/Features/BlogPosts/Create/CreateBlogPostCommandValidator.cs
+++ b/src/Web/Features/BlogPosts/Create/CreateBlogPostCommandValidator.cs
@@ -1,0 +1,29 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     CreateBlogPostCommandValidator.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web
+//=======================================================
+
+using FluentValidation;
+
+namespace MyBlog.Web.Features.BlogPosts.Create;
+
+public sealed class CreateBlogPostCommandValidator : AbstractValidator<CreateBlogPostCommand>
+{
+	public CreateBlogPostCommandValidator()
+	{
+		RuleFor(x => x.Title)
+			.NotEmpty().WithMessage("Title is required.")
+			.MaximumLength(200).WithMessage("Title must not exceed 200 characters.");
+
+		RuleFor(x => x.Content)
+			.NotEmpty().WithMessage("Content is required.");
+
+		RuleFor(x => x.Author)
+			.NotEmpty().WithMessage("Author is required.")
+			.MaximumLength(100).WithMessage("Author must not exceed 100 characters.");
+	}
+}

--- a/src/Web/Features/BlogPosts/Delete/DeleteBlogPostCommandValidator.cs
+++ b/src/Web/Features/BlogPosts/Delete/DeleteBlogPostCommandValidator.cs
@@ -1,0 +1,21 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     DeleteBlogPostCommandValidator.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web
+//=======================================================
+
+using FluentValidation;
+
+namespace MyBlog.Web.Features.BlogPosts.Delete;
+
+public sealed class DeleteBlogPostCommandValidator : AbstractValidator<DeleteBlogPostCommand>
+{
+	public DeleteBlogPostCommandValidator()
+	{
+		RuleFor(x => x.Id)
+			.NotEmpty().WithMessage("Id is required.");
+	}
+}

--- a/src/Web/Features/BlogPosts/Edit/EditBlogPostCommandValidator.cs
+++ b/src/Web/Features/BlogPosts/Edit/EditBlogPostCommandValidator.cs
@@ -1,0 +1,28 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     EditBlogPostCommandValidator.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web
+//=======================================================
+
+using FluentValidation;
+
+namespace MyBlog.Web.Features.BlogPosts.Edit;
+
+public sealed class EditBlogPostCommandValidator : AbstractValidator<EditBlogPostCommand>
+{
+	public EditBlogPostCommandValidator()
+	{
+		RuleFor(x => x.Id)
+			.NotEmpty().WithMessage("Id is required.");
+
+		RuleFor(x => x.Title)
+			.NotEmpty().WithMessage("Title is required.")
+			.MaximumLength(200).WithMessage("Title must not exceed 200 characters.");
+
+		RuleFor(x => x.Content)
+			.NotEmpty().WithMessage("Content is required.");
+	}
+}

--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -11,10 +11,13 @@ using System.Security.Claims;
 
 using Auth0.AspNetCore.Authentication;
 
+using FluentValidation;
+
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.EntityFrameworkCore;
 
+using MyBlog.Domain.Entities;
 using MyBlog.Web.Components;
 using MyBlog.Web.Security;
 
@@ -90,9 +93,15 @@ builder.Services.AddScoped<MongoDbBlogPostRepository>();
 builder.Services.AddScoped<IBlogPostRepository>(sp =>
 		sp.GetRequiredService<MongoDbBlogPostRepository>());
 
-// MediatR — scans Web assembly for all handlers
+// MediatR — scans Web and Domain assemblies for all handlers
 builder.Services.AddMediatR(cfg =>
-		cfg.RegisterServicesFromAssembly(typeof(Program).Assembly));
+{
+    cfg.RegisterServicesFromAssembly(typeof(Program).Assembly);
+    cfg.RegisterServicesFromAssembly(typeof(BlogPost).Assembly); // Domain
+});
+
+// FluentValidation — scans Domain assembly for all validators
+builder.Services.AddValidatorsFromAssembly(typeof(BlogPost).Assembly);
 
 // HttpClient for Auth0 Management API
 builder.Services.AddHttpClient();

--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -13,10 +13,13 @@ using Auth0.AspNetCore.Authentication;
 
 using FluentValidation;
 
+using MediatR;
+
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.EntityFrameworkCore;
 
+using MyBlog.Domain.Behaviors;
 using MyBlog.Domain.Entities;
 using MyBlog.Web.Components;
 using MyBlog.Web.Security;
@@ -102,6 +105,9 @@ builder.Services.AddMediatR(cfg =>
 
 // FluentValidation — scans Domain assembly for all validators
 builder.Services.AddValidatorsFromAssembly(typeof(BlogPost).Assembly);
+
+// Register ValidationBehavior pipeline
+builder.Services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
 
 // HttpClient for Auth0 Management API
 builder.Services.AddHttpClient();

--- a/src/Web/Web.csproj
+++ b/src/Web/Web.csproj
@@ -10,6 +10,8 @@
     <PackageReference Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.2.2" />
     <PackageReference Include="Auth0.AspNetCore.Authentication" Version="1.7.0" />
     <PackageReference Include="Auth0.ManagementApi" Version="8.1.0" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
     <PackageReference Include="MediatR" Version="14.1.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.6" />
     <PackageReference Include="MongoDB.EntityFrameworkCore" Version="10.0.1" />

--- a/tests/Unit.Tests/Behaviors/ValidationBehaviorTests.cs
+++ b/tests/Unit.Tests/Behaviors/ValidationBehaviorTests.cs
@@ -1,0 +1,189 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     ValidationBehaviorTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Unit.Tests
+//=======================================================
+
+using FluentValidation;
+using MediatR;
+using MyBlog.Domain.Behaviors;
+using MyBlog.Web.Features.BlogPosts.Create;
+using MyBlog.Web.Features.BlogPosts.Delete;
+using MyBlog.Web.Features.BlogPosts.Edit;
+
+namespace MyBlog.Unit.Tests.Behaviors;
+
+public class ValidationBehaviorTests
+{
+	// ── CreateBlogPostCommand (Result<Guid>) ─────────────────────────────────
+
+	[Fact]
+	public async Task Handle_NoValidators_CallsNext()
+	{
+		var next = Substitute.For<RequestHandlerDelegate<Result<Guid>>>();
+		next(Arg.Any<CancellationToken>()).Returns(Result.Ok<Guid>(Guid.NewGuid()));
+		var behavior = new ValidationBehavior<CreateBlogPostCommand, Result<Guid>>([]);
+
+		var result = await behavior.Handle(
+			new CreateBlogPostCommand("T", "C", "A"), next, CancellationToken.None);
+
+		result.Success.Should().BeTrue();
+		await next.Received(1)(Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_ValidRequest_CallsNext()
+	{
+		var validator = new CreateBlogPostCommandValidator();
+		var next = Substitute.For<RequestHandlerDelegate<Result<Guid>>>();
+		next(Arg.Any<CancellationToken>()).Returns(Result.Ok<Guid>(Guid.NewGuid()));
+		var behavior = new ValidationBehavior<CreateBlogPostCommand, Result<Guid>>([validator]);
+
+		var result = await behavior.Handle(
+			new CreateBlogPostCommand("Title", "Content", "Author"), next, CancellationToken.None);
+
+		result.Success.Should().BeTrue();
+		await next.Received(1)(Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_InvalidRequest_ReturnsValidationFailWithoutCallingNext()
+	{
+		var validator = new CreateBlogPostCommandValidator();
+		var next = Substitute.For<RequestHandlerDelegate<Result<Guid>>>();
+		var behavior = new ValidationBehavior<CreateBlogPostCommand, Result<Guid>>([validator]);
+
+		var result = await behavior.Handle(
+			new CreateBlogPostCommand("", "", ""), next, CancellationToken.None);
+
+		result.Success.Should().BeFalse();
+		result.ErrorCode.Should().Be(ResultErrorCode.Validation);
+		await next.DidNotReceive()(Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_InvalidRequest_ErrorMessageContainsValidationDetails()
+	{
+		var validator = new CreateBlogPostCommandValidator();
+		var next = Substitute.For<RequestHandlerDelegate<Result<Guid>>>();
+		var behavior = new ValidationBehavior<CreateBlogPostCommand, Result<Guid>>([validator]);
+
+		var result = await behavior.Handle(
+			new CreateBlogPostCommand("", "Content", ""), next, CancellationToken.None);
+
+		result.Error.Should().NotBeNullOrEmpty();
+	}
+
+	[Fact]
+	public async Task Handle_MultipleValidators_AllAreExecuted()
+	{
+		var validator1 = new CreateBlogPostCommandValidator();
+		var validator2 = new CreateBlogPostCommandValidator();
+		var next = Substitute.For<RequestHandlerDelegate<Result<Guid>>>();
+		next(Arg.Any<CancellationToken>()).Returns(Result.Ok<Guid>(Guid.NewGuid()));
+		var behavior = new ValidationBehavior<CreateBlogPostCommand, Result<Guid>>([validator1, validator2]);
+
+		var result = await behavior.Handle(
+			new CreateBlogPostCommand("Title", "Content", "Author"), next, CancellationToken.None);
+
+		result.Success.Should().BeTrue();
+		await next.Received(1)(Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_MultipleValidatorsOneInvalid_ReturnsFail()
+	{
+		var validator1 = new CreateBlogPostCommandValidator();
+		var validator2 = new CreateBlogPostCommandValidator();
+		var next = Substitute.For<RequestHandlerDelegate<Result<Guid>>>();
+		var behavior = new ValidationBehavior<CreateBlogPostCommand, Result<Guid>>([validator1, validator2]);
+
+		var result = await behavior.Handle(
+			new CreateBlogPostCommand("", "", ""), next, CancellationToken.None);
+
+		result.Success.Should().BeFalse();
+		result.ErrorCode.Should().Be(ResultErrorCode.Validation);
+		await next.DidNotReceive()(Arg.Any<CancellationToken>());
+	}
+
+	// ── DeleteBlogPostCommand (Result — non-generic) ─────────────────────────
+
+	[Fact]
+	public async Task Handle_DeleteNoValidators_CallsNext()
+	{
+		var next = Substitute.For<RequestHandlerDelegate<Result>>();
+		next(Arg.Any<CancellationToken>()).Returns(Result.Ok());
+		var behavior = new ValidationBehavior<DeleteBlogPostCommand, Result>([]);
+
+		var result = await behavior.Handle(
+			new DeleteBlogPostCommand(Guid.NewGuid()), next, CancellationToken.None);
+
+		result.Success.Should().BeTrue();
+		await next.Received(1)(Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_DeleteValidRequest_CallsNext()
+	{
+		var validator = new DeleteBlogPostCommandValidator();
+		var next = Substitute.For<RequestHandlerDelegate<Result>>();
+		next(Arg.Any<CancellationToken>()).Returns(Result.Ok());
+		var behavior = new ValidationBehavior<DeleteBlogPostCommand, Result>([validator]);
+
+		var result = await behavior.Handle(
+			new DeleteBlogPostCommand(Guid.NewGuid()), next, CancellationToken.None);
+
+		result.Success.Should().BeTrue();
+		await next.Received(1)(Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_DeleteEmptyGuid_ReturnsValidationFailWithoutCallingNext()
+	{
+		var validator = new DeleteBlogPostCommandValidator();
+		var next = Substitute.For<RequestHandlerDelegate<Result>>();
+		var behavior = new ValidationBehavior<DeleteBlogPostCommand, Result>([validator]);
+
+		var result = await behavior.Handle(
+			new DeleteBlogPostCommand(Guid.Empty), next, CancellationToken.None);
+
+		result.Success.Should().BeFalse();
+		result.ErrorCode.Should().Be(ResultErrorCode.Validation);
+		await next.DidNotReceive()(Arg.Any<CancellationToken>());
+	}
+
+	// ── EditBlogPostCommand (Result — non-generic) ────────────────────────────
+
+	[Fact]
+	public async Task Handle_EditValidRequest_CallsNext()
+	{
+		var validator = new EditBlogPostCommandValidator();
+		var next = Substitute.For<RequestHandlerDelegate<Result>>();
+		next(Arg.Any<CancellationToken>()).Returns(Result.Ok());
+		var behavior = new ValidationBehavior<EditBlogPostCommand, Result>([validator]);
+
+		var result = await behavior.Handle(
+			new EditBlogPostCommand(Guid.NewGuid(), "Title", "Content"), next, CancellationToken.None);
+
+		result.Success.Should().BeTrue();
+		await next.Received(1)(Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_EditInvalidRequest_ReturnsValidationFailWithoutCallingNext()
+	{
+		var validator = new EditBlogPostCommandValidator();
+		var next = Substitute.For<RequestHandlerDelegate<Result>>();
+		var behavior = new ValidationBehavior<EditBlogPostCommand, Result>([validator]);
+
+		var result = await behavior.Handle(
+			new EditBlogPostCommand(Guid.Empty, "", ""), next, CancellationToken.None);
+
+		result.Success.Should().BeFalse();
+		result.ErrorCode.Should().Be(ResultErrorCode.Validation);
+		await next.DidNotReceive()(Arg.Any<CancellationToken>());
+	}
+}

--- a/tests/Unit.Tests/Domain/Commands/CreateBlogPostCommandHandlerTests.cs
+++ b/tests/Unit.Tests/Domain/Commands/CreateBlogPostCommandHandlerTests.cs
@@ -1,0 +1,55 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     CreateBlogPostCommandHandlerTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Unit.Tests
+//=======================================================
+
+using MyBlog.Domain.Features.BlogPosts.Commands.CreateBlogPost;
+
+namespace MyBlog.Unit.Tests.Domain.Commands;
+
+public class CreateBlogPostCommandHandlerTests
+{
+	private readonly IBlogPostRepository _repo = Substitute.For<IBlogPostRepository>();
+	private readonly CreateBlogPostCommandHandler _handler;
+
+	public CreateBlogPostCommandHandlerTests()
+	{
+		_handler = new CreateBlogPostCommandHandler(_repo);
+	}
+
+	[Fact]
+	public async Task Handle_ValidCommand_AddsPostAndReturnsGuid()
+	{
+		// Arrange
+		var command = new CreateBlogPostCommand("Test Title", "Test Content", "Author One");
+
+		// Act
+		var result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().NotBe(Guid.Empty);
+		await _repo.Received(1).AddAsync(
+			Arg.Is<BlogPost>(p => p.Title == "Test Title" && p.Author == "Author One"),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_RepositoryThrows_PropagatesException()
+	{
+		// Arrange
+		var command = new CreateBlogPostCommand("Title", "Content", "Author");
+		_repo.AddAsync(Arg.Any<BlogPost>(), Arg.Any<CancellationToken>())
+			.ThrowsAsync(new InvalidOperationException("DB error"));
+
+		// Act
+		var act = () => _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<InvalidOperationException>();
+	}
+}

--- a/tests/Unit.Tests/Domain/Commands/DeleteBlogPostCommandHandlerTests.cs
+++ b/tests/Unit.Tests/Domain/Commands/DeleteBlogPostCommandHandlerTests.cs
@@ -1,0 +1,53 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     DeleteBlogPostCommandHandlerTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Unit.Tests
+//=======================================================
+
+using MyBlog.Domain.Features.BlogPosts.Commands.DeleteBlogPost;
+
+namespace MyBlog.Unit.Tests.Domain.Commands;
+
+public class DeleteBlogPostCommandHandlerTests
+{
+	private readonly IBlogPostRepository _repo = Substitute.For<IBlogPostRepository>();
+	private readonly DeleteBlogPostCommandHandler _handler;
+
+	public DeleteBlogPostCommandHandlerTests()
+	{
+		_handler = new DeleteBlogPostCommandHandler(_repo);
+	}
+
+	[Fact]
+	public async Task Handle_ValidId_DeletesPostAndReturnsSuccess()
+	{
+		// Arrange
+		var id = Guid.NewGuid();
+		var command = new DeleteBlogPostCommand(id);
+
+		// Act
+		var result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		await _repo.Received(1).DeleteAsync(id, Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_RepositoryThrows_PropagatesException()
+	{
+		// Arrange
+		var command = new DeleteBlogPostCommand(Guid.NewGuid());
+		_repo.DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+			.ThrowsAsync(new InvalidOperationException("DB error"));
+
+		// Act
+		var act = () => _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<InvalidOperationException>();
+	}
+}

--- a/tests/Unit.Tests/Domain/Commands/UpdateBlogPostCommandHandlerTests.cs
+++ b/tests/Unit.Tests/Domain/Commands/UpdateBlogPostCommandHandlerTests.cs
@@ -1,0 +1,73 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     UpdateBlogPostCommandHandlerTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Unit.Tests
+//=======================================================
+
+using MyBlog.Domain.Features.BlogPosts.Commands.UpdateBlogPost;
+
+namespace MyBlog.Unit.Tests.Domain.Commands;
+
+public class UpdateBlogPostCommandHandlerTests
+{
+	private readonly IBlogPostRepository _repo = Substitute.For<IBlogPostRepository>();
+	private readonly UpdateBlogPostCommandHandler _handler;
+
+	public UpdateBlogPostCommandHandlerTests()
+	{
+		_handler = new UpdateBlogPostCommandHandler(_repo);
+	}
+
+	[Fact]
+	public async Task Handle_ExistingPost_UpdatesAndReturnsSuccess()
+	{
+		// Arrange
+		var post = BlogPost.Create("Old Title", "Old Content", "Author");
+		var command = new UpdateBlogPostCommand(post.Id, "New Title", "New Content");
+		_repo.GetByIdAsync(post.Id, Arg.Any<CancellationToken>()).Returns(post);
+
+		// Act
+		var result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		await _repo.Received(1).UpdateAsync(
+			Arg.Is<BlogPost>(p => p.Title == "New Title"),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_PostNotFound_ReturnsNotFoundFailure()
+	{
+		// Arrange
+		var id = Guid.NewGuid();
+		var command = new UpdateBlogPostCommand(id, "Title", "Content");
+		_repo.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((BlogPost?)null);
+
+		// Act
+		var result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeFalse();
+		result.ErrorCode.Should().Be(ResultErrorCode.NotFound);
+		await _repo.DidNotReceive().UpdateAsync(Arg.Any<BlogPost>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_RepositoryThrowsOnGet_PropagatesException()
+	{
+		// Arrange
+		var command = new UpdateBlogPostCommand(Guid.NewGuid(), "Title", "Content");
+		_repo.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+			.ThrowsAsync(new InvalidOperationException("DB error"));
+
+		// Act
+		var act = () => _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<InvalidOperationException>();
+	}
+}

--- a/tests/Unit.Tests/Domain/Queries/GetAllBlogPostsQueryHandlerTests.cs
+++ b/tests/Unit.Tests/Domain/Queries/GetAllBlogPostsQueryHandlerTests.cs
@@ -1,0 +1,71 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     GetAllBlogPostsQueryHandlerTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Unit.Tests
+//=======================================================
+
+using MyBlog.Domain.Features.BlogPosts.Queries.GetAllBlogPosts;
+
+namespace MyBlog.Unit.Tests.Domain.Queries;
+
+public class GetAllBlogPostsQueryHandlerTests
+{
+	private readonly IBlogPostRepository _repo = Substitute.For<IBlogPostRepository>();
+	private readonly GetAllBlogPostsQueryHandler _handler;
+
+	public GetAllBlogPostsQueryHandlerTests()
+	{
+		_handler = new GetAllBlogPostsQueryHandler(_repo);
+	}
+
+	[Fact]
+	public async Task Handle_WithPosts_ReturnsSuccessWithList()
+	{
+		// Arrange
+		var posts = new List<BlogPost>
+		{
+			BlogPost.Create("Post 1", "Content 1", "Author A"),
+			BlogPost.Create("Post 2", "Content 2", "Author B")
+		};
+		_repo.GetAllAsync(Arg.Any<CancellationToken>()).Returns((IReadOnlyList<BlogPost>)posts);
+
+		// Act
+		var result = await _handler.Handle(new GetAllBlogPostsQuery(), CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().HaveCount(2);
+	}
+
+	[Fact]
+	public async Task Handle_EmptyRepository_ReturnsSuccessWithEmptyList()
+	{
+		// Arrange
+		_repo.GetAllAsync(Arg.Any<CancellationToken>())
+			.Returns((IReadOnlyList<BlogPost>)new List<BlogPost>());
+
+		// Act
+		var result = await _handler.Handle(new GetAllBlogPostsQuery(), CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task Handle_RepositoryThrows_PropagatesException()
+	{
+		// Arrange
+		_repo.GetAllAsync(Arg.Any<CancellationToken>())
+			.ThrowsAsync(new InvalidOperationException("DB error"));
+
+		// Act
+		var act = () => _handler.Handle(new GetAllBlogPostsQuery(), CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<InvalidOperationException>();
+	}
+}

--- a/tests/Unit.Tests/Domain/Queries/GetBlogPostByIdQueryHandlerTests.cs
+++ b/tests/Unit.Tests/Domain/Queries/GetBlogPostByIdQueryHandlerTests.cs
@@ -1,0 +1,70 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     GetBlogPostByIdQueryHandlerTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Unit.Tests
+//=======================================================
+
+using MyBlog.Domain.Features.BlogPosts.Queries.GetBlogPostById;
+
+namespace MyBlog.Unit.Tests.Domain.Queries;
+
+public class GetBlogPostByIdQueryHandlerTests
+{
+	private readonly IBlogPostRepository _repo = Substitute.For<IBlogPostRepository>();
+	private readonly GetBlogPostByIdQueryHandler _handler;
+
+	public GetBlogPostByIdQueryHandlerTests()
+	{
+		_handler = new GetBlogPostByIdQueryHandler(_repo);
+	}
+
+	[Fact]
+	public async Task Handle_ExistingPost_ReturnsSuccessWithPost()
+	{
+		// Arrange
+		var post = BlogPost.Create("Title", "Content", "Author");
+		var query = new GetBlogPostByIdQuery(post.Id);
+		_repo.GetByIdAsync(post.Id, Arg.Any<CancellationToken>()).Returns(post);
+
+		// Act
+		var result = await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().BeEquivalentTo(post);
+	}
+
+	[Fact]
+	public async Task Handle_PostNotFound_ReturnsNotFoundFailure()
+	{
+		// Arrange
+		var id = Guid.NewGuid();
+		var query = new GetBlogPostByIdQuery(id);
+		_repo.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((BlogPost?)null);
+
+		// Act
+		var result = await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeFalse();
+		result.ErrorCode.Should().Be(ResultErrorCode.NotFound);
+	}
+
+	[Fact]
+	public async Task Handle_RepositoryThrows_PropagatesException()
+	{
+		// Arrange
+		var query = new GetBlogPostByIdQuery(Guid.NewGuid());
+		_repo.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+			.ThrowsAsync(new InvalidOperationException("DB error"));
+
+		// Act
+		var act = () => _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<InvalidOperationException>();
+	}
+}

--- a/tests/Unit.Tests/Features/BlogPosts/Commands/CreateBlogPostCommandValidatorTests.cs
+++ b/tests/Unit.Tests/Features/BlogPosts/Commands/CreateBlogPostCommandValidatorTests.cs
@@ -1,0 +1,97 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     CreateBlogPostCommandValidatorTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Unit.Tests
+//=======================================================
+
+using MyBlog.Web.Features.BlogPosts.Create;
+
+namespace MyBlog.Unit.Tests.Features.BlogPosts.Commands;
+
+public class CreateBlogPostCommandValidatorTests
+{
+	private readonly CreateBlogPostCommandValidator _sut = new();
+
+	[Fact]
+	public void Validate_ValidCommand_ReturnsNoErrors()
+	{
+		var command = new CreateBlogPostCommand("Valid Title", "Valid Content", "Valid Author");
+		var result = _sut.Validate(command);
+		result.IsValid.Should().BeTrue();
+	}
+
+	[Theory]
+	[InlineData("", "Content", "Author")]
+	[InlineData("Title", "", "Author")]
+	[InlineData("Title", "Content", "")]
+	public void Validate_MissingRequiredFields_ReturnsErrors(string title, string content, string author)
+	{
+		var command = new CreateBlogPostCommand(title, content, author);
+		var result = _sut.Validate(command);
+		result.IsValid.Should().BeFalse();
+	}
+
+	[Fact]
+	public void Validate_TitleExceedsMaxLength_ReturnsError()
+	{
+		var command = new CreateBlogPostCommand(new string('A', 201), "Content", "Author");
+		var result = _sut.Validate(command);
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().ContainSingle(e => e.PropertyName == "Title");
+	}
+
+	[Fact]
+	public void Validate_AuthorExceedsMaxLength_ReturnsError()
+	{
+		var command = new CreateBlogPostCommand("Title", "Content", new string('A', 101));
+		var result = _sut.Validate(command);
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().ContainSingle(e => e.PropertyName == "Author");
+	}
+
+	[Fact]
+	public void Validate_TitleAtMaxLength_ReturnsNoErrors()
+	{
+		var command = new CreateBlogPostCommand(new string('A', 200), "Content", "Author");
+		var result = _sut.Validate(command);
+		result.IsValid.Should().BeTrue();
+	}
+
+	[Fact]
+	public void Validate_AuthorAtMaxLength_ReturnsNoErrors()
+	{
+		var command = new CreateBlogPostCommand("Title", "Content", new string('A', 100));
+		var result = _sut.Validate(command);
+		result.IsValid.Should().BeTrue();
+	}
+
+	[Fact]
+	public void Validate_WhitespaceTitle_ReturnsError()
+	{
+		var command = new CreateBlogPostCommand("   ", "Content", "Author");
+		var result = _sut.Validate(command);
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Title");
+	}
+
+	[Fact]
+	public void Validate_WhitespaceAuthor_ReturnsError()
+	{
+		var command = new CreateBlogPostCommand("Title", "Content", "   ");
+		var result = _sut.Validate(command);
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Author");
+	}
+
+	[Fact]
+	public void Validate_WhitespaceContent_ReturnsError()
+	{
+		var command = new CreateBlogPostCommand("Title", "   ", "Author");
+		var result = _sut.Validate(command);
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Content");
+	}
+}

--- a/tests/Unit.Tests/Features/BlogPosts/Commands/DeleteBlogPostCommandValidatorTests.cs
+++ b/tests/Unit.Tests/Features/BlogPosts/Commands/DeleteBlogPostCommandValidatorTests.cs
@@ -1,0 +1,43 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     DeleteBlogPostCommandValidatorTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Unit.Tests
+//=======================================================
+
+using MyBlog.Web.Features.BlogPosts.Delete;
+
+namespace MyBlog.Unit.Tests.Features.BlogPosts.Commands;
+
+public class DeleteBlogPostCommandValidatorTests
+{
+	private readonly DeleteBlogPostCommandValidator _sut = new();
+
+	[Fact]
+	public void Validate_ValidId_ReturnsNoErrors()
+	{
+		var command = new DeleteBlogPostCommand(Guid.NewGuid());
+		var result = _sut.Validate(command);
+		result.IsValid.Should().BeTrue();
+	}
+
+	[Fact]
+	public void Validate_EmptyGuid_ReturnsError()
+	{
+		var command = new DeleteBlogPostCommand(Guid.Empty);
+		var result = _sut.Validate(command);
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().ContainSingle(e => e.PropertyName == "Id");
+	}
+
+	[Fact]
+	public void Validate_EmptyGuid_ReturnsRequiredMessage()
+	{
+		var command = new DeleteBlogPostCommand(Guid.Empty);
+		var result = _sut.Validate(command);
+		result.Errors.Should().ContainSingle(e =>
+			e.PropertyName == "Id" && e.ErrorMessage == "Id is required.");
+	}
+}

--- a/tests/Unit.Tests/Features/BlogPosts/Commands/EditBlogPostCommandValidatorTests.cs
+++ b/tests/Unit.Tests/Features/BlogPosts/Commands/EditBlogPostCommandValidatorTests.cs
@@ -1,0 +1,96 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     EditBlogPostCommandValidatorTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Unit.Tests
+//=======================================================
+
+using MyBlog.Web.Features.BlogPosts.Edit;
+
+namespace MyBlog.Unit.Tests.Features.BlogPosts.Commands;
+
+public class EditBlogPostCommandValidatorTests
+{
+	private readonly EditBlogPostCommandValidator _sut = new();
+
+	[Fact]
+	public void Validate_ValidCommand_ReturnsNoErrors()
+	{
+		var command = new EditBlogPostCommand(Guid.NewGuid(), "Valid Title", "Valid Content");
+		var result = _sut.Validate(command);
+		result.IsValid.Should().BeTrue();
+	}
+
+	[Fact]
+	public void Validate_EmptyId_ReturnsError()
+	{
+		var command = new EditBlogPostCommand(Guid.Empty, "Title", "Content");
+		var result = _sut.Validate(command);
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Id");
+	}
+
+	[Fact]
+	public void Validate_EmptyTitle_ReturnsError()
+	{
+		var command = new EditBlogPostCommand(Guid.NewGuid(), "", "Content");
+		var result = _sut.Validate(command);
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Title");
+	}
+
+	[Fact]
+	public void Validate_EmptyContent_ReturnsError()
+	{
+		var command = new EditBlogPostCommand(Guid.NewGuid(), "Title", "");
+		var result = _sut.Validate(command);
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Content");
+	}
+
+	[Fact]
+	public void Validate_TitleExceedsMaxLength_ReturnsError()
+	{
+		var command = new EditBlogPostCommand(Guid.NewGuid(), new string('A', 201), "Content");
+		var result = _sut.Validate(command);
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().ContainSingle(e => e.PropertyName == "Title");
+	}
+
+	[Fact]
+	public void Validate_TitleAtMaxLength_ReturnsNoErrors()
+	{
+		var command = new EditBlogPostCommand(Guid.NewGuid(), new string('A', 200), "Content");
+		var result = _sut.Validate(command);
+		result.IsValid.Should().BeTrue();
+	}
+
+	[Fact]
+	public void Validate_WhitespaceTitle_ReturnsError()
+	{
+		var command = new EditBlogPostCommand(Guid.NewGuid(), "   ", "Content");
+		var result = _sut.Validate(command);
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Title");
+	}
+
+	[Fact]
+	public void Validate_WhitespaceContent_ReturnsError()
+	{
+		var command = new EditBlogPostCommand(Guid.NewGuid(), "Title", "   ");
+		var result = _sut.Validate(command);
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Content");
+	}
+
+	[Fact]
+	public void Validate_MultipleEmptyFields_ReturnsMultipleErrors()
+	{
+		var command = new EditBlogPostCommand(Guid.Empty, "", "");
+		var result = _sut.Validate(command);
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().HaveCountGreaterThan(1);
+	}
+}


### PR DESCRIPTION
## Sprint 2 Closeout

Merges `sprint/2-cqrs-mediatr` → `dev`

### Delivered
- #45 — MediatR 14.1.0 + FluentValidation 12.0.0 packages
- #46 — BlogPost vertical slice folder structure  
- #39 — ValidationBehavior pipeline behavior
- #40 — Unit tests for CQRS handlers and validators
- #56 — Project board automation (In Review / Done column transitions)

### Sprint 2 issues closed: 45, 46, 39, 40, 56

Closes #45
Closes #46
Closes #39
Closes #40
Closes #56

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>