### PR TITLE
[Sprint 2] Fix remaining Boromir DevOps review items from PR #58

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'
-          dotnet-quality: 'preview'
+          dotnet-quality: 'ga'
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/squad-label-enforce.yml
+++ b/.github/workflows/squad-label-enforce.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Enforce mutual exclusivity
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/squad-pr-auto-label.yml
+++ b/.github/workflows/squad-pr-auto-label.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto-label PR for squad system
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
 	"sdk": {
 		"version": "10.0.202",
-		"rollForward": "latestPatch",
+		"rollForward": "latestMinor",
 		"allowPrerelease": false
 	}
 }


### PR DESCRIPTION
Working as Boromir (DevOps Engineer)

Closes #64

## Summary

Fixes three non-blocking DevOps items flagged in Boromir's review of PR #58.

## Changes

| File | Change |
|------|--------|
| `global.json` | `rollForward: "latestPatch"` → `"latestMinor"` — restores original value; `latestPatch` blocks developers on SDK 10.0.3xx+ |
| `.github/workflows/codeql-analysis.yml` | `dotnet-quality: 'preview'` → `'ga'` — aligns with `allowPrerelease: false` |
| `.github/workflows/squad-label-enforce.yml` | `github-script@v7` → `@v9` — consistent with `project-board-automation.yml` |
| `.github/workflows/squad-pr-auto-label.yml` | `github-script@v7` → `@v9` — consistent with `project-board-automation.yml` |

## Related

- Parent PR: #58 (`sprint/2-cqrs-mediatr` → `dev`)