### PR TITLE
feat(handlers): refactor all BlogPost handlers to use IBlogPostCacheService (#110)

### DIFF
--- a/docs/adr/sprint5-caching-abstraction.md
+++ b/docs/adr/sprint5-caching-abstraction.md
@@ -1,0 +1,71 @@
+---
+post_title: "ADR: Extract IBlogPostCacheService Abstraction"
+author1: "Frodo"
+post_slug: "adr-sprint5-caching-abstraction"
+microsoft_alias: ""
+featured_image: ""
+categories: ["Architecture"]
+tags: ["caching", "redis", "abstraction", "adr"]
+ai_note: "AI-assisted"
+summary: "Decision to extract a two-tier cache service abstraction to eliminate duplication across BlogPost handlers."
+post_date: "2026-04-23"
+---
+
+## Context
+
+Sprint 5 introduced a two-tier caching strategy across all four BlogPost MediatR handlers (`GetBlogPostsHandler`, `EditBlogPostHandler`, `CreateBlogPostHandler`, `DeleteBlogPostHandler`). Each handler independently declares:
+
+- `MemoryCacheEntryOptions` (L1 in-memory, 1-minute TTL)
+- `DistributedCacheEntryOptions` (L2 Redis, 5-minute TTL)
+- `JsonSerializerOptions` for serialization to/from Redis bytes
+- Inline cache key strings (`"blog:all"`, `$"blog:{id}"`)
+
+This results in four copies of the same boilerplate. Cache key strings are magic literals scattered across files, making a future key rename a multi-file search-and-replace. The `JsonSerializerOptions` instance is duplicated rather than shared.
+
+Any change to TTL policy, serialization options, or key naming requires touching every handler — a violation of the DRY principle and a maintenance hazard.
+
+---
+
+## Decision
+
+Extract a dedicated two-tier cache service behind the interface `IBlogPostCacheService`, implemented by `BlogPostCacheService`. Cache key constants are centralised in a companion static class `BlogPostCacheKeys`.
+
+### New types
+
+| Type | Kind | Responsibility |
+|------|------|----------------|
+| `IBlogPostCacheService` | Interface | Contract for L1 + L2 blog post cache operations |
+| `BlogPostCacheService` | Class | Implementation wrapping `IMemoryCache` + `IDistributedCache` |
+| `BlogPostCacheKeys` | Static class | Centralized cache key constants (`All`, `ById(Guid)`) |
+
+### Handler refactor
+
+All four handlers replace their inline `IMemoryCache` + `IDistributedCache` parameters with a single `IBlogPostCacheService` injection. The TTL constants, serialization options, and cache key logic move into `BlogPostCacheService`.
+
+### Registration
+
+`BlogPostCacheService` is registered in `Program.cs` as a scoped or singleton service alongside `IMemoryCache` and the Redis `IDistributedCache`.
+
+---
+
+## Status
+
+Accepted
+
+---
+
+## Consequences
+
+### Positive
+
+- **Eliminates duplication** — cache logic lives in one place; all four handlers become simpler.
+- **Single TTL policy** — changing L1 or L2 TTL requires editing one file.
+- **Centralised key management** — `BlogPostCacheKeys` prevents typos and enables compile-time refactoring.
+- **Testable abstraction** — handlers under test can receive a mock `IBlogPostCacheService` instead of coordinating two separate mock caches.
+- **Consistent serialization** — `JsonSerializerOptions` is created once inside `BlogPostCacheService`, ensuring uniform behaviour.
+
+### Negative
+
+- **Extra abstraction layer** — introduces an interface + implementation pair for what is conceptually simple cache I/O. Teams unfamiliar with the abstraction need to trace one more indirection when debugging cache behaviour.
+- **Discoverability** — a developer reading a handler for the first time will not see caching details inline; they must navigate to `BlogPostCacheService`. Mitigation: XML doc comments on the interface methods document what each call does.
+- **Migration cost** — all four existing handlers require a signature change and removal of their inline cache fields. The change is mechanical but touches multiple files.

--- a/docs/sprint5-xml-doc-stubs.md
+++ b/docs/sprint5-xml-doc-stubs.md
@@ -1,0 +1,160 @@
+# Sprint 5 — XML Doc Comment Stubs
+
+XML doc comment stubs for Sam to apply to the new cache abstraction types introduced in Sprint 5.
+
+---
+
+## `IBlogPostCacheService`
+
+```csharp
+/// <summary>
+/// Provides two-tier (L1 in-memory + L2 Redis) cache operations for blog post data.
+/// </summary>
+public interface IBlogPostCacheService
+{
+    /// <summary>
+    /// Retrieves all blog posts from the cache, checking L1 (in-memory) before L2 (Redis).
+    /// Returns <see langword="null"/> when no cached entry exists.
+    /// </summary>
+    /// <param name="ct">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that resolves to a read-only list of <see cref="BlogPostDto"/>
+    /// instances, or <see langword="null"/> if the entry is not present in either cache tier.
+    /// </returns>
+    Task<IReadOnlyList<BlogPostDto>?> GetAllAsync(CancellationToken ct);
+
+    /// <summary>
+    /// Stores all blog posts in both cache tiers (L1 in-memory and L2 Redis).
+    /// </summary>
+    /// <param name="posts">The list of blog post DTOs to cache.</param>
+    /// <param name="ct">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous set operation.</returns>
+    Task SetAllAsync(IReadOnlyList<BlogPostDto> posts, CancellationToken ct);
+
+    /// <summary>
+    /// Retrieves a single blog post by its unique identifier from the cache,
+    /// checking L1 (in-memory) before L2 (Redis).
+    /// Returns <see langword="null"/> when no cached entry exists for the given ID.
+    /// </summary>
+    /// <param name="id">The unique identifier of the blog post to retrieve.</param>
+    /// <param name="ct">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that resolves to the cached <see cref="BlogPostDto"/>,
+    /// or <see langword="null"/> if no entry is found.
+    /// </returns>
+    Task<BlogPostDto?> GetByIdAsync(Guid id, CancellationToken ct);
+
+    /// <summary>
+    /// Stores a single blog post in both cache tiers (L1 in-memory and L2 Redis),
+    /// keyed by its unique identifier.
+    /// </summary>
+    /// <param name="id">The unique identifier used as the cache key.</param>
+    /// <param name="post">The blog post DTO to cache.</param>
+    /// <param name="ct">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous set operation.</returns>
+    Task SetByIdAsync(Guid id, BlogPostDto post, CancellationToken ct);
+
+    /// <summary>
+    /// Removes the all-posts cache entry from both L1 (in-memory) and L2 (Redis).
+    /// Call this after any write operation that affects the full post list
+    /// (create, edit, delete, publish/unpublish).
+    /// </summary>
+    /// <param name="ct">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous invalidation operation.</returns>
+    Task InvalidateAllAsync(CancellationToken ct);
+
+    /// <summary>
+    /// Removes the per-post cache entry for the given identifier from both
+    /// L1 (in-memory) and L2 (Redis).
+    /// Call this after any write operation that modifies or deletes a specific post.
+    /// </summary>
+    /// <param name="id">The unique identifier of the blog post whose cache entry should be removed.</param>
+    /// <param name="ct">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous invalidation operation.</returns>
+    Task InvalidateByIdAsync(Guid id, CancellationToken ct);
+}
+```
+
+---
+
+## `BlogPostCacheKeys`
+
+```csharp
+/// <summary>Cache key constants for blog post entries.</summary>
+public static class BlogPostCacheKeys
+{
+    /// <summary>Cache key for the full list of blog posts.</summary>
+    public const string All = "blog:all";
+
+    /// <summary>
+    /// Returns the cache key for a single blog post identified by <paramref name="id"/>.
+    /// </summary>
+    /// <param name="id">The unique identifier of the blog post.</param>
+    /// <returns>A string cache key in the format <c>blog:{id}</c>.</returns>
+    public static string ById(Guid id) => $"blog:{id}";
+}
+```
+
+---
+
+## `BlogPostCacheService`
+
+```csharp
+/// <summary>
+/// Two-tier cache implementation for blog post data, combining an L1 in-process
+/// <see cref="IMemoryCache"/> (1-minute TTL) with an L2 distributed
+/// <see cref="IDistributedCache"/> backed by Redis (5-minute TTL).
+/// </summary>
+/// <remarks>
+/// Read operations check L1 first; on an L1 miss they fall through to L2 and
+/// back-fill L1 on a hit. Write operations populate both tiers simultaneously.
+/// Invalidation removes from both tiers.
+/// </remarks>
+public sealed class BlogPostCacheService : IBlogPostCacheService
+```
+
+---
+
+## README.md — Needed Updates
+
+The current `README.md` does **not** mention caching or Redis. The following two sections require updates once Sprint 5 is merged:
+
+### Technology Stack section
+
+Add entries for the caching layer:
+
+```markdown
+- **IMemoryCache** — L1 in-process cache (1-minute TTL per entry)
+- **Redis via .NET Aspire** — L2 distributed cache (5-minute TTL); provisioned by
+  `builder.AddRedis("redis")` in `AppHost`
+```
+
+Also update the stale line:
+
+```markdown
+- **In-Memory Repository** — No database (training project by design)
+```
+
+This is no longer accurate after the MongoDB migration (Sprint 4). It should read:
+
+```markdown
+- **MongoDB via EF Core Adapter** — Document store for blog posts,
+  accessed through `IDbContextFactory<BlogDbContext>`
+```
+
+### Features section
+
+No new user-visible features are introduced by the caching abstraction. No changes needed here.
+
+### Learning Objectives section
+
+Consider adding a seventh objective once Sprint 5 ships:
+
+```markdown
+7. **Two-Tier Caching** — L1 IMemoryCache + L2 Redis via IBlogPostCacheService abstraction,
+   cache invalidation on write, DRY cache key management with BlogPostCacheKeys
+```
+
+---
+
+*Stubs prepared by Frodo (Tech Writer) — Sprint 5, 2026-04-23*

--- a/src/Web/Features/BlogPosts/Create/CreateBlogPostHandler.cs
+++ b/src/Web/Features/BlogPosts/Create/CreateBlogPostHandler.cs
@@ -8,27 +8,26 @@
 //=======================================================
 
 using MyBlog.Domain.Abstractions;
+using MyBlog.Web.Infrastructure.Caching;
 
 namespace MyBlog.Web.Features.BlogPosts.Create;
 
 public sealed class CreateBlogPostHandler(
-		IBlogPostRepository repo,
-		IMemoryCache localCache,
-		IDistributedCache distributedCache) : IRequestHandler<CreateBlogPostCommand, Result<Guid>>
+IBlogPostRepository repo,
+IBlogPostCacheService cache) : IRequestHandler<CreateBlogPostCommand, Result<Guid>>
 {
-	public async Task<Result<Guid>> Handle(CreateBlogPostCommand request, CancellationToken ct)
-	{
-		try
-		{
-			var post = BlogPost.Create(request.Title, request.Content, request.Author);
-			await repo.AddAsync(post, ct);
-			localCache.Remove("blog:all");
-			_ = distributedCache.RemoveAsync("blog:all", ct);
-			return Result.Ok<Guid>(post.Id);
-		}
-		catch (Exception ex)
-		{
-			return Result.Fail<Guid>(ex.Message);
-		}
-	}
+public async Task<Result<Guid>> Handle(CreateBlogPostCommand request, CancellationToken ct)
+{
+try
+{
+var post = BlogPost.Create(request.Title, request.Content, request.Author);
+await repo.AddAsync(post, ct);
+await cache.InvalidateAllAsync(ct);
+return Result.Ok<Guid>(post.Id);
+}
+catch (Exception ex)
+{
+return Result.Fail<Guid>(ex.Message);
+}
+}
 }

