### PR TITLE
docs: Sprint 5 caching ADR and XML doc stubs

### DIFF
--- a/docs/adr/sprint5-caching-abstraction.md
+++ b/docs/adr/sprint5-caching-abstraction.md
@@ -1,0 +1,71 @@
+---
+post_title: "ADR: Extract IBlogPostCacheService Abstraction"
+author1: "Frodo"
+post_slug: "adr-sprint5-caching-abstraction"
+microsoft_alias: ""
+featured_image: ""
+categories: ["Architecture"]
+tags: ["caching", "redis", "abstraction", "adr"]
+ai_note: "AI-assisted"
+summary: "Decision to extract a two-tier cache service abstraction to eliminate duplication across BlogPost handlers."
+post_date: "2026-04-23"
+---
+
+## Context
+
+Sprint 5 introduced a two-tier caching strategy across all four BlogPost MediatR handlers (`GetBlogPostsHandler`, `EditBlogPostHandler`, `CreateBlogPostHandler`, `DeleteBlogPostHandler`). Each handler independently declares:
+
+- `MemoryCacheEntryOptions` (L1 in-memory, 1-minute TTL)
+- `DistributedCacheEntryOptions` (L2 Redis, 5-minute TTL)
+- `JsonSerializerOptions` for serialization to/from Redis bytes
+- Inline cache key strings (`"blog:all"`, `$"blog:{id}"`)
+
+This results in four copies of the same boilerplate. Cache key strings are magic literals scattered across files, making a future key rename a multi-file search-and-replace. The `JsonSerializerOptions` instance is duplicated rather than shared.
+
+Any change to TTL policy, serialization options, or key naming requires touching every handler — a violation of the DRY principle and a maintenance hazard.
+
+---
+
+## Decision
+
+Extract a dedicated two-tier cache service behind the interface `IBlogPostCacheService`, implemented by `BlogPostCacheService`. Cache key constants are centralised in a companion static class `BlogPostCacheKeys`.
+
+### New types
+
+| Type | Kind | Responsibility |
+|------|------|----------------|
+| `IBlogPostCacheService` | Interface | Contract for L1 + L2 blog post cache operations |
+| `BlogPostCacheService` | Class | Implementation wrapping `IMemoryCache` + `IDistributedCache` |
+| `BlogPostCacheKeys` | Static class | Centralized cache key constants (`All`, `ById(Guid)`) |
+
+### Handler refactor
+
+All four handlers replace their inline `IMemoryCache` + `IDistributedCache` parameters with a single `IBlogPostCacheService` injection. The TTL constants, serialization options, and cache key logic move into `BlogPostCacheService`.
+
+### Registration
+
+`BlogPostCacheService` is registered in `Program.cs` as a scoped or singleton service alongside `IMemoryCache` and the Redis `IDistributedCache`.
+
+---
+
+## Status
+
+Accepted
+
+---
+
+## Consequences
+
+### Positive
+
+- **Eliminates duplication** — cache logic lives in one place; all four handlers become simpler.
+- **Single TTL policy** — changing L1 or L2 TTL requires editing one file.
+- **Centralised key management** — `BlogPostCacheKeys` prevents typos and enables compile-time refactoring.
+- **Testable abstraction** — handlers under test can receive a mock `IBlogPostCacheService` instead of coordinating two separate mock caches.
+- **Consistent serialization** — `JsonSerializerOptions` is created once inside `BlogPostCacheService`, ensuring uniform behaviour.
+
+### Negative
+
+- **Extra abstraction layer** — introduces an interface + implementation pair for what is conceptually simple cache I/O. Teams unfamiliar with the abstraction need to trace one more indirection when debugging cache behaviour.
+- **Discoverability** — a developer reading a handler for the first time will not see caching details inline; they must navigate to `BlogPostCacheService`. Mitigation: XML doc comments on the interface methods document what each call does.
+- **Migration cost** — all four existing handlers require a signature change and removal of their inline cache fields. The change is mechanical but touches multiple files.

