### PR TITLE
feat(caching): extract IBlogPostCacheService abstraction and centralize cache keys (#109)

### DIFF
--- a/docs/adr/sprint5-caching-abstraction.md
+++ b/docs/adr/sprint5-caching-abstraction.md
@@ -1,0 +1,71 @@
+---
+post_title: "ADR: Extract IBlogPostCacheService Abstraction"
+author1: "Frodo"
+post_slug: "adr-sprint5-caching-abstraction"
+microsoft_alias: ""
+featured_image: ""
+categories: ["Architecture"]
+tags: ["caching", "redis", "abstraction", "adr"]
+ai_note: "AI-assisted"
+summary: "Decision to extract a two-tier cache service abstraction to eliminate duplication across BlogPost handlers."
+post_date: "2026-04-23"
+---
+
+## Context
+
+Sprint 5 introduced a two-tier caching strategy across all four BlogPost MediatR handlers (`GetBlogPostsHandler`, `EditBlogPostHandler`, `CreateBlogPostHandler`, `DeleteBlogPostHandler`). Each handler independently declares:
+
+- `MemoryCacheEntryOptions` (L1 in-memory, 1-minute TTL)
+- `DistributedCacheEntryOptions` (L2 Redis, 5-minute TTL)
+- `JsonSerializerOptions` for serialization to/from Redis bytes
+- Inline cache key strings (`"blog:all"`, `$"blog:{id}"`)
+
+This results in four copies of the same boilerplate. Cache key strings are magic literals scattered across files, making a future key rename a multi-file search-and-replace. The `JsonSerializerOptions` instance is duplicated rather than shared.
+
+Any change to TTL policy, serialization options, or key naming requires touching every handler — a violation of the DRY principle and a maintenance hazard.
+
+---
+
+## Decision
+
+Extract a dedicated two-tier cache service behind the interface `IBlogPostCacheService`, implemented by `BlogPostCacheService`. Cache key constants are centralised in a companion static class `BlogPostCacheKeys`.
+
+### New types
+
+| Type | Kind | Responsibility |
+|------|------|----------------|
+| `IBlogPostCacheService` | Interface | Contract for L1 + L2 blog post cache operations |
+| `BlogPostCacheService` | Class | Implementation wrapping `IMemoryCache` + `IDistributedCache` |
+| `BlogPostCacheKeys` | Static class | Centralized cache key constants (`All`, `ById(Guid)`) |
+
+### Handler refactor
+
+All four handlers replace their inline `IMemoryCache` + `IDistributedCache` parameters with a single `IBlogPostCacheService` injection. The TTL constants, serialization options, and cache key logic move into `BlogPostCacheService`.
+
+### Registration
+
+`BlogPostCacheService` is registered in `Program.cs` as a scoped or singleton service alongside `IMemoryCache` and the Redis `IDistributedCache`.
+
+---
+
+## Status
+
+Accepted
+
+---
+
+## Consequences
+
+### Positive
+
+- **Eliminates duplication** — cache logic lives in one place; all four handlers become simpler.
+- **Single TTL policy** — changing L1 or L2 TTL requires editing one file.
+- **Centralised key management** — `BlogPostCacheKeys` prevents typos and enables compile-time refactoring.
+- **Testable abstraction** — handlers under test can receive a mock `IBlogPostCacheService` instead of coordinating two separate mock caches.
+- **Consistent serialization** — `JsonSerializerOptions` is created once inside `BlogPostCacheService`, ensuring uniform behaviour.
+
+### Negative
+
+- **Extra abstraction layer** — introduces an interface + implementation pair for what is conceptually simple cache I/O. Teams unfamiliar with the abstraction need to trace one more indirection when debugging cache behaviour.
+- **Discoverability** — a developer reading a handler for the first time will not see caching details inline; they must navigate to `BlogPostCacheService`. Mitigation: XML doc comments on the interface methods document what each call does.
+- **Migration cost** — all four existing handlers require a signature change and removal of their inline cache fields. The change is mechanical but touches multiple files.

--- a/docs/sprint5-xml-doc-stubs.md
+++ b/docs/sprint5-xml-doc-stubs.md
@@ -1,0 +1,160 @@
+# Sprint 5 — XML Doc Comment Stubs
+
+XML doc comment stubs for Sam to apply to the new cache abstraction types introduced in Sprint 5.
+
+---
+
+## `IBlogPostCacheService`
+
+```csharp
+/// <summary>
+/// Provides two-tier (L1 in-memory + L2 Redis) cache operations for blog post data.
+/// </summary>
+public interface IBlogPostCacheService
+{
+    /// <summary>
+    /// Retrieves all blog posts from the cache, checking L1 (in-memory) before L2 (Redis).
+    /// Returns <see langword="null"/> when no cached entry exists.
+    /// </summary>
+    /// <param name="ct">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that resolves to a read-only list of <see cref="BlogPostDto"/>
+    /// instances, or <see langword="null"/> if the entry is not present in either cache tier.
+    /// </returns>
+    Task<IReadOnlyList<BlogPostDto>?> GetAllAsync(CancellationToken ct);
+
+    /// <summary>
+    /// Stores all blog posts in both cache tiers (L1 in-memory and L2 Redis).
+    /// </summary>
+    /// <param name="posts">The list of blog post DTOs to cache.</param>
+    /// <param name="ct">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous set operation.</returns>
+    Task SetAllAsync(IReadOnlyList<BlogPostDto> posts, CancellationToken ct);
+
+    /// <summary>
+    /// Retrieves a single blog post by its unique identifier from the cache,
+    /// checking L1 (in-memory) before L2 (Redis).
+    /// Returns <see langword="null"/> when no cached entry exists for the given ID.
+    /// </summary>
+    /// <param name="id">The unique identifier of the blog post to retrieve.</param>
+    /// <param name="ct">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that resolves to the cached <see cref="BlogPostDto"/>,
+    /// or <see langword="null"/> if no entry is found.
+    /// </returns>
+    Task<BlogPostDto?> GetByIdAsync(Guid id, CancellationToken ct);
+
+    /// <summary>
+    /// Stores a single blog post in both cache tiers (L1 in-memory and L2 Redis),
+    /// keyed by its unique identifier.
+    /// </summary>
+    /// <param name="id">The unique identifier used as the cache key.</param>
+    /// <param name="post">The blog post DTO to cache.</param>
+    /// <param name="ct">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous set operation.</returns>
+    Task SetByIdAsync(Guid id, BlogPostDto post, CancellationToken ct);
+
+    /// <summary>
+    /// Removes the all-posts cache entry from both L1 (in-memory) and L2 (Redis).
+    /// Call this after any write operation that affects the full post list
+    /// (create, edit, delete, publish/unpublish).
+    /// </summary>
+    /// <param name="ct">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous invalidation operation.</returns>
+    Task InvalidateAllAsync(CancellationToken ct);
+
+    /// <summary>
+    /// Removes the per-post cache entry for the given identifier from both
+    /// L1 (in-memory) and L2 (Redis).
+    /// Call this after any write operation that modifies or deletes a specific post.
+    /// </summary>
+    /// <param name="id">The unique identifier of the blog post whose cache entry should be removed.</param>
+    /// <param name="ct">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous invalidation operation.</returns>
+    Task InvalidateByIdAsync(Guid id, CancellationToken ct);
+}
+```
+
+---
+
+## `BlogPostCacheKeys`
+
+```csharp
+/// <summary>Cache key constants for blog post entries.</summary>
+public static class BlogPostCacheKeys
+{
+    /// <summary>Cache key for the full list of blog posts.</summary>
+    public const string All = "blog:all";
+
+    /// <summary>
+    /// Returns the cache key for a single blog post identified by <paramref name="id"/>.
+    /// </summary>
+    /// <param name="id">The unique identifier of the blog post.</param>
+    /// <returns>A string cache key in the format <c>blog:{id}</c>.</returns>
+    public static string ById(Guid id) => $"blog:{id}";
+}
+```
+
+---
+
+## `BlogPostCacheService`
+
+```csharp
+/// <summary>
+/// Two-tier cache implementation for blog post data, combining an L1 in-process
+/// <see cref="IMemoryCache"/> (1-minute TTL) with an L2 distributed
+/// <see cref="IDistributedCache"/> backed by Redis (5-minute TTL).
+/// </summary>
+/// <remarks>
+/// Read operations check L1 first; on an L1 miss they fall through to L2 and
+/// back-fill L1 on a hit. Write operations populate both tiers simultaneously.
+/// Invalidation removes from both tiers.
+/// </remarks>
+public sealed class BlogPostCacheService : IBlogPostCacheService
+```
+
+---
+
+## README.md — Needed Updates
+
+The current `README.md` does **not** mention caching or Redis. The following two sections require updates once Sprint 5 is merged:
+
+### Technology Stack section
+
+Add entries for the caching layer:
+
+```markdown
+- **IMemoryCache** — L1 in-process cache (1-minute TTL per entry)
+- **Redis via .NET Aspire** — L2 distributed cache (5-minute TTL); provisioned by
+  `builder.AddRedis("redis")` in `AppHost`
+```
+
+Also update the stale line:
+
+```markdown
+- **In-Memory Repository** — No database (training project by design)
+```
+
+This is no longer accurate after the MongoDB migration (Sprint 4). It should read:
+
+```markdown
+- **MongoDB via EF Core Adapter** — Document store for blog posts,
+  accessed through `IDbContextFactory<BlogDbContext>`
+```
+
+### Features section
+
+No new user-visible features are introduced by the caching abstraction. No changes needed here.
+
+### Learning Objectives section
+
+Consider adding a seventh objective once Sprint 5 ships:
+
+```markdown
+7. **Two-Tier Caching** — L1 IMemoryCache + L2 Redis via IBlogPostCacheService abstraction,
+   cache invalidation on write, DRY cache key management with BlogPostCacheKeys
+```
+
+---
+
+*Stubs prepared by Frodo (Tech Writer) — Sprint 5, 2026-04-23*

--- a/src/Web/Infrastructure/Caching/BlogPostCacheKeys.cs
+++ b/src/Web/Infrastructure/Caching/BlogPostCacheKeys.cs
@@ -1,0 +1,20 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     BlogPostCacheKeys.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web
+//=======================================================
+
+namespace MyBlog.Web.Infrastructure.Caching;
+
+/// <summary>Cache key constants for the BlogPost two-tier cache.</summary>
+public static class BlogPostCacheKeys
+{
+	/// <summary>Key for the list of all blog posts.</summary>
+	public const string All = "blog:all";
+
+	/// <summary>Key for a single blog post identified by <paramref name="id"/>.</summary>
+	public static string ById(Guid id) => $"blog:{id}";
+}

--- a/src/Web/Infrastructure/Caching/BlogPostCacheService.cs
+++ b/src/Web/Infrastructure/Caching/BlogPostCacheService.cs
@@ -1,0 +1,127 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     BlogPostCacheService.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web
+//=======================================================
+
+using System.Text.Json;
+
+using MyBlog.Web.Data;
+
+namespace MyBlog.Web.Infrastructure.Caching;
+
+internal sealed class BlogPostCacheService(
+	IMemoryCache localCache,
+	IDistributedCache distributedCache) : IBlogPostCacheService
+{
+	private static readonly MemoryCacheEntryOptions LocalOpts =
+		new MemoryCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromMinutes(1));
+
+	private static readonly DistributedCacheEntryOptions RedisOpts =
+		new DistributedCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromMinutes(5));
+
+	private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+
+	public async ValueTask<IReadOnlyList<BlogPostDto>> GetOrFetchAllAsync(
+		Func<Task<IReadOnlyList<BlogPostDto>>> fetch,
+		CancellationToken ct = default)
+	{
+		// L1 hit (synchronous — no heap allocation)
+		if (localCache.TryGetValue(BlogPostCacheKeys.All, out List<BlogPostDto>? cached) && cached is not null)
+			return cached;
+
+		// L2 hit
+		var bytes = await distributedCache.GetAsync(BlogPostCacheKeys.All, ct);
+		if (bytes is not null)
+		{
+			try
+			{
+				var fromRedis = JsonSerializer.Deserialize<List<BlogPostDto>>(bytes, JsonOpts);
+				if (fromRedis is not null)
+				{
+					localCache.Set(BlogPostCacheKeys.All, fromRedis, LocalOpts);
+					return fromRedis;
+				}
+			}
+			catch (JsonException)
+			{
+				// Stale or corrupt bytes — remove and fall through to the DB
+				await distributedCache.RemoveAsync(BlogPostCacheKeys.All, CancellationToken.None);
+			}
+		}
+
+		// DB via caller-supplied fetch
+		var result = await fetch();
+		var list = result as List<BlogPostDto> ?? result.ToList();
+		localCache.Set(BlogPostCacheKeys.All, list, LocalOpts);
+		await distributedCache.SetAsync(
+			BlogPostCacheKeys.All,
+			JsonSerializer.SerializeToUtf8Bytes(list, JsonOpts),
+			RedisOpts,
+			ct);
+		return result;
+	}
+
+	public async ValueTask<BlogPostDto?> GetOrFetchByIdAsync(
+		Guid id,
+		Func<Task<BlogPostDto?>> fetch,
+		CancellationToken ct = default)
+	{
+		var key = BlogPostCacheKeys.ById(id);
+
+		// L1 hit (synchronous — no heap allocation)
+		if (localCache.TryGetValue(key, out BlogPostDto? cached) && cached is not null)
+			return cached;
+
+		// L2 hit
+		var bytes = await distributedCache.GetAsync(key, ct);
+		if (bytes is not null)
+		{
+			try
+			{
+				var dto = JsonSerializer.Deserialize<BlogPostDto>(bytes, JsonOpts);
+				if (dto is not null)
+				{
+					localCache.Set(key, dto, LocalOpts);
+					return dto;
+				}
+			}
+			catch (JsonException)
+			{
+				// Stale or corrupt bytes — remove and fall through to the DB
+				await distributedCache.RemoveAsync(key, CancellationToken.None);
+			}
+		}
+
+		// DB via caller-supplied fetch
+		var result = await fetch();
+		if (result is null)
+			return null;
+
+		localCache.Set(key, result, LocalOpts);
+		await distributedCache.SetAsync(
+			key,
+			JsonSerializer.SerializeToUtf8Bytes(result, JsonOpts),
+			RedisOpts,
+			ct);
+		return result;
+	}
+
+	public async Task InvalidateAllAsync(CancellationToken ct = default)
+	{
+		localCache.Remove(BlogPostCacheKeys.All);
+		// CancellationToken.None: the DB write already committed — must not be cancelled
+		await distributedCache.RemoveAsync(BlogPostCacheKeys.All, CancellationToken.None);
+	}
+
+	public async Task InvalidateByIdAsync(Guid id, CancellationToken ct = default)
+	{
+		var key = BlogPostCacheKeys.ById(id);
+		localCache.Remove(key);
+		// CancellationToken.None: the DB write already committed — must not be cancelled
+		await distributedCache.RemoveAsync(key, CancellationToken.None);
+	}
+}

