### PR TITLE
feat(#59): Add Profile Admin badge, role-colored badges, and RoleClaimsHelper fixes

### DIFF
--- a/src/Web/Features/UserManagement/Profile.razor
+++ b/src/Web/Features/UserManagement/Profile.razor
@@ -30,7 +30,14 @@ else
 				}
 
 				<div class="space-y-2">
-					<h2 class="!text-2xl">@_displayName</h2>
+					<div class="flex flex-wrap items-center gap-2">
+						<h2 class="!text-2xl">@_displayName</h2>
+						@if (_isAdmin)
+						{
+							<span class="rounded-full bg-red-600 px-3 py-0.5 text-xs font-bold uppercase tracking-wide text-white shadow-sm dark:bg-red-700"
+							      title="Administrator">Admin</span>
+						}
+					</div>
 					<p class="!text-base !font-medium text-gray-600 dark:text-gray-300">@_emailAddress</p>
 					@if (!string.IsNullOrWhiteSpace(_userId))
 					{
@@ -61,7 +68,14 @@ else
 						<div class="flex flex-wrap gap-2">
 							@foreach (var role in _roles)
 							{
-								<span class="rounded-full bg-green-100 px-3 py-1 text-sm font-semibold text-green-800 dark:bg-green-900/40 dark:text-green-300">@role</span>
+								@if (role.Equals("Admin", StringComparison.OrdinalIgnoreCase))
+								{
+									<span class="rounded-full bg-red-100 px-3 py-1 text-sm font-semibold text-red-800 dark:bg-red-900/40 dark:text-red-300">@role</span>
+								}
+								else
+								{
+									<span class="rounded-full bg-green-100 px-3 py-1 text-sm font-semibold text-green-800 dark:bg-green-900/40 dark:text-green-300">@role</span>
+								}
 							}
 						</div>
 					}
@@ -121,6 +135,7 @@ else
 	private string _userId = string.Empty;
 	private string _pictureUrl = string.Empty;
 	private string _initials = "?";
+	private bool _isAdmin;
 	private IReadOnlyList<string> _roles = [];
 	private IReadOnlyList<Claim> _claims = [];
 
@@ -161,6 +176,7 @@ else
 
 		_initials = GetInitials(_displayName, _emailAddress);
 		_roles = RoleClaimsHelper.GetRoles(_user);
+		_isAdmin = _roles.Contains("Admin", StringComparer.OrdinalIgnoreCase);
 		_claims = _user.Claims
 			.Where(c => !_sensitiveClaimTypes.Contains(c.Type))
 			.OrderBy(c => c.Type)

