### PR TITLE
fix: Add GitHub project board automation for issues and PRs

### DIFF
--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -1,0 +1,78 @@
+name: Add Issues to Project
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  issues: read
+  repository-projects: write
+
+env:
+  PROJECT_ID: PVT_kwHOA5k0b84BVFTy
+  STATUS_FIELD_ID: PVTSSF_lAHOA5k0b84BVFTyzhQjgPk
+  BACKLOG_OPTION_ID: f75ad846
+
+jobs:
+  add-to-project:
+    # Only add squad-labeled issues
+    if: contains(github.event.issue.labels.*.name, 'squad')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add issue to MyBlog project board
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue = context.payload.issue;
+
+            core.info(`Adding issue #${issue.number} to project board...`);
+
+            // Add the issue to the project board and set Status → Backlog
+            try {
+              const mutation = await github.graphql(`
+                mutation($projectId: ID!, $contentId: ID!) {
+                  addProjectV2ItemById(input: {
+                    projectId: $projectId
+                    contentId: $contentId
+                  }) {
+                    item {
+                      id
+                    }
+                  }
+                }
+              `, {
+                projectId: process.env.PROJECT_ID,
+                contentId: issue.node_id
+              });
+
+              const itemId = mutation.addProjectV2ItemById.item.id;
+
+              // Set Status to Backlog
+              await github.graphql(`
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $projectId
+                    itemId: $itemId
+                    fieldId: $fieldId
+                    value: { singleSelectOptionId: $optionId }
+                  }) {
+                    projectV2Item { id }
+                  }
+                }
+              `, {
+                projectId: process.env.PROJECT_ID,
+                itemId: itemId,
+                fieldId: process.env.STATUS_FIELD_ID,
+                optionId: process.env.BACKLOG_OPTION_ID
+              });
+
+              core.info(`✅ Issue #${issue.number} added to project → Backlog`);
+            } catch (err) {
+              if (err.message.includes('403')) {
+                core.warning(`Access denied (403). If this persists, create a PAT with 'project' scope and store as secrets.GH_PROJECT_TOKEN`);
+              } else {
+                core.warning(`Could not add issue to project: ${err.message}`);
+              }
+            }

--- a/.github/workflows/add-prs-to-project.yml
+++ b/.github/workflows/add-prs-to-project.yml
@@ -1,0 +1,76 @@
+name: Add Pull Requests to Project
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: read
+  repository-projects: write
+
+env:
+  PROJECT_ID: PVT_kwHOA5k0b84BVFTy
+  STATUS_FIELD_ID: PVTSSF_lAHOA5k0b84BVFTyzhQjgPk
+  IN_REVIEW_OPTION_ID: df73e18b
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add PR to MyBlog project board
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+
+            core.info(`Adding PR #${pr.number} to project board...`);
+
+            // Add the PR to the project board and set Status → In Review
+            try {
+              const mutation = await github.graphql(`
+                mutation($projectId: ID!, $contentId: ID!) {
+                  addProjectV2ItemById(input: {
+                    projectId: $projectId
+                    contentId: $contentId
+                  }) {
+                    item {
+                      id
+                    }
+                  }
+                }
+              `, {
+                projectId: process.env.PROJECT_ID,
+                contentId: pr.node_id
+              });
+
+              const itemId = mutation.addProjectV2ItemById.item.id;
+
+              // Set Status to In Review
+              await github.graphql(`
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $projectId
+                    itemId: $itemId
+                    fieldId: $fieldId
+                    value: { singleSelectOptionId: $optionId }
+                  }) {
+                    projectV2Item { id }
+                  }
+                }
+              `, {
+                projectId: process.env.PROJECT_ID,
+                itemId: itemId,
+                fieldId: process.env.STATUS_FIELD_ID,
+                optionId: process.env.IN_REVIEW_OPTION_ID
+              });
+
+              core.info(`✅ PR #${pr.number} added to project → In review`);
+            } catch (err) {
+              if (err.message.includes('403')) {
+                core.warning(`Access denied (403). If this persists, create a PAT with 'project' scope and store as secrets.GH_PROJECT_TOKEN`);
+              } else {
+                core.warning(`Could not add PR to project: ${err.message}`);
+              }
+            }


### PR DESCRIPTION
## Summary

Closes #76

Working as Boromir (DevOps / Infra)

The existing `project-board-automation.yml` only moves items between columns — it never added new issues or PRs to the board in the first place. This PR fills that gap with two dedicated workflows.

## Changes

### `add-issues-to-project.yml`
- Triggers on `issues: [opened, reopened]`
- Filters to issues labelled `squad` (avoids noise from unrelated issues)
- Adds the issue to the MyBlog project board via GraphQL `addProjectV2ItemById`
- Sets the **Status** field → **Backlog** (`f75ad846`)
- Handles 403 errors gracefully with a hint to use a PAT with `project` scope

### `add-prs-to-project.yml`
- Triggers on `pull_request: [opened, reopened]`
- Adds every new PR to the MyBlog project board
- Sets the **Status** field → **In Review** (`df73e18b`)
- Handles 403 errors gracefully

## Project IDs used
| Key | Value |
|-----|-------|
| PROJECT_ID | `PVT_kwHOA5k0b84BVFTy` |
| STATUS_FIELD_ID | `PVTSSF_lAHOA5k0b84BVFTyzhQjgPk` |
| BACKLOG_OPTION_ID | `f75ad846` |
| IN_REVIEW_OPTION_ID | `df73e18b` |

## Notes
Both workflows use `secrets.GITHUB_TOKEN`. If GitHub's fine-grained token restrictions block project writes (403), a PAT with the `project` scope stored as `secrets.GH_PROJECT_TOKEN` can be substituted.
