### PR TITLE
[Sprint 3] Fix install-hooks.sh Gate 0 description to include sprint/* branches

### DIFF
--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -60,7 +60,8 @@ fi
 
 echo ""
 echo "The hook enforces 5 gates on every 'git push':"
-echo "  0. Enforces squad/{issue}-{slug} branch naming"
+echo "  0. Enforces branch naming — squad/{issue}-{slug} runs all gates;"
+echo "       sprint/{N}-{slug} passes Gate 0 and exits (skips feature gates)"
 echo "  1. Warns about untracked .razor/.cs source files"
 echo "  2. Release build  (dotnet build MyBlog.slnx --configuration Release)"
 echo "  3. Unit/arch tests (tests/Architecture.Tests, tests/Unit.Tests)"


### PR DESCRIPTION
## Summary

Working as Boromir (DevOps / Infra)

Closes #61

The pre-push hook Gate 0 fix for `sprint/*` branches was already merged via PR #62 into `sprint/3-mongodb-persistence` (and subsequently into `dev`). The one remaining gap: `scripts/install-hooks.sh` still printed an outdated Gate 0 description that only mentioned `squad/{issue}-{slug}`.

This PR updates the install-hooks.sh output text to accurately document both valid branch patterns.

## Changes

- `scripts/install-hooks.sh` — Gate 0 description now lists both patterns:
  - `squad/{issue}-{slug}` → runs all gates (build + tests)
  - `sprint/{N}-{slug}` → passes Gate 0, exits (skips feature gates)

## Merge hierarchy

```
squad/{issue}-{slug} → sprint/{N}-{slug} → dev → main (release only)
```

## Acceptance Criteria

- [x] `git push origin sprint/*` passes without `--no-verify` (hook fix in dev via PR #62)
- [x] Squad branches still run full gates (build + tests) (unchanged)
- [x] `scripts/install-hooks.sh` description accurately reflects sprint/* support