--- a/docs/sprint5-xml-doc-stubs.md
+++ b/docs/sprint5-xml-doc-stubs.md
@@ -1,0 +1,160 @@
+# Sprint 5 — XML Doc Comment Stubs
+
+XML doc comment stubs for Sam to apply to the new cache abstraction types introduced in Sprint 5.
+
+---
+
+## `IBlogPostCacheService`
+
+```csharp
+/// <summary>
+/// Provides two-tier (L1 in-memory + L2 Redis) cache operations for blog post data.
+/// </summary>
+public interface IBlogPostCacheService
+{
+    /// <summary>
+    /// Retrieves all blog posts from the cache, checking L1 (in-memory) before L2 (Redis).
+    /// Returns <see langword="null"/> when no cached entry exists.
+    /// </summary>
+    /// <param name="ct">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that resolves to a read-only list of <see cref="BlogPostDto"/>
+    /// instances, or <see langword="null"/> if the entry is not present in either cache tier.
+    /// </returns>
+    Task<IReadOnlyList<BlogPostDto>?> GetAllAsync(CancellationToken ct);
+
+    /// <summary>
+    /// Stores all blog posts in both cache tiers (L1 in-memory and L2 Redis).
+    /// </summary>
+    /// <param name="posts">The list of blog post DTOs to cache.</param>
+    /// <param name="ct">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous set operation.</returns>
+    Task SetAllAsync(IReadOnlyList<BlogPostDto> posts, CancellationToken ct);
+
+    /// <summary>
+    /// Retrieves a single blog post by its unique identifier from the cache,
+    /// checking L1 (in-memory) before L2 (Redis).
+    /// Returns <see langword="null"/> when no cached entry exists for the given ID.
+    /// </summary>
+    /// <param name="id">The unique identifier of the blog post to retrieve.</param>
+    /// <param name="ct">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that resolves to the cached <see cref="BlogPostDto"/>,
+    /// or <see langword="null"/> if no entry is found.
+    /// </returns>
+    Task<BlogPostDto?> GetByIdAsync(Guid id, CancellationToken ct);
+
+    /// <summary>
+    /// Stores a single blog post in both cache tiers (L1 in-memory and L2 Redis),
+    /// keyed by its unique identifier.
+    /// </summary>
+    /// <param name="id">The unique identifier used as the cache key.</param>
+    /// <param name="post">The blog post DTO to cache.</param>
+    /// <param name="ct">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous set operation.</returns>
+    Task SetByIdAsync(Guid id, BlogPostDto post, CancellationToken ct);
+
+    /// <summary>
+    /// Removes the all-posts cache entry from both L1 (in-memory) and L2 (Redis).
+    /// Call this after any write operation that affects the full post list
+    /// (create, edit, delete, publish/unpublish).
+    /// </summary>
+    /// <param name="ct">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous invalidation operation.</returns>
+    Task InvalidateAllAsync(CancellationToken ct);
+
+    /// <summary>
+    /// Removes the per-post cache entry for the given identifier from both
+    /// L1 (in-memory) and L2 (Redis).
+    /// Call this after any write operation that modifies or deletes a specific post.
+    /// </summary>
+    /// <param name="id">The unique identifier of the blog post whose cache entry should be removed.</param>
+    /// <param name="ct">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous invalidation operation.</returns>
+    Task InvalidateByIdAsync(Guid id, CancellationToken ct);
+}
+```
+
+---
+
+## `BlogPostCacheKeys`
+
+```csharp
+/// <summary>Cache key constants for blog post entries.</summary>
+public static class BlogPostCacheKeys
+{
+    /// <summary>Cache key for the full list of blog posts.</summary>
+    public const string All = "blog:all";
+
+    /// <summary>
+    /// Returns the cache key for a single blog post identified by <paramref name="id"/>.
+    /// </summary>
+    /// <param name="id">The unique identifier of the blog post.</param>
+    /// <returns>A string cache key in the format <c>blog:{id}</c>.</returns>
+    public static string ById(Guid id) => $"blog:{id}";
+}
+```
+
+---
+
+## `BlogPostCacheService`
+
+```csharp
+/// <summary>
+/// Two-tier cache implementation for blog post data, combining an L1 in-process
+/// <see cref="IMemoryCache"/> (1-minute TTL) with an L2 distributed
+/// <see cref="IDistributedCache"/> backed by Redis (5-minute TTL).
+/// </summary>
+/// <remarks>
+/// Read operations check L1 first; on an L1 miss they fall through to L2 and
+/// back-fill L1 on a hit. Write operations populate both tiers simultaneously.
+/// Invalidation removes from both tiers.
+/// </remarks>
+public sealed class BlogPostCacheService : IBlogPostCacheService
+```
+
+---
+
+## README.md — Needed Updates
+
+The current `README.md` does **not** mention caching or Redis. The following two sections require updates once Sprint 5 is merged:
+
+### Technology Stack section
+
+Add entries for the caching layer:
+
+```markdown
+- **IMemoryCache** — L1 in-process cache (1-minute TTL per entry)
+- **Redis via .NET Aspire** — L2 distributed cache (5-minute TTL); provisioned by
+  `builder.AddRedis("redis")` in `AppHost`
+```
+
+Also update the stale line:
+
+```markdown
+- **In-Memory Repository** — No database (training project by design)
+```
+
+This is no longer accurate after the MongoDB migration (Sprint 4). It should read:
+
+```markdown
+- **MongoDB via EF Core Adapter** — Document store for blog posts,
+  accessed through `IDbContextFactory<BlogDbContext>`
+```
+
+### Features section
+
+No new user-visible features are introduced by the caching abstraction. No changes needed here.
+
+### Learning Objectives section
+
+Consider adding a seventh objective once Sprint 5 ships:
+
+```markdown
+7. **Two-Tier Caching** — L1 IMemoryCache + L2 Redis via IBlogPostCacheService abstraction,
+   cache invalidation on write, DRY cache key management with BlogPostCacheKeys
+```
+
+---
+
+*Stubs prepared by Frodo (Tech Writer) — Sprint 5, 2026-04-23*