--- a/src/Web/Security/RoleClaimsHelper.cs
+++ b/src/Web/Security/RoleClaimsHelper.cs
@@ -55,7 +55,7 @@ public static class RoleClaimsHelper
             || tail.Equals("role", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static IReadOnlyList<string> GetEffectiveRoleClaimTypes(IEnumerable<Claim> claims, IEnumerable<string>? roleClaimTypes)
+    private static string[] GetEffectiveRoleClaimTypes(IEnumerable<Claim> claims, IEnumerable<string>? roleClaimTypes)
     {
         return (roleClaimTypes ?? DefaultRoleClaimTypes)
             .Append(ClaimTypes.Role)
@@ -105,6 +105,8 @@ public static class RoleClaimsHelper
 
     public static void AddRoleClaims(ClaimsIdentity identity, IEnumerable<string> roleClaimTypes)
     {
+        ArgumentNullException.ThrowIfNull(identity);
+
         foreach (var roleClaimType in GetEffectiveRoleClaimTypes(identity.Claims, roleClaimTypes))
         {
             foreach (var claim in identity.FindAll(roleClaimType).ToList())

--- a/tests/Unit.Tests/Features/UserManagement/ProfileTests.cs
+++ b/tests/Unit.Tests/Features/UserManagement/ProfileTests.cs
@@ -7,14 +7,6 @@
 //Project Name :  Unit.Tests
 //=======================================================
 
-// ============================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     ProfileTests.cs
-// Company :       mpaulosky
-// Author :        mpaulosky
-// Solution Name : MyBlog
-// Project Name :  Unit.Tests
-// =============================================
 using Microsoft.AspNetCore.Components.Authorization;
 
 using MyBlog.Web.Features.UserManagement;
@@ -69,6 +61,83 @@ public class ProfileTests : BunitContext
 		cut.Markup.Should().Contain("No email claim found");
 		cut.Markup.Should().Contain("No roles found in the current claims.");
 		cut.Markup.Should().Contain(">NE<");
+	}
+
+	[Fact]
+	public void Profile_AdminRoleBadge_HasRedColorClasses()
+	{
+		// Arrange
+		var principal = CreatePrincipal(
+				name: "Admin User",
+				email: "admin@example.com",
+				userId: "auth0|admin",
+				pictureUrl: null,
+				rolesJson: null,
+				extraClaims: [new Claim(ClaimTypes.Role, "Admin")]);
+
+		// Act
+		var cut = RenderForUser(principal);
+
+		// Assert — the roles card Admin span must carry red Tailwind classes
+		var adminBadge = cut.FindAll("span")
+				.FirstOrDefault(span =>
+						span.TextContent.Trim() == "Admin"
+						&& span.GetAttribute("class") is { } cls
+						&& cls.Contains("bg-red-100"));
+
+		adminBadge.Should().NotBeNull("Admin role should render with red-100 background");
+		adminBadge!.GetAttribute("class").Should().Contain("text-red-800");
+	}
+
+	[Fact]
+	public void Profile_NonAdminRoleBadge_HasGreenColorClasses()
+	{
+		// Arrange
+		var principal = CreatePrincipal(
+				name: "Author User",
+				email: "author@example.com",
+				userId: "auth0|author",
+				pictureUrl: null,
+				rolesJson: null,
+				extraClaims: [new Claim(ClaimTypes.Role, "Author")]);
+
+		// Act
+		var cut = RenderForUser(principal);
+
+		// Assert — the roles card Author span must carry green Tailwind classes
+		var authorBadge = cut.FindAll("span")
+				.FirstOrDefault(span =>
+						span.TextContent.Trim() == "Author"
+						&& span.GetAttribute("class") is { } cls
+						&& cls.Contains("bg-green-100"));
+
+		authorBadge.Should().NotBeNull("Non-admin role should render with green-100 background");
+		authorBadge!.GetAttribute("class").Should().Contain("text-green-800");
+	}
+
+	[Fact]
+	public void Profile_AdminHeaderBadge_HasRedBackgroundClass()
+	{
+		// Arrange
+		var principal = CreatePrincipal(
+				name: "Super Admin",
+				email: "superadmin@example.com",
+				userId: "auth0|super",
+				pictureUrl: null,
+				rolesJson: null,
+				extraClaims: [new Claim(ClaimTypes.Role, "Admin")]);
+
+		// Act
+		var cut = RenderForUser(principal);
+
+		// Assert — the header-area Admin badge (title="Administrator") must use red-600 bg
+		var headerBadge = cut.FindAll("span")
+				.FirstOrDefault(span =>
+						span.GetAttribute("title") == "Administrator"
+						&& span.GetAttribute("class") is { } cls
+						&& cls.Contains("bg-red-600"));
+
+		headerBadge.Should().NotBeNull("Header Admin badge should render with bg-red-600");
 	}
 
 	private IRenderedComponent<Profile> RenderForUser(ClaimsPrincipal principal)

--- a/tests/Unit.Tests/Security/RoleClaimsHelperTests.cs
+++ b/tests/Unit.Tests/Security/RoleClaimsHelperTests.cs
@@ -7,14 +7,6 @@
 //Project Name :  Unit.Tests
 //=======================================================
 
-// ============================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     RoleClaimsHelperTests.cs
-// Company :       mpaulosky
-// Author :        mpaulosky
-// Solution Name : MyBlog
-// Project Name :  Unit.Tests
-// =============================================
 using Microsoft.Extensions.Configuration;
 
 using MyBlog.Web.Security;
@@ -157,5 +149,95 @@ public class RoleClaimsHelperTests
 
 		// Assert
 		result.Should().Equal("Admin", "User");
+	}
+
+	[Fact]
+	public void GetRoles_ReturnsEmpty_WhenUserHasNoClaims()
+	{
+		// Arrange
+		var principal = new ClaimsPrincipal(new ClaimsIdentity([], "TestAuth", ClaimTypes.Name, ClaimTypes.Role));
+
+		// Act
+		var result = RoleClaimsHelper.GetRoles(principal);
+
+		// Assert
+		result.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void GetRoles_ReturnsRoles_FromAuth0NamespacedClaim()
+	{
+		// Arrange
+		var principal = new ClaimsPrincipal(new ClaimsIdentity(new[]
+		{
+						new Claim("https://myblog/roles", "[\"Admin\",\"Author\"]")
+				}, "TestAuth", ClaimTypes.Name, ClaimTypes.Role));
+
+		// Act
+		var result = RoleClaimsHelper.GetRoles(principal);
+
+		// Assert
+		result.Should().Equal("Admin", "Author");
+	}
+
+	[Fact]
+	public void GetRoles_ReturnsRoles_FromStandardRoleClaim()
+	{
+		// Arrange
+		var principal = new ClaimsPrincipal(new ClaimsIdentity(new[]
+		{
+						new Claim(ClaimTypes.Role, "Admin"),
+						new Claim(ClaimTypes.Role, "Editor")
+				}, "TestAuth", ClaimTypes.Name, ClaimTypes.Role));
+
+		// Act
+		var result = RoleClaimsHelper.GetRoles(principal);
+
+		// Assert
+		result.Should().Equal("Admin", "Editor");
+	}
+
+	[Fact]
+	public void GetRoles_IgnoresNonRoleClaims_WhenMixedClaimsPresent()
+	{
+		// Arrange
+		var principal = new ClaimsPrincipal(new ClaimsIdentity(new[]
+		{
+						new Claim(ClaimTypes.Role, "Admin"),
+						new Claim(ClaimTypes.Email, "user@example.com"),
+						new Claim(ClaimTypes.Name, "Test User"),
+						new Claim("department", "Engineering")
+				}, "TestAuth", ClaimTypes.Name, ClaimTypes.Role));
+
+		// Act
+		var result = RoleClaimsHelper.GetRoles(principal);
+
+		// Assert
+		result.Should().ContainSingle().Which.Should().Be("Admin");
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void ExpandRoleValues_ReturnsEmpty_WhenInputIsNullOrWhitespace(string? input)
+	{
+		// Arrange (none)
+		// Act
+		var result = RoleClaimsHelper.ExpandRoleValues(input);
+
+		// Assert
+		result.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void ExpandRoleValues_ReturnsEmpty_WhenJsonIsInvalid()
+	{
+		// Arrange (none)
+		// Act
+		var result = RoleClaimsHelper.ExpandRoleValues("[not-valid-json");
+
+		// Assert
+		result.Should().BeEmpty();
 	}
 }


### PR DESCRIPTION
## Summary

Working as Legolas (Frontend Engineer)

Closes #59

Implements Profile page improvements, NavMenu role-aware rendering verification, and `RoleClaimsHelper` code-quality fixes.

## Changes

### `src/Web/Features/UserManagement/Profile.razor`
- **Admin badge in header**: Prominent red badge displayed next to the user's display name when the authenticated user holds the `Admin` role
- **Role-colored badges**: Admin role badge styled in red; all other roles displayed in green — provides clear visual distinction in the Roles card
- Added `_isAdmin` boolean field derived from `RoleClaimsHelper.GetRoles()`

### `src/Web/Security/RoleClaimsHelper.cs`
- **Fix CA1859**: Changed `GetEffectiveRoleClaimTypes` return type from `IReadOnlyList<string>` to `string[]` for improved performance (compiler-recommended)
- **Fix CA1062**: Added `ArgumentNullException.ThrowIfNull(identity)` guard in `AddRoleClaims` to satisfy null-validation analysis rule

### No changes required
- **`NavMenu.razor`**: Already conditionally shows admin links using `<AuthorizeView Roles="Admin">` and `<AuthorizeView Roles="Author,Admin">` — fully satisfies role-aware rendering requirement
- **`MainLayout.razor`**: `AddCascadingAuthenticationState()` is registered in `Program.cs`; `AuthorizeRouteView` in `Routes.razor` cascades auth state — no layout changes needed

## Acceptance Criteria

- ✅ Profile page renders user info and roles (existing implementation)
- ✅ Profile page shows distinct **Admin** badge when user has Admin role (new)
- ✅ RoleClaimsHelper correctly maps Auth0 role claims (existing + CA warnings fixed)
- ✅ NavMenu conditionally shows admin links by role (existing `AuthorizeView`)
- ✅ Web project builds: `dotnet build src/Web -c Release` — 0 errors, RoleClaimsHelper CA warnings resolved

## Test Coverage

Gimli (Test Warden) is responsible for bUnit component tests. Existing tests:
- `tests/Unit.Tests/Features/UserManagement/ProfileTests.cs`
- `tests/Unit.Tests/Components/Layout/NavMenuTests.cs`
- `tests/Unit.Tests/Security/RoleClaimsHelperTests.cs`
- `tests/Unit.Tests/Components/RazorSmokeTests.cs`