### PR TITLE
fix(ci): fix YAML literal block scalar indentation in 3 workflows

### DIFF
--- a/.github/workflows/milestone-blog.yml
+++ b/.github/workflows/milestone-blog.yml
@@ -62,45 +62,45 @@ jobs:
         run: |
           BODY="## Milestone Review: ${MILESTONE_TITLE}
 
-Ralph, **${MILESTONE_TITLE}** has been closed with **${ISSUE_COUNT} issues** completed.
-Current latest release: \`${LAST_TAG}\`
+          Ralph, **${MILESTONE_TITLE}** has been closed with **${ISSUE_COUNT} issues** completed.
+          Current latest release: \`${LAST_TAG}\`
 
-### Closed Issues (${ISSUE_COUNT} total)
-${ISSUES_LIST}
+          ### Closed Issues (${ISSUE_COUNT} total)
+          ${ISSUES_LIST}
 
----
+          ---
 
-## 🔍 Release Candidate Checklist
+          ## 🔍 Release Candidate Checklist
 
-Review these criteria to decide between a full release or a blog-only post:
+          Review these criteria to decide between a full release or a blog-only post:
 
-| Criteria | Check |
-|----------|-------|
-| Contains user-facing features or enhancements? | (${FEATURE_COUNT} enhancement-labeled issues) |
-| Contains breaking changes or schema migrations? | Review issues above |
-| Significant enough to warrant a version bump? | Your call |
-| All CI gates green on \`main\`? | Check GitHub Actions |
-| Blog post needed either way? | **Yes — always** |
+          | Criteria | Check |
+          |----------|-------|
+          | Contains user-facing features or enhancements? | (${FEATURE_COUNT} enhancement-labeled issues) |
+          | Contains breaking changes or schema migrations? | Review issues above |
+          | Significant enough to warrant a version bump? | Your call |
+          | All CI gates green on \`main\`? | Check GitHub Actions |
+          | Blog post needed either way? | **Yes — always** |
 
----
+          ---
 
-## ✅ Your Decision
+          ## ✅ Your Decision
 
-**Option A — Release Candidate** (tag + GitHub Release + release blog post):
-> Add the label **\`release-candidate\`** to this issue.
-> Then choose the version bump type in the comment below (major / minor / patch).
+          **Option A — Release Candidate** (tag + GitHub Release + release blog post):
+          > Add the label **\`release-candidate\`** to this issue.
+          > Then choose the version bump type in the comment below (major / minor / patch).
 
-**Option B — Blog Only** (milestone summary blog post, no release):
-> Add the label **\`blog-only\`** to this issue.
+          **Option B — Blog Only** (milestone summary blog post, no release):
+          > Add the label **\`blog-only\`** to this issue.
 
-Either choice will automatically:
-- Trigger Bilbo to write the blog post
-- Update \`docs/blog/index.md\` (the blog page)
-- Sync \`README.md\` via the blog-readme-sync workflow
+          Either choice will automatically:
+          - Trigger Bilbo to write the blog post
+          - Update \`docs/blog/index.md\` (the blog page)
+          - Sync \`README.md\` via the blog-readme-sync workflow
 
----
+          ---
 
-*Triggered by milestone close at ${PUBLISH_DATE}. Workflow: \`milestone-blog.yml\`*"
+          *Triggered by milestone close at ${PUBLISH_DATE}. Workflow: \`milestone-blog.yml\`*"
 
           gh issue create \
             --title "📋 Milestone Review: ${MILESTONE_TITLE} — release or blog?" \

--- a/.github/workflows/milestone-release-decision.yml
+++ b/.github/workflows/milestone-release-decision.yml
@@ -63,12 +63,12 @@ jobs:
         run: |
           gh issue comment "$ISSUE_NUMBER" --body "✅ **Release flow triggered.**
 
-- Version bump: \`${BUMP}\`
-- \`squad-milestone-release.yml\` dispatched — this will create the tag, push it, and publish a GitHub Release.
-- \`release-blog.yml\` will fire automatically on release publish and create a \`squad:bilbo\` blog brief.
-- Once Bilbo's PR merges, \`blog-readme-sync.yml\` will update \`README.md\` (the Page).
+          - Version bump: \`${BUMP}\`
+          - \`squad-milestone-release.yml\` dispatched — this will create the tag, push it, and publish a GitHub Release.
+          - \`release-blog.yml\` will fire automatically on release publish and create a \`squad:bilbo\` blog brief.
+          - Once Bilbo's PR merges, \`blog-readme-sync.yml\` will update \`README.md\` (the Page).
 
-Closing this review issue."
+          Closing this review issue."
 
           gh issue close "$ISSUE_NUMBER" --reason completed
 
@@ -109,25 +109,25 @@ Closing this review issue."
         run: |
           BODY="## Blog Post Brief: ${MILESTONE_TITLE}
 
-Bilbo, Ralph has reviewed the **${MILESTONE_TITLE}** milestone and decided: **blog post only** (no release).
+          Bilbo, Ralph has reviewed the **${MILESTONE_TITLE}** milestone and decided: **blog post only** (no release).
 
-### Post metadata
-- **Suggested filename:** \`docs/blog/${PUBLISH_DATE}-${SLUG}.md\`
-- **Suggested publish date:** ${PUBLISH_DATE}
-- **Review issue:** ${REVIEW_ISSUE_URL} (see for full issue list)
+          ### Post metadata
+          - **Suggested filename:** \`docs/blog/${PUBLISH_DATE}-${SLUG}.md\`
+          - **Suggested publish date:** ${PUBLISH_DATE}
+          - **Review issue:** ${REVIEW_ISSUE_URL} (see for full issue list)
 
-### Suggested post structure
-1. **Summary** — what this milestone accomplished (2–3 sentences)
-2. **What was built** — key features, fixes, or improvements with context
-3. **Technical highlights** — architecture decisions, tricky problems solved, patterns introduced
-4. **What's next** — follow-up work planned
+          ### Suggested post structure
+          1. **Summary** — what this milestone accomplished (2–3 sentences)
+          2. **What was built** — key features, fixes, or improvements with context
+          3. **Technical highlights** — architecture decisions, tricky problems solved, patterns introduced
+          4. **What's next** — follow-up work planned
 
-### Instructions
-- Write the post to \`docs/blog/${PUBLISH_DATE}-${SLUG}.md\`
-- Update \`docs/blog/index.md\` to add the new post at the top of the Recent Posts table
-- Follow existing post style (see \`docs/blog/2026-04-04-release-v0-7-0.md\`)
-- Open a PR targeting \`main\` when complete
-- Close both this issue and the review issue (#${REVIEW_ISSUE_NUMBER}) in the PR description"
+          ### Instructions
+          - Write the post to \`docs/blog/${PUBLISH_DATE}-${SLUG}.md\`
+          - Update \`docs/blog/index.md\` to add the new post at the top of the Recent Posts table
+          - Follow existing post style (see \`docs/blog/2026-04-04-release-v0-7-0.md\`)
+          - Open a PR targeting \`main\` when complete
+          - Close both this issue and the review issue (#${REVIEW_ISSUE_NUMBER}) in the PR description"
 
           gh issue create \
             --title "Blog post: ${MILESTONE_TITLE} — milestone recap" \
@@ -141,10 +141,10 @@ Bilbo, Ralph has reviewed the **${MILESTONE_TITLE}** milestone and decided: **bl
         run: |
           gh issue comment "$ISSUE_NUMBER" --body "📝 **Blog-only path selected.**
 
-A \`squad:bilbo\` blog brief issue has been created. Once Bilbo's PR merges:
-- \`docs/blog/index.md\` will be updated (the blog page)
-- \`blog-readme-sync.yml\` will update \`README.md\` (the Page)
+          A \`squad:bilbo\` blog brief issue has been created. Once Bilbo's PR merges:
+          - \`docs/blog/index.md\` will be updated (the blog page)
+          - \`blog-readme-sync.yml\` will update \`README.md\` (the Page)
 
-Closing this review issue."
+          Closing this review issue."
 
           gh issue close "$ISSUE_NUMBER" --reason completed

--- a/.github/workflows/release-blog.yml
+++ b/.github/workflows/release-blog.yml
@@ -46,31 +46,31 @@ jobs:
         run: |
           BODY="## Blog Post Brief: ${RELEASE_NAME}
 
-Bilbo, a new GitHub Release has been published. Please write a dev blog post for **${RELEASE_NAME}**.
+          Bilbo, a new GitHub Release has been published. Please write a dev blog post for **${RELEASE_NAME}**.
 
-### Post metadata
-- **Suggested filename:** \`docs/blog/${PUBLISH_DATE}-release-${SLUG}.md\`
-- **Suggested publish date:** ${PUBLISH_DATE}
-- **Release:** [${TAG}](${RELEASE_URL})
-- **Changelog range:** [\`${PREV_TAG}...${TAG}\`](https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${TAG})
+          ### Post metadata
+          - **Suggested filename:** \`docs/blog/${PUBLISH_DATE}-release-${SLUG}.md\`
+          - **Suggested publish date:** ${PUBLISH_DATE}
+          - **Release:** [${TAG}](${RELEASE_URL})
+          - **Changelog range:** [\`${PREV_TAG}...${TAG}\`](https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${TAG})
 
-### Release notes
-$(gh api "repos/${{ github.repository }}/releases/tags/${TAG}" --jq '.body // "No release notes provided."')
+          ### Release notes
+          $(gh api "repos/${{ github.repository }}/releases/tags/${TAG}" --jq '.body // "No release notes provided."')
 
-### Suggested post structure
-1. **Summary** — what this release delivers in 2–3 sentences
-2. **What's New** — feature sections with code snippets and context
-3. **Bug Fixes / Improvements** — notable fixes
-4. **How to Upgrade** — any steps required (migrations, config changes)
-5. **Stats** — test counts, coverage numbers, PR count
-6. **What's Next** — upcoming work
+          ### Suggested post structure
+          1. **Summary** — what this release delivers in 2–3 sentences
+          2. **What's New** — feature sections with code snippets and context
+          3. **Bug Fixes / Improvements** — notable fixes
+          4. **How to Upgrade** — any steps required (migrations, config changes)
+          5. **Stats** — test counts, coverage numbers, PR count
+          6. **What's Next** — upcoming work
 
-### Instructions
-- Write the post to \`docs/blog/${PUBLISH_DATE}-release-${SLUG}.md\`
-- Update \`docs/blog/index.md\` to add the new post at the top of the Recent Posts table
-- Follow existing post style (see \`docs/blog/2026-04-04-release-v0-7-0.md\`)
-- Open a PR targeting \`main\` when complete
-- Close this issue in the PR description with \`Closes #<this-issue>\`"
+          ### Instructions
+          - Write the post to \`docs/blog/${PUBLISH_DATE}-release-${SLUG}.md\`
+          - Update \`docs/blog/index.md\` to add the new post at the top of the Recent Posts table
+          - Follow existing post style (see \`docs/blog/2026-04-04-release-v0-7-0.md\`)
+          - Open a PR targeting \`main\` when complete
+          - Close this issue in the PR description with \`Closes #<this-issue>\`"
 
           gh issue create \
             --title "Blog post: ${RELEASE_NAME} — release recap" \


### PR DESCRIPTION
## Summary

Working as Boromir (DevOps Engineer)

Closes #123

Fixes YAML parse failures in three GitHub Actions workflows that have been silently failing since the Sprint 5 merge (PR #122).

## Root Cause

All three workflows use `run: |` (YAML literal block scalars) where multi-line bash body strings drop to column 0 inside the block. The block indentation level is 10 spaces (set by the first content line). Any **non-empty** line at column 0 terminates the YAML block, causing a parse error **before any job starts**.

Evidence:
- Zero jobs ran for all 3 failing runs (`total_count: 0, jobs: []`)
- Run `name` showed the file path instead of the workflow's `name:` field (GitHub couldn't parse past the error)
- All three runs show `event: push` because GitHub registers new workflow files on the first push to `main`

## Fix

Added the required 10-space block indentation prefix to all col-0 non-empty content lines within each `run: |` block. YAML strips exactly the block-indent level from each line during parse, so **the resulting bash script content is semantically identical** — no behavior change.

## Files Changed

| File | Error location | Lines fixed |
|------|---------------|-------------|
| `release-blog.yml` | line 49, col 1 | 17 lines in BODY string |
| `milestone-blog.yml` | line 65, col 1 | 25 lines in BODY string |
| `milestone-release-decision.yml` | lines 66, 112, 144 | 18 lines across 3 run blocks |

## squad-release.yml Status

This workflow (tag push trigger) validated OK and was **intentionally** not triggered for v1.2.0 — GitHub's anti-loop protection prevents `push: tags` workflows from firing when the tag is pushed by a GITHUB_TOKEN workflow run. The v1.2.0 release was correctly created by `squad-milestone-release.yml`.

## Verification

```
python3 -c 'import yaml; [yaml.safe_load(open(f).read()) for f in ["release-blog.yml", "milestone-blog.yml", "milestone-release-decision.yml"]]'
# No errors — all 3 files parse cleanly
```