--- a/src/Web/Features/BlogPosts/Delete/DeleteBlogPostHandler.cs
+++ b/src/Web/Features/BlogPosts/Delete/DeleteBlogPostHandler.cs
@@ -8,34 +8,32 @@
 //=======================================================
 
 using MyBlog.Domain.Abstractions;
+using MyBlog.Web.Infrastructure.Caching;
 
 namespace MyBlog.Web.Features.BlogPosts.Delete;
 
 public sealed class DeleteBlogPostHandler(
-		IBlogPostRepository repo,
-		IMemoryCache localCache,
-		IDistributedCache distributedCache) : IRequestHandler<DeleteBlogPostCommand, Result>
+IBlogPostRepository repo,
+IBlogPostCacheService cache) : IRequestHandler<DeleteBlogPostCommand, Result>
 {
-	public async Task<Result> Handle(DeleteBlogPostCommand request, CancellationToken ct)
-	{
-		try
-		{
-			await repo.DeleteAsync(request.Id, ct);
-			localCache.Remove("blog:all");
-			localCache.Remove($"blog:{request.Id}");
-			await distributedCache.RemoveAsync("blog:all", ct);
-			await distributedCache.RemoveAsync($"blog:{request.Id}", ct);
-			return Result.Ok();
-		}
-		catch (DbUpdateConcurrencyException)
-		{
-			return Result.Fail(
-					"This post was modified by another user. Please reload and try again.",
-					ResultErrorCode.Concurrency);
-		}
-		catch (Exception ex)
-		{
-			return Result.Fail(ex.Message);
-		}
-	}
+public async Task<Result> Handle(DeleteBlogPostCommand request, CancellationToken ct)
+{
+try
+{
+await repo.DeleteAsync(request.Id, ct);
+await cache.InvalidateAllAsync(ct);
+await cache.InvalidateByIdAsync(request.Id, ct);
+return Result.Ok();
+}
+catch (DbUpdateConcurrencyException)
+{
+return Result.Fail(
+"This post was modified by another user. Please reload and try again.",
+ResultErrorCode.Concurrency);
+}
+catch (Exception ex)
+{
+return Result.Fail(ex.Message);
+}
+}
 }

--- a/src/Web/Features/BlogPosts/Edit/EditBlogPostHandler.cs
+++ b/src/Web/Features/BlogPosts/Edit/EditBlogPostHandler.cs
@@ -7,79 +7,58 @@
 //Project Name :  Web
 //=======================================================
 
-using System.Text.Json;
-
 using MyBlog.Domain.Abstractions;
+using MyBlog.Web.Infrastructure.Caching;
 
 namespace MyBlog.Web.Features.BlogPosts.Edit;
 
 public sealed class EditBlogPostHandler(
-		IBlogPostRepository repo,
-		IMemoryCache localCache,
-		IDistributedCache distributedCache)
-		: IRequestHandler<EditBlogPostCommand, Result>,
-			IRequestHandler<GetBlogPostByIdQuery, Result<BlogPostDto?>>
+IBlogPostRepository repo,
+IBlogPostCacheService cache)
+: IRequestHandler<EditBlogPostCommand, Result>,
+IRequestHandler<GetBlogPostByIdQuery, Result<BlogPostDto?>>
 {
-	private static readonly MemoryCacheEntryOptions LocalOpts =
-			new MemoryCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromMinutes(1));
-	private static readonly DistributedCacheEntryOptions RedisOpts =
-			new DistributedCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromMinutes(5));
-	private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+public async Task<Result> Handle(EditBlogPostCommand request, CancellationToken ct)
+{
+try
+{
+var post = await repo.GetByIdAsync(request.Id, ct);
+if (post is null)
+return Result.Fail($"BlogPost {request.Id} not found.");
+post.Update(request.Title, request.Content);
+await repo.UpdateAsync(post, ct);
+await cache.InvalidateAllAsync(ct);
+await cache.InvalidateByIdAsync(request.Id, ct);
+return Result.Ok();
+}
+catch (DbUpdateConcurrencyException)
+{
+return Result.Fail(
+"This post was modified by another user. Please reload and try again.",
+ResultErrorCode.Concurrency);
+}
+catch (Exception ex)
+{
+return Result.Fail(ex.Message);
+}
+}
 
