### PR TITLE
ci: use majorMinorPatch for clean semver tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="v${{ steps.gitversion.outputs.semVer }}"
+          TAG="v${{ steps.gitversion.outputs.majorMinorPatch }}"
           echo "Creating tag: $TAG"
           git tag "$TAG" || echo "Tag already exists: $TAG"
           git push origin "$TAG" || echo "Tag already pushed"


### PR DESCRIPTION
GitVersion's semVer output includes pre-release height (e.g. v1.0.0-101).
On main, we want clean v1.0.1 format, which comes from majorMinorPatch.

This ensures the first post-sprint release is tagged v1.0.1, not v1.0.0-{height}.