### PR DESCRIPTION
## Summary

Working as Frodo (Tech Writer) · closes #114

Assessed documentation impact for the Sprint 5 `IBlogPostCacheService` extraction and produced two deliverables for the team.

## Changes

### `docs/adr/sprint5-caching-abstraction.md`
Architecture Decision Record documenting the decision to extract a dedicated `IBlogPostCacheService` interface from the four BlogPost CQRS handlers. Captures:
- **Context**: Inline duplication of L1/L2 cache options, `JsonSerializerOptions`, and hardcoded key strings across all handlers
- **Decision**: Introduce `IBlogPostCacheService`, `BlogPostCacheService`, and `BlogPostCacheKeys`
- **Status**: Accepted
- **Consequences**: DRY handlers, single-mock testability, one additional indirection layer

### `docs/sprint5-xml-doc-stubs.md`
Ready-to-paste XML doc comment stubs for Sam to apply when implementing:
- `IBlogPostCacheService` – all 6 interface methods (`GetAllAsync`, `SetAllAsync`, `GetByIdAsync`, `SetByIdAsync`, `RemoveAllAsync`, `RemoveByIdAsync`)
- `BlogPostCacheKeys` – class and two constant members
- `BlogPostCacheService` – class-level `<remarks>` block
- README.md update assessment: which sections need editing post-merge (Technology Stack, Learning Objectives)

## Notes

⚠️ README.md itself is **not** updated in this PR — the stubs file documents what needs to change so it can be done as part of the Sprint 5 merge or a follow-up. The README still references the old in-memory repository model; those lines should be updated when the caching layer lands.