-	public async Task<Result> Handle(EditBlogPostCommand request, CancellationToken ct)
-	{
-		try
-		{
-			var post = await repo.GetByIdAsync(request.Id, ct);
-			if (post is null)
-				return Result.Fail($"BlogPost {request.Id} not found.");
-			post.Update(request.Title, request.Content);
-			await repo.UpdateAsync(post, ct);
-			localCache.Remove("blog:all");
-			localCache.Remove($"blog:{request.Id}");
-			await distributedCache.RemoveAsync("blog:all", ct);
-			await distributedCache.RemoveAsync($"blog:{request.Id}", ct);
-			return Result.Ok();
-		}
-		catch (DbUpdateConcurrencyException)
-		{
-			return Result.Fail(
-					"This post was modified by another user. Please reload and try again.",
-					ResultErrorCode.Concurrency);
-		}
-		catch (Exception ex)
-		{
-			return Result.Fail(ex.Message);
-		}
-	}
-
-	public async Task<Result<BlogPostDto?>> Handle(GetBlogPostByIdQuery request, CancellationToken ct)
-	{
-		try
-		{
-			var key = $"blog:{request.Id}";
-			if (localCache.TryGetValue(key, out BlogPostDto? cached) && cached is not null)
-				return Result.Ok<BlogPostDto?>(cached);
-
-			var bytes = await distributedCache.GetAsync(key, ct);
-			if (bytes is not null)
-			{
-				var dto = JsonSerializer.Deserialize<BlogPostDto>(bytes, JsonOpts)!;
-				localCache.Set(key, dto, LocalOpts);
-				return Result.Ok<BlogPostDto?>(dto);
-			}
-
-			var post = await repo.GetByIdAsync(request.Id, ct);
-			if (post is null) return Result.Ok<BlogPostDto?>(null);
-			var result = post.ToDto();
-			localCache.Set(key, result, LocalOpts);
-			await distributedCache.SetAsync(key,
-					JsonSerializer.SerializeToUtf8Bytes(result, JsonOpts), RedisOpts, ct);
-			return Result.Ok<BlogPostDto?>(result);
-		}
-		catch (Exception ex)
-		{
-			return Result.Fail<BlogPostDto?>(ex.Message);
-		}
-	}
+public async Task<Result<BlogPostDto?>> Handle(GetBlogPostByIdQuery request, CancellationToken ct)
+{
+try
+{
+var dto = await cache.GetOrFetchByIdAsync(
+request.Id,
+async () =>
+{
+var post = await repo.GetByIdAsync(request.Id, ct);
+return post?.ToDto();
+}, ct);
+return Result.Ok<BlogPostDto?>(dto);
+}
+catch (Exception ex)
+{
+return Result.Fail<BlogPostDto?>(ex.Message);
+}
+}
 }

--- a/src/Web/Features/BlogPosts/List/GetBlogPostsHandler.cs
+++ b/src/Web/Features/BlogPosts/List/GetBlogPostsHandler.cs
@@ -7,50 +7,31 @@
 //Project Name :  Web
 //=======================================================
 
-using System.Text.Json;
-
 using MyBlog.Domain.Abstractions;
+using MyBlog.Web.Infrastructure.Caching;
 
 namespace MyBlog.Web.Features.BlogPosts.List;
 
 public sealed class GetBlogPostsHandler(
-		IBlogPostRepository repo,
-		IMemoryCache localCache,
-		IDistributedCache distributedCache) : IRequestHandler<GetBlogPostsQuery, Result<IReadOnlyList<BlogPostDto>>>
+IBlogPostRepository repo,
+IBlogPostCacheService cache) : IRequestHandler<GetBlogPostsQuery, Result<IReadOnlyList<BlogPostDto>>>
 {
-	private static readonly MemoryCacheEntryOptions LocalOpts =
-			new MemoryCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromMinutes(1));
-	private static readonly DistributedCacheEntryOptions RedisOpts =
-			new DistributedCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromMinutes(5));
-	private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
-	private const string CacheKey = "blog:all";
-
-	public async Task<Result<IReadOnlyList<BlogPostDto>>> Handle(
-			GetBlogPostsQuery request, CancellationToken ct)
-	{
-		try
-		{
-			if (localCache.TryGetValue(CacheKey, out List<BlogPostDto>? cached) && cached is not null)
-				return Result.Ok<IReadOnlyList<BlogPostDto>>(cached);
-
-			var bytes = await distributedCache.GetAsync(CacheKey, ct);
-			if (bytes is not null)
-			{
-				var fromRedis = JsonSerializer.Deserialize<List<BlogPostDto>>(bytes, JsonOpts)!;
-				localCache.Set(CacheKey, fromRedis, LocalOpts);
-				return Result.Ok<IReadOnlyList<BlogPostDto>>(fromRedis);
-			}
-
-			var posts = await repo.GetAllAsync(ct);
-			var dtos = posts.Select(p => p.ToDto()).ToList();
-			localCache.Set(CacheKey, dtos, LocalOpts);
-			await distributedCache.SetAsync(CacheKey,
-					JsonSerializer.SerializeToUtf8Bytes(dtos, JsonOpts), RedisOpts, ct);
-			return Result.Ok<IReadOnlyList<BlogPostDto>>(dtos);
-		}
-		catch (Exception ex)
-		{
-			return Result.Fail<IReadOnlyList<BlogPostDto>>(ex.Message);
-		}
-	}
+public async Task<Result<IReadOnlyList<BlogPostDto>>> Handle(
+GetBlogPostsQuery request, CancellationToken ct)
+{
+try
+{
+var result = await cache.GetOrFetchAllAsync(
+async () =>
+{
+var all = await repo.GetAllAsync(ct);
+return (IReadOnlyList<BlogPostDto>)all.Select(p => p.ToDto()).ToList();
+}, ct);
+return Result.Ok<IReadOnlyList<BlogPostDto>>(result);
+}
+catch (Exception ex)
+{
+return Result.Fail<IReadOnlyList<BlogPostDto>>(ex.Message);
+}
+}
 }

--- a/src/Web/GlobalUsings.cs
+++ b/src/Web/GlobalUsings.cs
@@ -14,3 +14,4 @@ global using Microsoft.Extensions.Caching.Memory;
 global using MyBlog.Domain.Entities;
 global using MyBlog.Domain.Interfaces;
 global using MyBlog.Web.Data;
+global using MyBlog.Web.Infrastructure.Caching;

--- a/src/Web/Infrastructure/Caching/BlogPostCacheKeys.cs
+++ b/src/Web/Infrastructure/Caching/BlogPostCacheKeys.cs
@@ -1,0 +1,20 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     BlogPostCacheKeys.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web
+//=======================================================
+
+namespace MyBlog.Web.Infrastructure.Caching;
+
+/// <summary>Cache key constants for the BlogPost two-tier cache.</summary>
+public static class BlogPostCacheKeys
+{
+	/// <summary>Key for the list of all blog posts.</summary>
+	public const string All = "blog:all";
+
+	/// <summary>Key for a single blog post identified by <paramref name="id"/>.</summary>
+	public static string ById(Guid id) => $"blog:{id}";
+}

