### PR TITLE
ci: enable automatic GitVersion tag creation on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,3 +140,13 @@ jobs:
         with:
           recreate: true
           path: code-coverage-results.md
+      
+      - name: Create and Push Git Tag
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ steps.gitversion.outputs.semVer }}"
+          echo "Creating tag: $TAG"
+          git tag "$TAG" || echo "Tag already exists: $TAG"
+          git push origin "$TAG" || echo "Tag already pushed"


### PR DESCRIPTION
Add step to CI workflow that creates and pushes git tags for each commit to main, using GitVersion-determined semver.

This completes the v1.0.1 release flow:
- Merge PR to main
- CI determines version with GitVersion
- CI creates and pushes tag (v1.0.1, v1.0.2, ...)
- Team creates GitHub Release from tag

Closes: versioning automation setup