--- a/src/Web/Infrastructure/Caching/CachingServiceExtensions.cs
+++ b/src/Web/Infrastructure/Caching/CachingServiceExtensions.cs
@@ -1,0 +1,24 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     CachingServiceExtensions.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web
+//=======================================================
+
+namespace MyBlog.Web.Infrastructure.Caching;
+
+public static class CachingServiceExtensions
+{
+	/// <summary>
+	/// Registers the two-tier (L1 in-memory + L2 Redis) <see cref="IBlogPostCacheService"/>
+	/// implementation. Call this after <c>AddMemoryCache()</c> and
+	/// <c>AddRedisDistributedCache()</c> are already registered.
+	/// </summary>
+	public static IServiceCollection AddBlogPostCaching(this IServiceCollection services)
+	{
+		services.AddSingleton<IBlogPostCacheService, BlogPostCacheService>();
+		return services;
+	}
+}

--- a/src/Web/Infrastructure/Caching/IBlogPostCacheService.cs
+++ b/src/Web/Infrastructure/Caching/IBlogPostCacheService.cs
@@ -1,0 +1,67 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     IBlogPostCacheService.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web
+//=======================================================
+
+using MyBlog.Web.Data;
+
+namespace MyBlog.Web.Infrastructure.Caching;
+
+/// <summary>
+/// Two-tier (L1 in-memory + L2 Redis) cache abstraction for <see cref="BlogPostDto"/> values.
+/// </summary>
+/// <remarks>
+/// Registered as a singleton. Both <see cref="IMemoryCache"/> and
+/// <see cref="IDistributedCache"/> (StackExchange Redis) are also singletons,
+/// so captive-dependency rules are satisfied.
+/// </remarks>
+public interface IBlogPostCacheService
+{
+	/// <summary>
+	/// Returns all blog posts from the nearest cache tier, or invokes
+	/// <paramref name="fetch"/> on a complete miss, populates both tiers, and returns the result.
+	/// </summary>
+	/// <remarks>
+	/// Returns <see cref="ValueTask{T}"/> because L1 hits complete synchronously.
+	/// Do not await the same <see cref="ValueTask{T}"/> instance more than once.
+	/// </remarks>
+	ValueTask<IReadOnlyList<BlogPostDto>> GetOrFetchAllAsync(
+		Func<Task<IReadOnlyList<BlogPostDto>>> fetch,
+		CancellationToken ct = default);
+
+	/// <summary>
+	/// Returns the blog post with <paramref name="id"/> from the nearest cache tier,
+	/// or invokes <paramref name="fetch"/> on a complete miss.
+	/// Returns <c>null</c> when the post does not exist.
+	/// </summary>
+	/// <remarks>
+	/// Returns <see cref="ValueTask{T}"/> because L1 hits complete synchronously.
+	/// Do not await the same <see cref="ValueTask{T}"/> instance more than once.
+	/// </remarks>
+	ValueTask<BlogPostDto?> GetOrFetchByIdAsync(
+		Guid id,
+		Func<Task<BlogPostDto?>> fetch,
+		CancellationToken ct = default);
+
+	/// <summary>
+	/// Removes the "all posts" entry from both cache tiers.
+	/// </summary>
+	/// <remarks>
+	/// Redis removal uses <see cref="CancellationToken.None"/>: the database write has
+	/// already committed and invalidation must complete regardless of caller cancellation.
+	/// </remarks>
+	Task InvalidateAllAsync(CancellationToken ct = default);
+
+	/// <summary>
+	/// Removes the per-post entry for <paramref name="id"/> from both cache tiers.
+	/// </summary>
+	/// <remarks>
+	/// Redis removal uses <see cref="CancellationToken.None"/>: the database write has
+	/// already committed and invalidation must complete regardless of caller cancellation.
+	/// </remarks>
+	Task InvalidateByIdAsync(Guid id, CancellationToken ct = default);
+}