--- a/src/Web/Infrastructure/Caching/BlogPostCacheService.cs
+++ b/src/Web/Infrastructure/Caching/BlogPostCacheService.cs
@@ -1,0 +1,127 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     BlogPostCacheService.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web
+//=======================================================
+
+using System.Text.Json;
+
+using MyBlog.Web.Data;
+
+namespace MyBlog.Web.Infrastructure.Caching;
+
+internal sealed class BlogPostCacheService(
+	IMemoryCache localCache,
+	IDistributedCache distributedCache) : IBlogPostCacheService
+{
+	private static readonly MemoryCacheEntryOptions LocalOpts =
+		new MemoryCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromMinutes(1));
+
+	private static readonly DistributedCacheEntryOptions RedisOpts =
+		new DistributedCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromMinutes(5));
+
+	private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+
+	public async ValueTask<IReadOnlyList<BlogPostDto>> GetOrFetchAllAsync(
+		Func<Task<IReadOnlyList<BlogPostDto>>> fetch,
+		CancellationToken ct = default)
+	{
+		// L1 hit (synchronous — no heap allocation)
+		if (localCache.TryGetValue(BlogPostCacheKeys.All, out List<BlogPostDto>? cached) && cached is not null)
+			return cached;
+
+		// L2 hit
+		var bytes = await distributedCache.GetAsync(BlogPostCacheKeys.All, ct);
+		if (bytes is not null)
+		{
+			try
+			{
+				var fromRedis = JsonSerializer.Deserialize<List<BlogPostDto>>(bytes, JsonOpts);
+				if (fromRedis is not null)
+				{
+					localCache.Set(BlogPostCacheKeys.All, fromRedis, LocalOpts);
+					return fromRedis;
+				}
+			}
+			catch (JsonException)
+			{
+				// Stale or corrupt bytes — remove and fall through to the DB
+				await distributedCache.RemoveAsync(BlogPostCacheKeys.All, CancellationToken.None);
+			}
+		}
+
+		// DB via caller-supplied fetch
+		var result = await fetch();
+		var list = result as List<BlogPostDto> ?? result.ToList();
+		localCache.Set(BlogPostCacheKeys.All, list, LocalOpts);
+		await distributedCache.SetAsync(
+			BlogPostCacheKeys.All,
+			JsonSerializer.SerializeToUtf8Bytes(list, JsonOpts),
+			RedisOpts,
+			ct);
+		return result;
+	}
+
+	public async ValueTask<BlogPostDto?> GetOrFetchByIdAsync(
+		Guid id,
+		Func<Task<BlogPostDto?>> fetch,
+		CancellationToken ct = default)
+	{
+		var key = BlogPostCacheKeys.ById(id);
+
+		// L1 hit (synchronous — no heap allocation)
+		if (localCache.TryGetValue(key, out BlogPostDto? cached) && cached is not null)
+			return cached;
+
+		// L2 hit
+		var bytes = await distributedCache.GetAsync(key, ct);
+		if (bytes is not null)
+		{
+			try
+			{
+				var dto = JsonSerializer.Deserialize<BlogPostDto>(bytes, JsonOpts);
+				if (dto is not null)
+				{
+					localCache.Set(key, dto, LocalOpts);
+					return dto;
+				}
+			}
+			catch (JsonException)
+			{
+				// Stale or corrupt bytes — remove and fall through to the DB
+				await distributedCache.RemoveAsync(key, CancellationToken.None);
+			}
+		}
+
+		// DB via caller-supplied fetch
+		var result = await fetch();
+		if (result is null)
+			return null;
+
+		localCache.Set(key, result, LocalOpts);
+		await distributedCache.SetAsync(
+			key,
+			JsonSerializer.SerializeToUtf8Bytes(result, JsonOpts),
+			RedisOpts,
+			ct);
+		return result;
+	}
+
+	public async Task InvalidateAllAsync(CancellationToken ct = default)
+	{
+		localCache.Remove(BlogPostCacheKeys.All);
+		// CancellationToken.None: the DB write already committed — must not be cancelled
+		await distributedCache.RemoveAsync(BlogPostCacheKeys.All, CancellationToken.None);
+	}
+
+	public async Task InvalidateByIdAsync(Guid id, CancellationToken ct = default)
+	{
+		var key = BlogPostCacheKeys.ById(id);
+		localCache.Remove(key);
+		// CancellationToken.None: the DB write already committed — must not be cancelled
+		await distributedCache.RemoveAsync(key, CancellationToken.None);
+	}
+}

--- a/src/Web/Infrastructure/Caching/CachingServiceExtensions.cs
+++ b/src/Web/Infrastructure/Caching/CachingServiceExtensions.cs
@@ -1,0 +1,24 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     CachingServiceExtensions.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web
+//=======================================================
+
+namespace MyBlog.Web.Infrastructure.Caching;
+
+public static class CachingServiceExtensions
+{
+	/// <summary>
+	/// Registers the two-tier (L1 in-memory + L2 Redis) <see cref="IBlogPostCacheService"/>
+	/// implementation. Call this after <c>AddMemoryCache()</c> and
+	/// <c>AddRedisDistributedCache()</c> are already registered.
+	/// </summary>
+	public static IServiceCollection AddBlogPostCaching(this IServiceCollection services)
+	{
+		services.AddSingleton<IBlogPostCacheService, BlogPostCacheService>();
+		return services;
+	}
+}

--- a/src/Web/Infrastructure/Caching/IBlogPostCacheService.cs
+++ b/src/Web/Infrastructure/Caching/IBlogPostCacheService.cs
@@ -1,0 +1,67 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     IBlogPostCacheService.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web
+//=======================================================
+
+using MyBlog.Web.Data;
+
+namespace MyBlog.Web.Infrastructure.Caching;
+
+/// <summary>
+/// Two-tier (L1 in-memory + L2 Redis) cache abstraction for <see cref="BlogPostDto"/> values.
+/// </summary>
+/// <remarks>
+/// Registered as a singleton. Both <see cref="IMemoryCache"/> and
+/// <see cref="IDistributedCache"/> (StackExchange Redis) are also singletons,
+/// so captive-dependency rules are satisfied.
+/// </remarks>
+public interface IBlogPostCacheService
+{
+	/// <summary>
+	/// Returns all blog posts from the nearest cache tier, or invokes
+	/// <paramref name="fetch"/> on a complete miss, populates both tiers, and returns the result.
+	/// </summary>
+	/// <remarks>
+	/// Returns <see cref="ValueTask{T}"/> because L1 hits complete synchronously.
+	/// Do not await the same <see cref="ValueTask{T}"/> instance more than once.
+	/// </remarks>
+	ValueTask<IReadOnlyList<BlogPostDto>> GetOrFetchAllAsync(
+		Func<Task<IReadOnlyList<BlogPostDto>>> fetch,
+		CancellationToken ct = default);
+
+	/// <summary>
+	/// Returns the blog post with <paramref name="id"/> from the nearest cache tier,
+	/// or invokes <paramref name="fetch"/> on a complete miss.
+	/// Returns <c>null</c> when the post does not exist.
+	/// </summary>
+	/// <remarks>
+	/// Returns <see cref="ValueTask{T}"/> because L1 hits complete synchronously.
+	/// Do not await the same <see cref="ValueTask{T}"/> instance more than once.
+	/// </remarks>
+	ValueTask<BlogPostDto?> GetOrFetchByIdAsync(
+		Guid id,
+		Func<Task<BlogPostDto?>> fetch,
+		CancellationToken ct = default);
+
+	/// <summary>
+	/// Removes the "all posts" entry from both cache tiers.
+	/// </summary>
+	/// <remarks>
+	/// Redis removal uses <see cref="CancellationToken.None"/>: the database write has
+	/// already committed and invalidation must complete regardless of caller cancellation.
+	/// </remarks>
+	Task InvalidateAllAsync(CancellationToken ct = default);
+
+	/// <summary>
+	/// Removes the per-post entry for <paramref name="id"/> from both cache tiers.
+	/// </summary>
+	/// <remarks>
+	/// Redis removal uses <see cref="CancellationToken.None"/>: the database write has
+	/// already committed and invalidation must complete regardless of caller cancellation.
+	/// </remarks>
+	Task InvalidateByIdAsync(Guid id, CancellationToken ct = default);
+}

--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -24,6 +24,7 @@ using MyBlog.Domain.Behaviors;
 using MyBlog.Domain.Entities;
 using MyBlog.ServiceDefaults;
 using MyBlog.Web.Components;
+using MyBlog.Web.Infrastructure.Caching;
 using MyBlog.Web.Security;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -102,6 +103,9 @@ builder.AddRedisDistributedCache("redis");
 
 // Local in-memory cache (L1)
 builder.Services.AddMemoryCache();
+
+// BlogPost two-tier cache service (L1 + L2)
+builder.Services.AddBlogPostCaching();
 
 // Repository: concrete + interface
 builder.Services.AddScoped<MongoDbBlogPostRepository>();

--- a/tests/Web.Tests/GlobalUsings.cs
+++ b/tests/Web.Tests/GlobalUsings.cs
@@ -15,6 +15,7 @@ global using Microsoft.Extensions.Caching.Memory;
 global using MyBlog.Domain.Entities;
 global using MyBlog.Domain.Interfaces;
 global using MyBlog.Web.Data;
+global using MyBlog.Web.Infrastructure.Caching;
 global using NSubstitute;
 global using NSubstitute.ExceptionExtensions;
 global using System.Security.Claims;

