### PR TITLE
ci: grant write permissions for tag creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     
     permissions:
-      contents: read
+      contents: write
       checks: write
       pull-requests: write
     


### PR DESCRIPTION
Change 'contents: read' to 'contents: write' so the 'Create and Push Git Tag' step can push tags.

This completes the automatic versioning workflow.