### PR TITLE
ci: fix GitVersion action deprecated parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         uses: gittools/actions/gitversion/execute@v4
         continue-on-error: true
         with:
-          useConfigFile: true
+          configFilePath: ./GitVersion.yml
 
       - name: Set Version Variables
         id: version


### PR DESCRIPTION
Replace deprecated 'useConfigFile' with 'configFilePath' in GitVersion action.

This is required for gittools/actions/gitversion/execute@v4 to work properly.