--- a/tests/Web.Tests/Handlers/CreateBlogPostHandlerTests.cs
+++ b/tests/Web.Tests/Handlers/CreateBlogPostHandlerTests.cs
@@ -4,7 +4,7 @@
 //Company :       mpaulosky
 //Author :        Matthew Paulosky
 //Solution Name : MyBlog
-//Project Name :  Unit.Tests
+//Project Name :  Web.Tests
 //=======================================================
 
 using MyBlog.Web.Features.BlogPosts.Create;
@@ -13,46 +13,44 @@ namespace Web.Handlers;
 
 public class CreateBlogPostHandlerTests
 {
-	private readonly IBlogPostRepository _repo = Substitute.For<IBlogPostRepository>();
-	private readonly IMemoryCache _localCache = Substitute.For<IMemoryCache>();
-	private readonly IDistributedCache _distributedCache = Substitute.For<IDistributedCache>();
-	private readonly CreateBlogPostHandler _handler;
+private readonly IBlogPostRepository _repo = Substitute.For<IBlogPostRepository>();
+private readonly IBlogPostCacheService _cache = Substitute.For<IBlogPostCacheService>();
+private readonly CreateBlogPostHandler _handler;
 
-	public CreateBlogPostHandlerTests()
-	{
-		_handler = new CreateBlogPostHandler(_repo, _localCache, _distributedCache);
-	}
+public CreateBlogPostHandlerTests()
+{
+_handler = new CreateBlogPostHandler(_repo, _cache);
+}
 
-	[Fact]
-	public async Task Handle_Success_CreatesPostInvalidatesCacheAndReturnsGuid()
-	{
-		// Arrange
-		var command = new CreateBlogPostCommand("Title", "Content", "Author");
+[Fact]
+public async Task Handle_Success_CreatesPostInvalidatesCacheAndReturnsGuid()
+{
+// Arrange
+var command = new CreateBlogPostCommand("Title", "Content", "Author");
 
-		// Act
-		var result = await _handler.Handle(command, CancellationToken.None);
+// Act
+var result = await _handler.Handle(command, CancellationToken.None);
 
-		// Assert
-		result.Success.Should().BeTrue();
-		result.Value.Should().NotBeEmpty();
-		await _repo.Received(1).AddAsync(Arg.Any<MyBlog.Domain.Entities.BlogPost>(), Arg.Any<CancellationToken>());
-		_localCache.Received(1).Remove("blog:all");
-		await _distributedCache.Received(1).RemoveAsync("blog:all", Arg.Any<CancellationToken>());
-	}
+// Assert
+result.Success.Should().BeTrue();
+result.Value.Should().NotBeEmpty();
+await _repo.Received(1).AddAsync(Arg.Any<BlogPost>(), Arg.Any<CancellationToken>());
+await _cache.Received(1).InvalidateAllAsync(Arg.Any<CancellationToken>());
+}
 
-	[Fact]
-	public async Task Handle_RepoThrows_ReturnsFailResult()
-	{
-		// Arrange
-		var command = new CreateBlogPostCommand("Title", "Content", "Author");
-		_repo.AddAsync(Arg.Any<MyBlog.Domain.Entities.BlogPost>(), Arg.Any<CancellationToken>())
-				.ThrowsAsync(new InvalidOperationException("insert failed"));
+[Fact]
+public async Task Handle_RepoThrows_ReturnsFailResult()
+{
+// Arrange
+var command = new CreateBlogPostCommand("Title", "Content", "Author");
+_repo.AddAsync(Arg.Any<BlogPost>(), Arg.Any<CancellationToken>())
+.ThrowsAsync(new InvalidOperationException("insert failed"));
 
-		// Act
-		var result = await _handler.Handle(command, CancellationToken.None);
+// Act
+var result = await _handler.Handle(command, CancellationToken.None);
 
-		// Assert
-		result.Failure.Should().BeTrue();
-		result.Error.Should().Contain("insert failed");
-	}
+// Assert
+result.Failure.Should().BeTrue();
+result.Error.Should().Contain("insert failed");
+}
 }

--- a/tests/Web.Tests/Handlers/DeleteBlogPostHandlerTests.cs
+++ b/tests/Web.Tests/Handlers/DeleteBlogPostHandlerTests.cs
@@ -4,7 +4,7 @@
 //Company :       mpaulosky
 //Author :        Matthew Paulosky
 //Solution Name : MyBlog
-//Project Name :  Unit.Tests
+//Project Name :  Web.Tests
 //=======================================================
 
 using Microsoft.EntityFrameworkCore;
@@ -16,66 +16,63 @@ namespace Web.Handlers;
 
 public class DeleteBlogPostHandlerTests
 {
-	private readonly IBlogPostRepository _repo = Substitute.For<IBlogPostRepository>();
-	private readonly IMemoryCache _localCache = Substitute.For<IMemoryCache>();
-	private readonly IDistributedCache _distributedCache = Substitute.For<IDistributedCache>();
-	private readonly DeleteBlogPostHandler _handler;
+private readonly IBlogPostRepository _repo = Substitute.For<IBlogPostRepository>();
+private readonly IBlogPostCacheService _cache = Substitute.For<IBlogPostCacheService>();
+private readonly DeleteBlogPostHandler _handler;
 
-	public DeleteBlogPostHandlerTests()
-	{
-		_handler = new DeleteBlogPostHandler(_repo, _localCache, _distributedCache);
-	}
+public DeleteBlogPostHandlerTests()
+{
+_handler = new DeleteBlogPostHandler(_repo, _cache);
+}
 
-	[Fact]
-	public async Task Handle_Success_DeletesAndInvalidatesBothCaches()
-	{
-		// Arrange
-		var id = Guid.NewGuid();
-		var command = new DeleteBlogPostCommand(id);
+[Fact]
+public async Task Handle_Success_DeletesAndInvalidatesBothCaches()
+{
+// Arrange
+var id = Guid.NewGuid();
+var command = new DeleteBlogPostCommand(id);
 
-		// Act
-		var result = await _handler.Handle(command, CancellationToken.None);
+// Act
+var result = await _handler.Handle(command, CancellationToken.None);
 
-		// Assert
-		result.Success.Should().BeTrue();
-		await _repo.Received(1).DeleteAsync(id, Arg.Any<CancellationToken>());
-		_localCache.Received(1).Remove("blog:all");
-		_localCache.Received(1).Remove($"blog:{id}");
-		await _distributedCache.Received(1).RemoveAsync("blog:all", Arg.Any<CancellationToken>());
-		await _distributedCache.Received(1).RemoveAsync($"blog:{id}", Arg.Any<CancellationToken>());
-	}
+// Assert
+result.Success.Should().BeTrue();
+await _repo.Received(1).DeleteAsync(id, Arg.Any<CancellationToken>());
+await _cache.Received(1).InvalidateAllAsync(Arg.Any<CancellationToken>());
+await _cache.Received(1).InvalidateByIdAsync(id, Arg.Any<CancellationToken>());
+}
 
-	[Fact]
-	public async Task Handle_RepoThrows_ReturnsFailResult()
-	{
-		// Arrange
-		var id = Guid.NewGuid();
-		var command = new DeleteBlogPostCommand(id);
-		_repo.DeleteAsync(id, Arg.Any<CancellationToken>())
-				.ThrowsAsync(new InvalidOperationException("delete failed"));
+[Fact]
+public async Task Handle_RepoThrows_ReturnsFailResult()
+{
+// Arrange
+var id = Guid.NewGuid();
+var command = new DeleteBlogPostCommand(id);
+_repo.DeleteAsync(id, Arg.Any<CancellationToken>())
+.ThrowsAsync(new InvalidOperationException("delete failed"));
 
-		// Act
-		var result = await _handler.Handle(command, CancellationToken.None);
+// Act
+var result = await _handler.Handle(command, CancellationToken.None);
 
-		// Assert
-		result.Failure.Should().BeTrue();
-		result.Error.Should().Contain("delete failed");
-	}
+// Assert
+result.Failure.Should().BeTrue();
+result.Error.Should().Contain("delete failed");
+}
 
-	[Fact]
-	public async Task Handle_ConcurrentDelete_ReturnsConcurrencyErrorCode()
-	{
-		// Arrange
-		var id = Guid.NewGuid();
-		var command = new DeleteBlogPostCommand(id);
-		_repo.DeleteAsync(id, Arg.Any<CancellationToken>())
-				.ThrowsAsync(new DbUpdateConcurrencyException("conflict", new Exception()));
+[Fact]
+public async Task Handle_ConcurrentDelete_ReturnsConcurrencyErrorCode()
+{
+// Arrange
+var id = Guid.NewGuid();
+var command = new DeleteBlogPostCommand(id);
+_repo.DeleteAsync(id, Arg.Any<CancellationToken>())
+.ThrowsAsync(new DbUpdateConcurrencyException("conflict", new Exception()));
 
-		// Act
-		var result = await _handler.Handle(command, CancellationToken.None);
+// Act
+var result = await _handler.Handle(command, CancellationToken.None);
 
-		// Assert
-		result.Failure.Should().BeTrue();
-		result.ErrorCode.Should().Be(ResultErrorCode.Concurrency);
-	}
+// Assert
+result.Failure.Should().BeTrue();
+result.ErrorCode.Should().Be(ResultErrorCode.Concurrency);
+}
 }

