### PR TITLE
[Sprint 3] Add UI component tests, Profile page, and RoleClaimsHelper

### DIFF
--- a/.squad/agents/aragorn/history.md
+++ b/.squad/agents/aragorn/history.md
@@ -400,3 +400,52 @@ Triaged Issue #18 ("Branch clean-up" / orphan local-repo changes) against draft 
 
 **Next Actor:** Ralph — coordinate fix cycle on PR #60 (resolve conflicts + copyright headers). PRs #62 and #63 are pending final approval from mpaulosky.
 
+---
+
+## 2026-04-20 — PR #60 Deep Review (Sprint 3 — UI Tests, Profile, RoleClaimsHelper)
+
+Conducted a comprehensive full-diff review of PR #60. The initial gate review (above) identified 3 blockers; this deeper review reveals additional regressions that make the PR more complex than initially assessed.
+
+### Key Finding: Sprint Branch Has Evolved Past the PR
+
+A `git diff origin/sprint/3-mongodb-persistence origin/squad/59-ui-component-tests-profile-roleclaimshelper` across all changed files revealed the sprint branch has SUPERIOR versions of several files. Merging the PR would **regress** already-committed improvements:
+
+| File | Regression if PR merges |
+|------|------------------------|
+| `Profile.razor` | Loses `_sensitiveClaimTypes` filter — exposes `nonce`, `c_hash`, `at_hash`, `aud`, etc. to end users |
+| `NavMenu.razor` | Loses `ILogger<NavMenu>` + exception logging; empty `catch { }` swallows errors silently |
+| `NavMenu.razor` | Loses `role="button"` + `tabindex="0"` on hamburger — accessibility regression |
+| `Program.cs` | Loses copyright header |
+| All 8 new `.cs` files | Lose copyright headers (Decision #2 violation) |
+
+### Critical Test Failure
+
+`RazorSmokeTests.cs` in the PR adds `Counter_Increments_WhenButtonClicked` and `Weather_LoadsForecasts` tests that reference `Counter` and `Weather` components **deleted in PR #6** (Decision #1). Build failure confirmed via grep — those types do not exist in `src/Web/`.
+
+### CI Gap Confirmed
+
+`squad-test.yml` does not trigger on `sprint/**` PRs. All 8 check runs for PR #60 were Copilot agent jobs. No build/test validation ran remotely. This is why the Counter/Weather compile failure was not caught automatically.
+
+### Architecture Assessment
+
+- ✅ `RoleClaimsHelper` design: configurable `Auth0:RoleClaimTypes`, JSON/CSV expansion, deduplication — sound
+- ✅ `Profile.razor` at `Features/UserManagement/` — correct VSA placement
+- ✅ `PostConfigure<OpenIdConnectOptions>` pattern in `Program.cs` — correct  
+- ✅ `@implements IDisposable` with proper `Dispose()` unregistering `LocationChanged` in NavMenu
+- ✅ `TestAuthorizationService` — well-designed, reusable
+- ❌ `AssemblyInfo.cs` duplicate `InternalsVisibleTo("Unit.Tests")` — should only have `"MyBlog.Unit.Tests"`
+- ❌ Package version regression in `Unit.Tests.csproj` (coverlet.collector 6.0.4 vs sprint's 10.0.0)
+
+### Review Posted
+
+Full REQUEST_CHANGES review posted as comment on PR #60 (GitHub limits self-review to comment-only). Review body includes 8 required-fix items and clear rebase instructions.
+
+### Next Actor
+
+Author (Ralph/Legolas) must:
+1. Rebase onto latest `sprint/3-mongodb-persistence`
+2. Verify Counter/Weather tests are gone after rebase
+3. Ensure `_sensitiveClaimTypes` filter, logger, and accessibility attributes are retained
+4. Add copyright headers to `RoleClaimsHelper.cs` and `AssemblyInfo.cs` (other files resolved by rebase)
+5. Remove duplicate `InternalsVisibleTo("Unit.Tests")`
+

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,5 +3,6 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,71 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <!-- Aspire -->
+  <ItemGroup>
+    <PackageVersion Include="Aspire.Hosting.MongoDB" Version="13.2.2" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.2.2" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.2.2" />
+    <PackageVersion Include="Aspire.MongoDB.Driver" Version="13.2.2" />
+    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.2.2" />
+  </ItemGroup>
+
+  <!-- Auth0 -->
+  <ItemGroup>
+    <PackageVersion Include="Auth0.AspNetCore.Authentication" Version="1.7.0" />
+    <PackageVersion Include="Auth0.ManagementApi" Version="8.1.0" />
+  </ItemGroup>
+
+  <!-- FluentValidation
+       NOTE: FluentValidation.AspNetCore has no 12.x release (latest: 11.3.1).
+             Its dependency range [11.11.0, ) is satisfied by FluentValidation 12.0.0,
+             so this combination is safe. Revisit when a 12.x release appears. -->
+  <ItemGroup>
+    <PackageVersion Include="FluentValidation" Version="12.1.1" />
+    <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.1" />
+    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
+  </ItemGroup>
+
+  <!-- MediatR -->
+  <ItemGroup>
+    <PackageVersion Include="MediatR" Version="14.1.0" />
+  </ItemGroup>
+
+  <!-- Microsoft -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+  </ItemGroup>
+
+  <!-- MongoDB -->
+  <ItemGroup>
+    <PackageVersion Include="MongoDB.EntityFrameworkCore" Version="10.0.1" />
+  </ItemGroup>
+
+  <!-- OpenTelemetry (exporter/extensions normalised to 1.15.2; instrumentation at actual latest) -->
+  <ItemGroup>
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
+  </ItemGroup>
+
+  <!-- Testing -->
+  <ItemGroup>
+    <PackageVersion Include="bunit" Version="2.7.2" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+    <PackageVersion Include="coverlet.msbuild" Version="10.0.0" />
+    <PackageVersion Include="FluentAssertions" Version="8.9.0" />
+    <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="Testcontainers.MongoDb" Version="4.11.0" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
+</Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
 	"sdk": {
-		"version": "10.0.202",
+		"version": "10.0.100",
 		"rollForward": "latestMinor",
 		"allowPrerelease": false
 	}

--- a/src/AppHost/AppHost.csproj
+++ b/src/AppHost/AppHost.csproj
@@ -6,8 +6,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.MongoDB" Version="13.2.2" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="13.2.2" />
+    <PackageReference Include="Aspire.Hosting.MongoDB" />
+    <PackageReference Include="Aspire.Hosting.Redis" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="12.0.0" />
-    <PackageReference Include="MediatR" Version="14.1.0" />
+    <PackageReference Include="FluentValidation" />
+    <PackageReference Include="MediatR" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceDefaults/ServiceDefaults.csproj
+++ b/src/ServiceDefaults/ServiceDefaults.csproj
@@ -11,13 +11,13 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
   </ItemGroup>
 
 </Project>

--- a/src/Web/Web.csproj
+++ b/src/Web/Web.csproj
@@ -6,15 +6,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.MongoDB.Driver" Version="13.2.2" />
-    <PackageReference Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.2.2" />
-    <PackageReference Include="Auth0.AspNetCore.Authentication" Version="1.7.0" />
-    <PackageReference Include="Auth0.ManagementApi" Version="8.1.0" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
-    <PackageReference Include="MediatR" Version="14.1.0" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.6" />
-    <PackageReference Include="MongoDB.EntityFrameworkCore" Version="10.0.1" />
+    <PackageReference Include="Aspire.MongoDB.Driver" />
+    <PackageReference Include="Aspire.StackExchange.Redis.DistributedCaching" />
+    <PackageReference Include="Auth0.AspNetCore.Authentication" />
+    <PackageReference Include="Auth0.ManagementApi" />
+    <PackageReference Include="FluentValidation.AspNetCore" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
+    <PackageReference Include="MediatR" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="MongoDB.EntityFrameworkCore" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/tests/Architecture.Tests/Architecture.Tests.csproj
+++ b/tests/Architecture.Tests/Architecture.Tests.csproj
@@ -9,12 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0" />
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageReference Include="NetArchTest.Rules" Version="1.3.2" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NetArchTest.Rules" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Integration.Tests/Integration.Tests.csproj
+++ b/tests/Integration.Tests/Integration.Tests.csproj
@@ -10,14 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Testing" Version="13.2.2" />
-    <PackageReference Include="coverlet.collector" Version="10.0.0" />
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="Testcontainers.MongoDb" Version="4.11.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="Aspire.Hosting.Testing" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Testcontainers.MongoDb" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Unit.Tests/Components/Layout/NavMenuTests.cs
+++ b/tests/Unit.Tests/Components/Layout/NavMenuTests.cs
@@ -7,14 +7,6 @@
 //Project Name :  Unit.Tests
 //=======================================================
 
-// ============================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     NavMenuTests.cs
-// Company :       mpaulosky
-// Author :        mpaulosky
-// Solution Name : MyBlog
-// Project Name :  Unit.Tests
-// =============================================
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.DependencyInjection;

--- a/tests/Unit.Tests/Components/RazorSmokeTests.cs
+++ b/tests/Unit.Tests/Components/RazorSmokeTests.cs
@@ -7,14 +7,6 @@
 //Project Name :  Unit.Tests
 //=======================================================
 
-// ============================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     RazorSmokeTests.cs
-// Company :       mpaulosky
-// Author :        mpaulosky
-// Solution Name : MyBlog
-// Project Name :  Unit.Tests
-// =============================================
 using MediatR;
 
 using Microsoft.AspNetCore.Components;

--- a/tests/Unit.Tests/Features/UserManagement/ProfileTests.cs
+++ b/tests/Unit.Tests/Features/UserManagement/ProfileTests.cs
@@ -7,14 +7,6 @@
 //Project Name :  Unit.Tests
 //=======================================================
 
-// ============================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     ProfileTests.cs
-// Company :       mpaulosky
-// Author :        mpaulosky
-// Solution Name : MyBlog
-// Project Name :  Unit.Tests
-// =============================================
 using Microsoft.AspNetCore.Components.Authorization;
 
 using MyBlog.Web.Features.UserManagement;

--- a/tests/Unit.Tests/Security/RoleClaimsHelperTests.cs
+++ b/tests/Unit.Tests/Security/RoleClaimsHelperTests.cs
@@ -7,14 +7,6 @@
 //Project Name :  Unit.Tests
 //=======================================================
 
-// ============================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     RoleClaimsHelperTests.cs
-// Company :       mpaulosky
-// Author :        mpaulosky
-// Solution Name : MyBlog
-// Project Name :  Unit.Tests
-// =============================================
 using Microsoft.Extensions.Configuration;
 
 using MyBlog.Web.Security;

--- a/tests/Unit.Tests/Testing/TestAuthorizationService.cs
+++ b/tests/Unit.Tests/Testing/TestAuthorizationService.cs
@@ -7,14 +7,6 @@
 //Project Name :  Unit.Tests
 //=======================================================
 
-// ============================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     TestAuthorizationService.cs
-// Company :       mpaulosky
-// Author :        mpaulosky
-// Solution Name : MyBlog
-// Project Name :  Unit.Tests
-// =============================================
 using Microsoft.AspNetCore.Authorization.Infrastructure;
 
 namespace MyBlog.Unit.Tests.Testing;

--- a/tests/Unit.Tests/Unit.Tests.csproj
+++ b/tests/Unit.Tests/Unit.Tests.csproj
@@ -15,17 +15,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="bunit" Version="2.7.2" />
-    <PackageReference Include="coverlet.collector" Version="10.0.0" />
-    <PackageReference Include="coverlet.msbuild" Version="10.0.0">
+    <PackageReference Include="bunit" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="coverlet.msbuild">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Closes #59

Working as Ralph (Meta-coordinator)

Adds UI component coverage gate, Auth UI tests, Profile page component, NavMenu refactor, and RoleClaimsHelper with comprehensive unit tests.

## Changes
- `src/Web/Components/Pages/Profile.razor` — new Profile page
- `src/Web/Security/RoleClaimsHelper.cs` — role claims mapping
- `tests/Unit.Tests/Components/` — NavMenu, Profile, and Auth component tests
- `tests/Unit.Tests/Security/RoleClaimsHelperTests.cs`

## Checklist
- [x] Targets `sprint/3-mongodb-persistence` (not dev/main)
- [x] Issue #59 linked via `Closes #59`
- [x] Sprint 3 milestone assigned to issue