--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -24,6 +24,7 @@ using MyBlog.Domain.Behaviors;
 using MyBlog.Domain.Entities;
 using MyBlog.ServiceDefaults;
 using MyBlog.Web.Components;
+using MyBlog.Web.Infrastructure.Caching;
 using MyBlog.Web.Security;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -102,6 +103,9 @@ builder.AddRedisDistributedCache("redis");
 
 // Local in-memory cache (L1)
 builder.Services.AddMemoryCache();
+
+// BlogPost two-tier cache service (L1 + L2)
+builder.Services.AddBlogPostCaching();
 
 // Repository: concrete + interface
 builder.Services.AddScoped<MongoDbBlogPostRepository>();


### PR DESCRIPTION
Closes #109

Working as Sam (Backend Developer)

## What

Introduces a two-tier cache abstraction (`IBlogPostCacheService`) and centralizes all cache key strings in `BlogPostCacheKeys`. This is the foundation required before handlers can be refactored in #110.

## Changes

| File | Description |
|------|-------------|
| `src/Web/Infrastructure/Caching/BlogPostCacheKeys.cs` | Centralizes `"blog:all"` and `$"blog:{id}"` — eliminates magic strings in 4 handlers |
| `src/Web/Infrastructure/Caching/IBlogPostCacheService.cs` | Public interface: `GetOrFetchAllAsync`, `GetOrFetchByIdAsync`, `InvalidateAllAsync`, `InvalidateByIdAsync` |
| `src/Web/Infrastructure/Caching/BlogPostCacheService.cs` | `internal sealed` implementation — L1 (IMemoryCache, 1 min) + L2 (IDistributedCache/Redis, 5 min), `JsonException` catch-and-remove on bad L2 bytes, `CancellationToken.None` on removals |
| `src/Web/Infrastructure/Caching/CachingServiceExtensions.cs` | `AddBlogPostCaching()` DI extension, registers as Singleton |
| `src/Web/Program.cs` | Calls `builder.Services.AddBlogPostCaching()` after `AddMemoryCache()` |

## Design Decisions

- **`GetOrFetch` pattern over split Get/Set** — if the interface only exposes Get/Set/Invalidate, handlers would still orchestrate the L1→miss→L2→miss→DB flow themselves, defeating the abstraction. `GetOrFetch` lets the service own the entire read path.
- **`CancellationToken.None` for invalidations** — a cancelled request CT must not leave Redis stale indefinitely; removals always complete.
- **`ValueTask` on reads** — L1 (`IMemoryCache.TryGetValue`) is synchronous; `ValueTask` avoids a `Task` heap allocation on the hot L1-hit path.
- **Singleton safety** — `IMemoryCache` and `IDistributedCache` (Redis) are both Singleton in ASP.NET Core; no captive dependency issue.

## Related

- #110 will refactor all 4 handlers to inject `IBlogPostCacheService` instead of `IMemoryCache` + `IDistributedCache`
- Architecture tests (TDD-red, skipped) added in #113 to enforce the abstraction boundary post-#110