--- a/tests/Web.Tests/Handlers/EditBlogPostHandlerTests.cs
+++ b/tests/Web.Tests/Handlers/EditBlogPostHandlerTests.cs
@@ -4,10 +4,8 @@
 //Company :       mpaulosky
 //Author :        Matthew Paulosky
 //Solution Name : MyBlog
-//Project Name :  Unit.Tests
+//Project Name :  Web.Tests
 //=======================================================
-
-using System.Text.Json;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -18,140 +16,142 @@ namespace Web.Handlers;
 
 public class EditBlogPostHandlerTests
 {
-	private readonly IBlogPostRepository _repo = Substitute.For<IBlogPostRepository>();
-	private readonly IMemoryCache _localCache = Substitute.For<IMemoryCache>();
-	private readonly IDistributedCache _distributedCache = Substitute.For<IDistributedCache>();
-	private readonly ICacheEntry _cacheEntry = Substitute.For<ICacheEntry>();
-	private readonly EditBlogPostHandler _handler;
-	private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+private readonly IBlogPostRepository _repo = Substitute.For<IBlogPostRepository>();
+private readonly IBlogPostCacheService _cache = Substitute.For<IBlogPostCacheService>();
+private readonly EditBlogPostHandler _handler;
 
-	public EditBlogPostHandlerTests()
-	{
-		// IMemoryCache.Set<T> is an extension that calls CreateEntry — mock it so Set doesn't throw
-		_localCache.CreateEntry(Arg.Any<object>()).Returns(_cacheEntry);
-		_handler = new EditBlogPostHandler(_repo, _localCache, _distributedCache);
-	}
+public EditBlogPostHandlerTests()
+{
+_handler = new EditBlogPostHandler(_repo, _cache);
+}
 
-	// ── Edit tests ────────────────────────────────────────────────────────────
+// ── Edit tests ────────────────────────────────────────────────────────────
 
-	[Fact]
-	public async Task HandleEdit_Success_UpdatesPostAndInvalidatesBothCaches()
-	{
-		// Arrange
-		var post = BlogPost.Create("Old Title", "Old Content", "Author");
-		var command = new EditBlogPostCommand(post.Id, "New Title", "New Content");
-		_repo.GetByIdAsync(post.Id, Arg.Any<CancellationToken>()).Returns(post);
+[Fact]
+public async Task HandleEdit_Success_UpdatesPostAndInvalidatesBothCaches()
+{
+// Arrange
+var post = BlogPost.Create("Old Title", "Old Content", "Author");
+var command = new EditBlogPostCommand(post.Id, "New Title", "New Content");
+_repo.GetByIdAsync(post.Id, Arg.Any<CancellationToken>()).Returns(post);
 
-		// Act
-		var result = await _handler.Handle(command, CancellationToken.None);
+// Act
+var result = await _handler.Handle(command, CancellationToken.None);
 
-		// Assert
-		result.Success.Should().BeTrue();
-		await _repo.Received(1).UpdateAsync(post, Arg.Any<CancellationToken>());
-		_localCache.Received(1).Remove("blog:all");
-		_localCache.Received(1).Remove($"blog:{post.Id}");
-		await _distributedCache.Received(1).RemoveAsync("blog:all", Arg.Any<CancellationToken>());
-		await _distributedCache.Received(1).RemoveAsync($"blog:{post.Id}", Arg.Any<CancellationToken>());
-		post.Title.Should().Be("New Title");
-		post.Content.Should().Be("New Content");
-	}
+// Assert
+result.Success.Should().BeTrue();
+await _repo.Received(1).UpdateAsync(post, Arg.Any<CancellationToken>());
+await _cache.Received(1).InvalidateAllAsync(Arg.Any<CancellationToken>());
+await _cache.Received(1).InvalidateByIdAsync(post.Id, Arg.Any<CancellationToken>());
+post.Title.Should().Be("New Title");
+post.Content.Should().Be("New Content");
+}
 
-	[Fact]
-	public async Task HandleEdit_NotFound_ReturnsFailResult()
-	{
-		// Arrange
-		var id = Guid.NewGuid();
-		var command = new EditBlogPostCommand(id, "T", "C");
-		_repo.GetByIdAsync(Arg.Is<Guid>(g => g == id), Arg.Any<CancellationToken>()).Returns((BlogPost?)null);
+[Fact]
+public async Task HandleEdit_NotFound_ReturnsFailResult()
+{
+// Arrange
+var id = Guid.NewGuid();
+var command = new EditBlogPostCommand(id, "T", "C");
+_repo.GetByIdAsync(Arg.Is<Guid>(g => g == id), Arg.Any<CancellationToken>())
+.Returns((BlogPost?)null);
 
-		// Act
-		var result = await _handler.Handle(command, CancellationToken.None);
+// Act
+var result = await _handler.Handle(command, CancellationToken.None);
 
-		// Assert
-		result.Failure.Should().BeTrue();
-		result.Error.Should().Contain(id.ToString());
-	}
+// Assert
+result.Failure.Should().BeTrue();
+result.Error.Should().Contain(id.ToString());
+}
 
-	// ── GetById tests ─────────────────────────────────────────────────────────
+// ── GetById tests ─────────────────────────────────────────────────────────
 
-	[Fact]
-	public async Task HandleGetById_L1CacheHit_ReturnsCachedDtoWithoutRepo()
-	{
-		// Arrange
-		var id = Guid.NewGuid();
-		var dto = new BlogPostDto(id, "T", "C", "A", DateTime.UtcNow, null, false);
-		object? outVal = null;
-		_localCache.TryGetValue(Arg.Any<object>(), out outVal)
-				.Returns(x => { x[1] = (object)dto; return true; });
+[Fact]
+public async Task HandleGetById_L1CacheHit_ReturnsCachedDtoWithoutRepo()
+{
+// Arrange
+var id = Guid.NewGuid();
+var dto = new BlogPostDto(id, "T", "C", "A", DateTime.UtcNow, null, false);
+_cache.GetOrFetchByIdAsync(
+Arg.Any<Guid>(),
+Arg.Any<Func<Task<BlogPostDto?>>>(),
+Arg.Any<CancellationToken>())
+.Returns(new ValueTask<BlogPostDto?>(dto));
 
-		// Act
-		var result = await _handler.Handle(new GetBlogPostByIdQuery(id), CancellationToken.None);
+// Act
+var result = await _handler.Handle(new GetBlogPostByIdQuery(id), CancellationToken.None);
 
-		// Assert
-		result.Success.Should().BeTrue();
-		result.Value.Should().NotBeNull();
-		result.Value!.Id.Should().Be(id);
-		await _repo.DidNotReceive().GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
-	}
+// Assert
+result.Success.Should().BeTrue();
+result.Value.Should().NotBeNull();
+result.Value!.Id.Should().Be(id);
+await _repo.DidNotReceive().GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+}
 
-	[Fact]
-	public async Task HandleGetById_CacheMissRepoReturnsNull_ReturnsOkWithNull()
-	{
-		// Arrange
-		var id = Guid.NewGuid();
-		object? outVal = null;
-		_localCache.TryGetValue(Arg.Any<object>(), out outVal).Returns(false);
-		_distributedCache.GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-				.Returns(Task.FromResult<byte[]?>(null));
-		_repo.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((BlogPost?)null);
+[Fact]
+public async Task HandleGetById_CacheMissRepoReturnsNull_ReturnsOkWithNull()
+{
+// Arrange
+var id = Guid.NewGuid();
+_repo.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((BlogPost?)null);
+_cache.GetOrFetchByIdAsync(
+Arg.Any<Guid>(),
+Arg.Any<Func<Task<BlogPostDto?>>>(),
+Arg.Any<CancellationToken>())
+.Returns<ValueTask<BlogPostDto?>>(ci =>
+{
+var fetch = ci.Arg<Func<Task<BlogPostDto?>>>();
+return new ValueTask<BlogPostDto?>(fetch().GetAwaiter().GetResult());
+});
 
-		// Act
-		var result = await _handler.Handle(new GetBlogPostByIdQuery(id), CancellationToken.None);
+// Act
+var result = await _handler.Handle(new GetBlogPostByIdQuery(id), CancellationToken.None);
 
-		// Assert
-		result.Success.Should().BeTrue();
-		result.Value.Should().BeNull();
-	}
+// Assert
+result.Success.Should().BeTrue();
+result.Value.Should().BeNull();
+}
 
-	[Fact]
-	public async Task HandleGetById_CacheMissRepoReturnsPost_MapsToDtoAndCachesBoth()
-	{
-		// Arrange
-		var post = BlogPost.Create("Title", "Content", "Author");
-		object? outVal = null;
-		_localCache.TryGetValue(Arg.Any<object>(), out outVal).Returns(false);
-		_distributedCache.GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-				.Returns(Task.FromResult<byte[]?>(null));
-		_repo.GetByIdAsync(post.Id, Arg.Any<CancellationToken>()).Returns(post);
+[Fact]
+public async Task HandleGetById_CacheMissRepoReturnsPost_MapsToDtoAndPopulatesCache()
+{
+// Arrange
+var post = BlogPost.Create("Title", "Content", "Author");
+_repo.GetByIdAsync(post.Id, Arg.Any<CancellationToken>()).Returns(post);
+_cache.GetOrFetchByIdAsync(
+Arg.Any<Guid>(),
+Arg.Any<Func<Task<BlogPostDto?>>>(),
+Arg.Any<CancellationToken>())
+.Returns<ValueTask<BlogPostDto?>>(ci =>
+{
+var fetch = ci.Arg<Func<Task<BlogPostDto?>>>();
+return new ValueTask<BlogPostDto?>(fetch().GetAwaiter().GetResult());
+});
 
-		// Act
-		var result = await _handler.Handle(new GetBlogPostByIdQuery(post.Id), CancellationToken.None);
+// Act
+var result = await _handler.Handle(new GetBlogPostByIdQuery(post.Id), CancellationToken.None);
 
-		// Assert
-		result.Success.Should().BeTrue();
-		result.Value.Should().NotBeNull();
-		result.Value!.Title.Should().Be("Title");
-		// IMemoryCache.Set<T> calls CreateEntry — verify L1 was populated
-		_localCache.Received(1).CreateEntry(Arg.Any<object>());
-		await _distributedCache.Received(1).SetAsync(
-				Arg.Any<string>(), Arg.Any<byte[]>(), Arg.Any<DistributedCacheEntryOptions>(), Arg.Any<CancellationToken>());
-	}
+// Assert
+result.Success.Should().BeTrue();
+result.Value!.Title.Should().Be("Title");
+await _repo.Received(1).GetByIdAsync(post.Id, Arg.Any<CancellationToken>());
+}
 
-	[Fact]
-	public async Task HandleEdit_ConcurrentUpdate_ReturnsConcurrencyErrorCode()
-	{
-		// Arrange
-		var post = BlogPost.Create("Title", "Content", "Author");
-		var command = new EditBlogPostCommand(post.Id, "New Title", "New Content");
-		_repo.GetByIdAsync(post.Id, Arg.Any<CancellationToken>()).Returns(post);
-		_repo.UpdateAsync(Arg.Any<BlogPost>(), Arg.Any<CancellationToken>())
-				.ThrowsAsync(new DbUpdateConcurrencyException("conflict", new Exception()));
+[Fact]
+public async Task HandleEdit_ConcurrentUpdate_ReturnsConcurrencyErrorCode()
+{
+// Arrange
+var post = BlogPost.Create("Title", "Content", "Author");
+var command = new EditBlogPostCommand(post.Id, "New Title", "New Content");
+_repo.GetByIdAsync(post.Id, Arg.Any<CancellationToken>()).Returns(post);
+_repo.UpdateAsync(Arg.Any<BlogPost>(), Arg.Any<CancellationToken>())
+.ThrowsAsync(new DbUpdateConcurrencyException("conflict", new Exception()));
 
-		// Act
-		var result = await _handler.Handle(command, CancellationToken.None);
+// Act
+var result = await _handler.Handle(command, CancellationToken.None);
 
-		// Assert
-		result.Failure.Should().BeTrue();
-		result.ErrorCode.Should().Be(ResultErrorCode.Concurrency);
-	}
+// Assert
+result.Failure.Should().BeTrue();
+result.ErrorCode.Should().Be(ResultErrorCode.Concurrency);
+}
 }

