### PR TITLE
[Sprint 3] Fix pre-push Gate 0 to allow sprint/* branches

### DIFF
--- a/.github/hooks/pre-push
+++ b/.github/hooks/pre-push
@@ -11,18 +11,26 @@ RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; RE
 
 echo -e "${CYAN}━━━ Pre-Push Gate ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
 
-# ── Gate 0: Enforce squad branch naming (squad/{issue}-{slug}) ─────────────
+# ── Gate 0: Enforce branch naming conventions ──────────────────────────────
+# Merge hierarchy: squad/{issue}-{slug} → sprint/{N}-{slug} → dev → main (release only)
 CURRENT_BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null || echo "")"
 if [[ "$CURRENT_BRANCH" == "main" || "$CURRENT_BRANCH" == "dev" ]]; then
   echo -e "${RED}❌  Direct pushes to '${CURRENT_BRANCH}' are not allowed.${RESET}"
-  echo -e "    Create a feature branch: ${YELLOW}squad/{issue}-{slug}${RESET}"
+  echo -e "    Feature work: ${YELLOW}squad/{issue}-{slug}${RESET} → sprint branch"
+  echo -e "    Sprint close: ${YELLOW}sprint/{N}-{slug}${RESET} → dev (via PR)"
   exit 1
 fi
 
+# sprint/* branches are merge targets (squad PRs land here); skip remaining gates.
+if [[ "$CURRENT_BRANCH" =~ ^sprint/[0-9]+-[a-z0-9-]+$ ]]; then
+  echo -e "${GREEN}✅  Sprint branch '${CURRENT_BRANCH}' — skipping feature gates.${RESET}"
+  exit 0
+fi
+
 if ! [[ "$CURRENT_BRANCH" =~ ^squad/[0-9]+-[a-z0-9-]+$ ]]; then
-  echo -e "${RED}❌  Branch name '${CURRENT_BRANCH}' does not match squad naming convention.${RESET}"
-  echo -e "    Expected format: ${YELLOW}squad/{issue}-{slug}${RESET}"
-  echo -e "    Examples: ${YELLOW}squad/42-fix-login${RESET}, ${YELLOW}squad/123-add-api-docs${RESET}"
+  echo -e "${RED}❌  Branch name '${CURRENT_BRANCH}' does not match naming convention.${RESET}"
+  echo -e "    Feature branch: ${YELLOW}squad/{issue}-{slug}${RESET}  (e.g. squad/42-fix-login)"
+  echo -e "    Sprint branch:  ${YELLOW}sprint/{N}-{slug}${RESET}     (e.g. sprint/3-mongodb-persistence)"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Closes #61

Fixes `.github/hooks/pre-push` Gate 0 to accept `sprint/{N}-{slug}` branches in addition to `squad/{issue}-{slug}` branches.

Sprint branches are merge targets — squad PRs land here before dev. They shouldn't run feature gates (build/tests).

## Merge hierarchy

```
squad/{issue}-{slug} → sprint/{N}-{slug} → dev → main (release only)
```

## Changes

- `.github/hooks/pre-push` — Gate 0 updated: sprint branches early-exit after naming check; squad branches run all gates as before

## Acceptance Criteria

- [x] `git push origin sprint/*` passes without `--no-verify`
- [x] Squad branches still run full gates
- [x] Updated error messages list both valid formats