### PR TITLE
Add test results artifact uploads to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,14 @@ jobs:
             --logger "trx;LogFileName=architecture-tests.trx" \
             --collect:"XPlat Code Coverage" \
             --results-directory ./test-results/architecture
+
+      - name: Upload Architecture Test Results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: architecture-test-results
+          path: test-results/architecture
+          retention-days: 30
       
       - name: Run Unit Tests
         run: |
@@ -95,6 +103,14 @@ jobs:
             --logger "trx;LogFileName=unit-tests.trx" \
             --collect:"XPlat Code Coverage" \
             --results-directory ./test-results/unit
+
+      - name: Upload Unit Test Results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: unit-test-results
+          path: test-results/unit
+          retention-days: 30
       
       - name: Run Integration Tests
         run: |
@@ -104,6 +120,14 @@ jobs:
             --logger "trx;LogFileName=integration-tests.trx" \
             --collect:"XPlat Code Coverage" \
             --results-directory ./test-results/integration
+
+      - name: Upload Integration Test Results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: integration-test-results
+          path: test-results/integration
+          retention-days: 30
       
       - name: Publish Test Results
         uses: dorny/test-reporter@v3


### PR DESCRIPTION
## Summary
Adds artifact upload steps to the CI workflow to capture and display test results from all test suites.

## Changes
- Added `Upload Architecture Test Results` step after Architecture Tests
- Added `Upload Unit Test Results` step after Unit Tests
- Added `Upload Integration Test Results` step after Integration Tests
- All uploads use `if: always()` to capture results even on test failures
- Configured 30-day retention for all test artifacts

## Artifacts Configured
- **architecture-test-results**: Contains Architecture Tests output (test-results/architecture)
- **unit-test-results**: Contains Unit Tests output (test-results/unit)
- **integration-test-results**: Contains Integration Tests output (test-results/integration)

## Benefits
✅ Test results are now visible in workflow run artifacts
✅ Results accessible directly from PR view for easier review
✅ All test results captured even when tests fail
✅ 30-day retention policy for artifact storage

Closes #73