--- a/tests/Web.Tests/Handlers/GetBlogPostsHandlerTests.cs
+++ b/tests/Web.Tests/Handlers/GetBlogPostsHandlerTests.cs
@@ -4,10 +4,8 @@
 //Company :       mpaulosky
 //Author :        Matthew Paulosky
 //Solution Name : MyBlog
-//Project Name :  Unit.Tests
+//Project Name :  Web.Tests
 //=======================================================
-
-using System.Text.Json;
 
 using MyBlog.Web.Features.BlogPosts.List;
 
@@ -15,110 +13,101 @@ namespace Web.Handlers;
 
 public class GetBlogPostsHandlerTests
 {
-	private readonly IBlogPostRepository _repo = Substitute.For<IBlogPostRepository>();
-	private readonly IMemoryCache _localCache = Substitute.For<IMemoryCache>();
-	private readonly IDistributedCache _distributedCache = Substitute.For<IDistributedCache>();
-	private readonly ICacheEntry _cacheEntry = Substitute.For<ICacheEntry>();
-	private readonly GetBlogPostsHandler _handler;
-	private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+private readonly IBlogPostRepository _repo = Substitute.For<IBlogPostRepository>();
+private readonly IBlogPostCacheService _cache = Substitute.For<IBlogPostCacheService>();
+private readonly GetBlogPostsHandler _handler;
 
-	public GetBlogPostsHandlerTests()
-	{
-		// IMemoryCache.Set<T> is an extension that calls CreateEntry — mock it so Set doesn't throw
-		_localCache.CreateEntry(Arg.Any<object>()).Returns(_cacheEntry);
-		_handler = new GetBlogPostsHandler(_repo, _localCache, _distributedCache);
-	}
+public GetBlogPostsHandlerTests()
+{
+_handler = new GetBlogPostsHandler(_repo, _cache);
+}
 
-	private static List<BlogPostDto> MakeDtos() =>
-	[
-			new(Guid.NewGuid(), "T1", "C1", "A1", DateTime.UtcNow, null, false),
-				new(Guid.NewGuid(), "T2", "C2", "A2", DateTime.UtcNow, null, true),
-		];
+private static List<BlogPostDto> MakeDtos() =>
+[
+new(Guid.NewGuid(), "T1", "C1", "A1", DateTime.UtcNow, null, false),
+new(Guid.NewGuid(), "T2", "C2", "A2", DateTime.UtcNow, null, true),
+];
 
-	[Fact]
-	public async Task Handle_L1CacheHit_ReturnsCachedDataWithoutCallingRepo()
-	{
-		// Arrange
-		var cachedList = MakeDtos();
-		object? outVal = null;
-		_localCache.TryGetValue(Arg.Any<object>(), out outVal)
-				.Returns(x => { x[1] = (object)cachedList; return true; });
+[Fact]
+public async Task Handle_L1CacheHit_ReturnsCachedDataWithoutCallingRepo()
+{
+// Arrange
+var cachedList = MakeDtos();
+_cache.GetOrFetchAllAsync(
+Arg.Any<Func<Task<IReadOnlyList<BlogPostDto>>>>(),
+Arg.Any<CancellationToken>())
+.Returns(new ValueTask<IReadOnlyList<BlogPostDto>>(cachedList));
 
-		// Act
-		var result = await _handler.Handle(new GetBlogPostsQuery(), CancellationToken.None);
+// Act
+var result = await _handler.Handle(new GetBlogPostsQuery(), CancellationToken.None);
 
-		// Assert
-		result.Success.Should().BeTrue();
-		result.Value.Should().HaveCount(2);
-		await _repo.DidNotReceive().GetAllAsync(Arg.Any<CancellationToken>());
-		await _distributedCache.DidNotReceive().GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
-	}
+// Assert
+result.Success.Should().BeTrue();
+result.Value.Should().HaveCount(2);
+await _repo.DidNotReceive().GetAllAsync(Arg.Any<CancellationToken>());
+}
 
-	[Fact]
-	public async Task Handle_L2CacheHit_DeserializesAndPopulatesL1()
-	{
-		// Arrange
-		object? outVal = null;
-		_localCache.TryGetValue(Arg.Any<object>(), out outVal).Returns(false);
+[Fact]
+public async Task Handle_L2CacheHit_ReturnsCachedDataWithoutCallingRepo()
+{
+// Arrange
+var cachedList = MakeDtos();
+_cache.GetOrFetchAllAsync(
+Arg.Any<Func<Task<IReadOnlyList<BlogPostDto>>>>(),
+Arg.Any<CancellationToken>())
+.Returns(new ValueTask<IReadOnlyList<BlogPostDto>>(cachedList));
 
-		var dtos = MakeDtos();
-		var bytes = JsonSerializer.SerializeToUtf8Bytes(dtos, JsonOpts);
-		_distributedCache.GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-				.Returns(Task.FromResult<byte[]?>(bytes));
+// Act
+var result = await _handler.Handle(new GetBlogPostsQuery(), CancellationToken.None);
 
-		// Act
-		var result = await _handler.Handle(new GetBlogPostsQuery(), CancellationToken.None);
+// Assert
+result.Success.Should().BeTrue();
+result.Value.Should().HaveCount(2);
+await _repo.DidNotReceive().GetAllAsync(Arg.Any<CancellationToken>());
+}
 
-		// Assert
-		result.Success.Should().BeTrue();
-		result.Value.Should().HaveCount(2);
-		// IMemoryCache.Set<T> calls CreateEntry — verify L1 was populated
-		_localCache.Received(1).CreateEntry(Arg.Any<object>());
-		await _repo.DidNotReceive().GetAllAsync(Arg.Any<CancellationToken>());
-	}
+[Fact]
+public async Task Handle_CacheMiss_CallsRepoAndPopulatesBothCaches()
+{
+// Arrange
+var post1 = BlogPost.Create("T1", "C1", "A1");
+var post2 = BlogPost.Create("T2", "C2", "A2");
+_repo.GetAllAsync(Arg.Any<CancellationToken>())
+.Returns(new List<BlogPost> { post1, post2 });
+_cache.GetOrFetchAllAsync(
+Arg.Any<Func<Task<IReadOnlyList<BlogPostDto>>>>(),
+Arg.Any<CancellationToken>())
+.Returns<ValueTask<IReadOnlyList<BlogPostDto>>>(ci =>
+{
+var fetch = ci.Arg<Func<Task<IReadOnlyList<BlogPostDto>>>>();
+return new ValueTask<IReadOnlyList<BlogPostDto>>(fetch().GetAwaiter().GetResult());
+});
 
-	[Fact]
-	public async Task Handle_CacheMiss_CallsRepoAndPopulatesBothCaches()
-	{
-		// Arrange
-		object? outVal = null;
-		_localCache.TryGetValue(Arg.Any<object>(), out outVal).Returns(false);
-		_distributedCache.GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-				.Returns(Task.FromResult<byte[]?>(null));
+// Act
+var result = await _handler.Handle(new GetBlogPostsQuery(), CancellationToken.None);
 
-		var post1 = BlogPost.Create("T1", "C1", "A1");
-		var post2 = BlogPost.Create("T2", "C2", "A2");
-		_repo.GetAllAsync(Arg.Any<CancellationToken>())
-				.Returns(new List<BlogPost> { post1, post2 });
+// Assert
+result.Success.Should().BeTrue();
+result.Value.Should().HaveCount(2);
+await _repo.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+}
 
-		// Act
-		var result = await _handler.Handle(new GetBlogPostsQuery(), CancellationToken.None);
+[Fact]
+public async Task Handle_RepoThrows_ReturnsFailResult()
+{
+// Arrange
+_cache.GetOrFetchAllAsync(
+Arg.Any<Func<Task<IReadOnlyList<BlogPostDto>>>>(),
+Arg.Any<CancellationToken>())
+.Returns(new ValueTask<IReadOnlyList<BlogPostDto>>(
+Task.FromException<IReadOnlyList<BlogPostDto>>(
+new InvalidOperationException("db error"))));
 
-		// Assert
-		result.Success.Should().BeTrue();
-		result.Value.Should().HaveCount(2);
-		// Verify both caches were populated
-		_localCache.Received(1).CreateEntry(Arg.Any<object>());
-		await _distributedCache.Received(1).SetAsync(
-				Arg.Any<string>(), Arg.Any<byte[]>(), Arg.Any<DistributedCacheEntryOptions>(), Arg.Any<CancellationToken>());
-	}
+// Act
+var result = await _handler.Handle(new GetBlogPostsQuery(), CancellationToken.None);
 
-	[Fact]
-	public async Task Handle_RepoThrows_ReturnsFailResult()
-	{
-		// Arrange
-		object? outVal = null;
-		_localCache.TryGetValue(Arg.Any<object>(), out outVal).Returns(false);
-		_distributedCache.GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-				.Returns(Task.FromResult<byte[]?>(null));
-		_repo.GetAllAsync(Arg.Any<CancellationToken>())
-				.ThrowsAsync(new InvalidOperationException("db error"));
-
-		// Act
-		var result = await _handler.Handle(new GetBlogPostsQuery(), CancellationToken.None);
-
-		// Assert
-		result.Failure.Should().BeTrue();
-		result.Error.Should().Contain("db error");
-	}
+// Assert
+result.Failure.Should().BeTrue();
+result.Error.Should().Contain("db error");
+}
 }


### PR DESCRIPTION
## Summary

Closes #110

Working as **Sam (Backend Developer)**

Refactors all 4 BlogPost handlers to use the `IBlogPostCacheService` abstraction introduced in #109 (PR #115).

## Changes

| File | Change |
|------|--------|
| `GetBlogPostsHandler.cs` | Inject `IBlogPostCacheService`, delegate to `GetOrFetchAllAsync` |
| `EditBlogPostHandler.cs` | Use `GetOrFetchByIdAsync`, `InvalidateAllAsync`, `InvalidateByIdAsync` |
| `CreateBlogPostHandler.cs` | Fix fire-and-forget bug: `await cache.InvalidateAllAsync(ct)` |
| `DeleteBlogPostHandler.cs` | `await InvalidateAllAsync` + `await InvalidateByIdAsync` |
| `src/Web/GlobalUsings.cs` | Add `global using MyBlog.Web.Infrastructure.Caching` |
| `tests/Web.Tests/GlobalUsings.cs` | Same — expose `IBlogPostCacheService` to all test files |
| 4 handler test files | Rewrite to mock `IBlogPostCacheService` via NSubstitute `ValueTask<T>` patterns |

## Test Results

- ✅ `Web.Tests` — 102/102 passed
- ✅ `Architecture.Tests` — 9/9 passed
- ✅ `Web.Tests.Bunit` — 61/61 passed
- ⏭️ Integration tests — skipped (Docker required)

⚠️ Test changes flagged for **Gimli (Tester)** review before merging.

## Follow-up

After this PR merges, remove `Skip` from both `[Fact(Skip=...)]` in `tests/Architecture.Tests/CachingLayerTests.cs` on branch `squad/113-arch-caching-test` (PR #116) to activate the caching arch enforcement tests.