### PR TITLE
chore: promote dev → main — docs post-release update v1.2.0

### DIFF
--- a/.github/workflows/milestone-blog.yml
+++ b/.github/workflows/milestone-blog.yml
@@ -62,45 +62,45 @@ jobs:
         run: |
           BODY="## Milestone Review: ${MILESTONE_TITLE}
 
-Ralph, **${MILESTONE_TITLE}** has been closed with **${ISSUE_COUNT} issues** completed.
-Current latest release: \`${LAST_TAG}\`
+          Ralph, **${MILESTONE_TITLE}** has been closed with **${ISSUE_COUNT} issues** completed.
+          Current latest release: \`${LAST_TAG}\`
 
-### Closed Issues (${ISSUE_COUNT} total)
-${ISSUES_LIST}
+          ### Closed Issues (${ISSUE_COUNT} total)
+          ${ISSUES_LIST}
 
----
+          ---
 
-## 🔍 Release Candidate Checklist
+          ## 🔍 Release Candidate Checklist
 
-Review these criteria to decide between a full release or a blog-only post:
+          Review these criteria to decide between a full release or a blog-only post:
 
-| Criteria | Check |
-|----------|-------|
-| Contains user-facing features or enhancements? | (${FEATURE_COUNT} enhancement-labeled issues) |
-| Contains breaking changes or schema migrations? | Review issues above |
-| Significant enough to warrant a version bump? | Your call |
-| All CI gates green on \`main\`? | Check GitHub Actions |
-| Blog post needed either way? | **Yes — always** |
+          | Criteria | Check |
+          |----------|-------|
+          | Contains user-facing features or enhancements? | (${FEATURE_COUNT} enhancement-labeled issues) |
+          | Contains breaking changes or schema migrations? | Review issues above |
+          | Significant enough to warrant a version bump? | Your call |
+          | All CI gates green on \`main\`? | Check GitHub Actions |
+          | Blog post needed either way? | **Yes — always** |
 
----
+          ---
 
-## ✅ Your Decision
+          ## ✅ Your Decision
 
-**Option A — Release Candidate** (tag + GitHub Release + release blog post):
-> Add the label **\`release-candidate\`** to this issue.
-> Then choose the version bump type in the comment below (major / minor / patch).
+          **Option A — Release Candidate** (tag + GitHub Release + release blog post):
+          > Add the label **\`release-candidate\`** to this issue.
+          > Then choose the version bump type in the comment below (major / minor / patch).
 
-**Option B — Blog Only** (milestone summary blog post, no release):
-> Add the label **\`blog-only\`** to this issue.
+          **Option B — Blog Only** (milestone summary blog post, no release):
+          > Add the label **\`blog-only\`** to this issue.
 
-Either choice will automatically:
-- Trigger Bilbo to write the blog post
-- Update \`docs/blog/index.md\` (the blog page)
-- Sync \`README.md\` via the blog-readme-sync workflow
+          Either choice will automatically:
+          - Trigger Bilbo to write the blog post
+          - Update \`docs/blog/index.md\` (the blog page)
+          - Sync \`README.md\` via the blog-readme-sync workflow
 
----
+          ---
 
-*Triggered by milestone close at ${PUBLISH_DATE}. Workflow: \`milestone-blog.yml\`*"
+          *Triggered by milestone close at ${PUBLISH_DATE}. Workflow: \`milestone-blog.yml\`*"
 
           gh issue create \
             --title "📋 Milestone Review: ${MILESTONE_TITLE} — release or blog?" \

--- a/.github/workflows/milestone-release-decision.yml
+++ b/.github/workflows/milestone-release-decision.yml
@@ -63,12 +63,12 @@ jobs:
         run: |
           gh issue comment "$ISSUE_NUMBER" --body "✅ **Release flow triggered.**
 
-- Version bump: \`${BUMP}\`
-- \`squad-milestone-release.yml\` dispatched — this will create the tag, push it, and publish a GitHub Release.
-- \`release-blog.yml\` will fire automatically on release publish and create a \`squad:bilbo\` blog brief.
-- Once Bilbo's PR merges, \`blog-readme-sync.yml\` will update \`README.md\` (the Page).
+          - Version bump: \`${BUMP}\`
+          - \`squad-milestone-release.yml\` dispatched — this will create the tag, push it, and publish a GitHub Release.
+          - \`release-blog.yml\` will fire automatically on release publish and create a \`squad:bilbo\` blog brief.
+          - Once Bilbo's PR merges, \`blog-readme-sync.yml\` will update \`README.md\` (the Page).
 
-Closing this review issue."
+          Closing this review issue."
 
           gh issue close "$ISSUE_NUMBER" --reason completed
 
@@ -109,25 +109,25 @@ Closing this review issue."
         run: |
           BODY="## Blog Post Brief: ${MILESTONE_TITLE}
 
-Bilbo, Ralph has reviewed the **${MILESTONE_TITLE}** milestone and decided: **blog post only** (no release).
+          Bilbo, Ralph has reviewed the **${MILESTONE_TITLE}** milestone and decided: **blog post only** (no release).
 
-### Post metadata
-- **Suggested filename:** \`docs/blog/${PUBLISH_DATE}-${SLUG}.md\`
-- **Suggested publish date:** ${PUBLISH_DATE}
-- **Review issue:** ${REVIEW_ISSUE_URL} (see for full issue list)
+          ### Post metadata
+          - **Suggested filename:** \`docs/blog/${PUBLISH_DATE}-${SLUG}.md\`
+          - **Suggested publish date:** ${PUBLISH_DATE}
+          - **Review issue:** ${REVIEW_ISSUE_URL} (see for full issue list)
 
-### Suggested post structure
-1. **Summary** — what this milestone accomplished (2–3 sentences)
-2. **What was built** — key features, fixes, or improvements with context
-3. **Technical highlights** — architecture decisions, tricky problems solved, patterns introduced
-4. **What's next** — follow-up work planned
+          ### Suggested post structure
+          1. **Summary** — what this milestone accomplished (2–3 sentences)
+          2. **What was built** — key features, fixes, or improvements with context
+          3. **Technical highlights** — architecture decisions, tricky problems solved, patterns introduced
+          4. **What's next** — follow-up work planned
 
-### Instructions
-- Write the post to \`docs/blog/${PUBLISH_DATE}-${SLUG}.md\`
-- Update \`docs/blog/index.md\` to add the new post at the top of the Recent Posts table
-- Follow existing post style (see \`docs/blog/2026-04-04-release-v0-7-0.md\`)
-- Open a PR targeting \`main\` when complete
-- Close both this issue and the review issue (#${REVIEW_ISSUE_NUMBER}) in the PR description"
+          ### Instructions
+          - Write the post to \`docs/blog/${PUBLISH_DATE}-${SLUG}.md\`
+          - Update \`docs/blog/index.md\` to add the new post at the top of the Recent Posts table
+          - Follow existing post style (see \`docs/blog/2026-04-04-release-v0-7-0.md\`)
+          - Open a PR targeting \`main\` when complete
+          - Close both this issue and the review issue (#${REVIEW_ISSUE_NUMBER}) in the PR description"
 
           gh issue create \
             --title "Blog post: ${MILESTONE_TITLE} — milestone recap" \
@@ -141,10 +141,10 @@ Bilbo, Ralph has reviewed the **${MILESTONE_TITLE}** milestone and decided: **bl
         run: |
           gh issue comment "$ISSUE_NUMBER" --body "📝 **Blog-only path selected.**
 
-A \`squad:bilbo\` blog brief issue has been created. Once Bilbo's PR merges:
-- \`docs/blog/index.md\` will be updated (the blog page)
-- \`blog-readme-sync.yml\` will update \`README.md\` (the Page)
+          A \`squad:bilbo\` blog brief issue has been created. Once Bilbo's PR merges:
+          - \`docs/blog/index.md\` will be updated (the blog page)
+          - \`blog-readme-sync.yml\` will update \`README.md\` (the Page)
 
-Closing this review issue."
+          Closing this review issue."
 
           gh issue close "$ISSUE_NUMBER" --reason completed

--- a/.github/workflows/release-blog.yml
+++ b/.github/workflows/release-blog.yml
@@ -46,31 +46,31 @@ jobs:
         run: |
           BODY="## Blog Post Brief: ${RELEASE_NAME}
 
-Bilbo, a new GitHub Release has been published. Please write a dev blog post for **${RELEASE_NAME}**.
+          Bilbo, a new GitHub Release has been published. Please write a dev blog post for **${RELEASE_NAME}**.
 
-### Post metadata
-- **Suggested filename:** \`docs/blog/${PUBLISH_DATE}-release-${SLUG}.md\`
-- **Suggested publish date:** ${PUBLISH_DATE}
-- **Release:** [${TAG}](${RELEASE_URL})
-- **Changelog range:** [\`${PREV_TAG}...${TAG}\`](https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${TAG})
+          ### Post metadata
+          - **Suggested filename:** \`docs/blog/${PUBLISH_DATE}-release-${SLUG}.md\`
+          - **Suggested publish date:** ${PUBLISH_DATE}
+          - **Release:** [${TAG}](${RELEASE_URL})
+          - **Changelog range:** [\`${PREV_TAG}...${TAG}\`](https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${TAG})
 
-### Release notes
-$(gh api "repos/${{ github.repository }}/releases/tags/${TAG}" --jq '.body // "No release notes provided."')
+          ### Release notes
+          $(gh api "repos/${{ github.repository }}/releases/tags/${TAG}" --jq '.body // "No release notes provided."')
 
-### Suggested post structure
-1. **Summary** — what this release delivers in 2–3 sentences
-2. **What's New** — feature sections with code snippets and context
-3. **Bug Fixes / Improvements** — notable fixes
-4. **How to Upgrade** — any steps required (migrations, config changes)
-5. **Stats** — test counts, coverage numbers, PR count
-6. **What's Next** — upcoming work
+          ### Suggested post structure
+          1. **Summary** — what this release delivers in 2–3 sentences
+          2. **What's New** — feature sections with code snippets and context
+          3. **Bug Fixes / Improvements** — notable fixes
+          4. **How to Upgrade** — any steps required (migrations, config changes)
+          5. **Stats** — test counts, coverage numbers, PR count
+          6. **What's Next** — upcoming work
 
-### Instructions
-- Write the post to \`docs/blog/${PUBLISH_DATE}-release-${SLUG}.md\`
-- Update \`docs/blog/index.md\` to add the new post at the top of the Recent Posts table
-- Follow existing post style (see \`docs/blog/2026-04-04-release-v0-7-0.md\`)
-- Open a PR targeting \`main\` when complete
-- Close this issue in the PR description with \`Closes #<this-issue>\`"
+          ### Instructions
+          - Write the post to \`docs/blog/${PUBLISH_DATE}-release-${SLUG}.md\`
+          - Update \`docs/blog/index.md\` to add the new post at the top of the Recent Posts table
+          - Follow existing post style (see \`docs/blog/2026-04-04-release-v0-7-0.md\`)
+          - Open a PR targeting \`main\` when complete
+          - Close this issue in the PR description with \`Closes #<this-issue>\`"
 
           gh issue create \
             --title "Blog post: ${RELEASE_NAME} — release recap" \

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ MyBlog is a Blazor Server blog application demonstrating modern .NET patterns: A
 ## Technology Stack
 
 - **.NET 10** with **C# 14**
-- **.NET Aspire 13.2.2** — Service orchestration, MongoDB + Redis resources, health checks
+- **.NET Aspire 13.2.3** — Service orchestration, MongoDB + Redis resources, health checks
 - **Blazor Server (Interactive Server Rendering)** — Dynamic UI with TailwindCSS v4 theming
 - **MongoDB** with **MongoDB.EntityFrameworkCore** — Blog post persistence
 - **Redis** — Distributed caching (L2 cache via `IDistributedCache`)
@@ -162,6 +162,18 @@ dotnet test
 - [SECURITY.md](docs/SECURITY.md) — Security guidelines
 - [CODE_OF_CONDUCT.md](docs/CODE_OF_CONDUCT.md) — Community standards
 - [REFERENCES.md](docs/REFERENCES.md) — NuGet and npm package references
+
+## Dev Blog
+
+<!-- BLOG_START -->
+| Date | Title | Tags |
+|------|-------|------|
+| 2026-04-24 | [Release: v1.2.0 — Redis Caching and L1/L2 Cache Strategy](docs/blog/2026-04-24-release-v1-2-0.md) | release, v1.2.0, redis, caching, aspire, sprint-5 |
+| 2026-04-24 | [Release: v1.1.0 — Blazor Theme System with TailwindCSS v4](docs/blog/2026-04-24-release-v1-1-0.md) | release, v1.1.0, blazor, tailwind, theme, testing, sprint-4 |
+| 2026-04-20 | [Release: v1.0.0 — Semantic Versioning and Production Readiness](docs/blog/2026-04-20-release-v1-0-0.md) | release, semver, ci, devops |
+| 2026-04-20 | [Sprint 3: E2E Testing and CI Hardening](docs/blog/2026-04-20-sprint-3-e2e-tests-ci-hardening.md) | e2e, aspire, ci, testing, sprint-3 |
+| 2026-04-20 | [Sprint 2: CQRS and MediatR Deep Dive](docs/blog/2026-04-20-sprint-2-cqrs-mediatr.md) | cqrs, mediatr, testing, domain, sprint-2 |
+<!-- BLOG_END -->
 
 ## Release History
 

--- a/README.md
+++ b/README.md
@@ -4,56 +4,82 @@ A hands-on learning project for .NET Aspire orchestration, Blazor Server renderi
 
 [![.NET 10](https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet)](https://dotnet.microsoft.com/)
 [![MIT License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![xUnit Tests](https://img.shields.io/badge/Tests-xUnit-blueviolet?logo=github)](https://github.com/mpaulosky/MyBlog/actions/workflows/squad-ci.yml)
+[![Latest Release](https://img.shields.io/github/v/release/mpaulosky/MyBlog?logo=github&color=blue&label=Release)](https://github.com/mpaulosky/MyBlog/releases/latest)
+
+[![CI/CD](https://github.com/mpaulosky/MyBlog/actions/workflows/squad-ci.yml/badge.svg)](https://github.com/mpaulosky/MyBlog/actions/workflows/squad-ci.yml)
+[![Test Suite](https://github.com/mpaulosky/MyBlog/actions/workflows/squad-test.yml/badge.svg)](https://github.com/mpaulosky/MyBlog/actions/workflows/squad-test.yml)
+
+[![CodeCov Coverage](https://codecov.io/gh/mpaulosky/MyBlog/branch/main/graph/badge.svg)](https://codecov.io/gh/mpaulosky/MyBlog)
+[![Coverage Trend](https://img.shields.io/badge/Coverage-Trend-blue?logo=codecov)](https://codecov.io/gh/mpaulosky/MyBlog/commits/main)
+[![Coverage Gate](https://img.shields.io/badge/Coverage%20Gate-≥80%25-brightgreen?logo=codecov)](https://github.com/mpaulosky/MyBlog/actions/workflows/squad-test.yml)
+
+[![Open Issues](https://img.shields.io/github/issues/mpaulosky/MyBlog?color=0366d6)](https://github.com/mpaulosky/MyBlog/issues?q=is%3Aopen+is%3Aissue)
+[![Closed Issues](https://img.shields.io/github/issues-closed/mpaulosky/MyBlog?color=6f42c1)](https://github.com/mpaulosky/MyBlog/issues?q=is%3Aclosed+is%3Aissue)
+[![Open PRs](https://img.shields.io/github/issues-pr/mpaulosky/MyBlog?color=28a745)](https://github.com/mpaulosky/MyBlog/pulls?q=is%3Aopen+is%3Apr)
+[![Closed PRs](https://img.shields.io/github/issues-pr-closed/mpaulosky/MyBlog?color=6f42c1)](https://github.com/mpaulosky/MyBlog/pulls?q=is%3Aclosed+is%3Apr)
 
 > ⚠️ **Training Project** — This is a learning exercise focused on .NET practices, not a production application.
 
 ## Overview
 
-MyBlog is a simple blog application demonstrating core .NET concepts: .NET Aspire orchestration, Blazor Server for interactive server rendering, clean architecture with domain/web layer separation, and test-driven development.
+MyBlog is a Blazor Server blog application demonstrating modern .NET patterns: Aspire orchestration, CQRS with MediatR, MongoDB persistence, Redis distributed caching, Auth0 authentication, TailwindCSS v4 theming, and comprehensive testing (unit, architecture, integration, bUnit, E2E).
 
 ## Features
 
-- **List Blog Posts** — View all published and draft posts with metadata
-- **Create Posts** — New posts start in draft status
-- **Edit Posts** — Update title and content anytime
-- **Delete with Confirmation** — ConfirmDeleteDialog component prevents accidental deletions
-- **Publish/Unpublish** — Toggle post publication status
+- **Blog Management**: Create, edit, delete, publish/unpublish blog posts
+- **CQRS with MediatR**: All blog operations handled by MediatR command/query handlers with FluentValidation pipeline
+- **Redis Caching**: L1 (in-memory) + L2 (Redis distributed) cache via `IBlogPostCacheService` abstraction
+- **Auth0 Authentication**: Secure login with Authorization Code + PKCE flow; Role-Based Authorization (Admin/User policies)
+- **Blazor TailwindCSS Theming**: Dark/light/system modes, 4 color schemes (Blue, Red, Green, Yellow), localStorage persistence
+- **Aspire Orchestration**: MongoDB + Redis as Aspire resources with health checks and OpenTelemetry
 
 ## Technology Stack
 
 - **.NET 10** with **C# 14**
-- **.NET Aspire 13.2.2** — Service orchestration and health checks
-- **Blazor Server (Interactive Server Rendering)** — Dynamic UI
-- **xUnit** — Test framework
-- **FluentAssertions** — Assertion library
+- **.NET Aspire 13.2.2** — Service orchestration, MongoDB + Redis resources, health checks
+- **Blazor Server (Interactive Server Rendering)** — Dynamic UI with TailwindCSS v4 theming
+- **MongoDB** with **MongoDB.EntityFrameworkCore** — Blog post persistence
+- **Redis** — Distributed caching (L2 cache via `IDistributedCache`)
+- **MediatR** — CQRS pattern (Create/Update/Delete/GetAll/GetById handlers)
+- **FluentValidation** — Validation pipeline behavior
+- **Auth0** — Authentication + role-based authorization
+- **xUnit** + **FluentAssertions** + **NSubstitute** — Test framework
+- **bUnit** — Blazor component testing
 - **NetArchTest.Rules** — Architecture validation
-- **NSubstitute** — Mocking framework
-- **In-Memory Repository** — No database (training project by design)
 
 ## Project Structure
 
 ```
 MyBlog/
 ├── src/
-│   ├── AppHost/              # .NET Aspire orchestration entry point
-│   ├── Domain/               # BlogPost entity, IBlogPostRepository, InMemoryBlogPostRepository
-│   ├── ServiceDefaults/      # Shared Aspire concerns (OpenTelemetry, health checks)
+│   ├── AppHost/              # .NET Aspire orchestration (MongoDB + Redis resources)
+│   ├── Domain/               # BlogPost entity, MediatR handlers, validators, IBlogPostCacheService
+│   │   ├── Abstractions/     # Result<T>, IBlogPostRepository, IBlogPostCacheService
+│   │   ├── Behaviors/        # ValidationBehavior MediatR pipeline
+│   │   ├── Entities/         # BlogPost domain entity
+│   │   └── Interfaces/       # Repository and cache interfaces
+│   ├── ServiceDefaults/      # OpenTelemetry, health checks, Aspire extensions
 │   └── Web/                  # Blazor Server application
-│       └── Components/
-│           ├── Pages/BlogPosts/  # Index, Create, Edit pages
-│           ├── Pages/            # Home, Error, NotFound
-│           ├── Shared/           # ConfirmDeleteDialog
-│           └── Layout/           # MainLayout, NavMenu, ReconnectModal
+│       ├── Features/BlogPosts/  # Vertical slice: commands, queries, Blazor pages
+│       ├── Infrastructure/Caching/  # BlogPostCacheService (L1+L2 implementation)
+│       ├── Components/Theme/ # TailwindCSS theme components
+│       ├── Security/         # Auth0 endpoints
+│       └── Styles/           # TailwindCSS input.css
 ├── tests/
-│   ├── Unit.Tests/           # 7 unit tests (BlogPost, Repository)
-│   ├── Architecture.Tests/    # 2 architecture tests (layer rules)
-│   └── Integration.Tests/     # Stubbed for future Aspire integration
-├── docs/                     # Documentation
+│   ├── Unit.Tests/           # Domain entity + handler unit tests
+│   ├── Architecture.Tests/   # Layer dependency enforcement
+│   ├── Integration.Tests/    # Aspire integration tests
+│   ├── AppHost.Tests/        # Aspire AppHost + E2E tests
+│   ├── Web.Tests/            # Web layer unit tests
+│   ├── Web.Tests.Bunit/      # Blazor component tests (bUnit)
+│   └── Web.Tests.Integration/# Web integration tests
+├── docs/                     # Documentation + GitHub Pages blog
 ├── Directory.Build.props     # Centralized build settings
-├── global.json               # SDK version lock
-├── GitVersion.yml            # Versioning config
-├── MyBlog.slnx               # Solution file
-└── README.md
+├── Directory.Packages.props  # Centralized NuGet versioning (CPM)
+├── global.json               # SDK version lock (.NET 10.0.202)
+├── GitVersion.yml            # Semantic versioning config
+└── MyBlog.slnx               # Solution file
 ```
 
 ## Getting Started
@@ -61,7 +87,10 @@ MyBlog/
 ### Prerequisites
 
 - **.NET 10 SDK** — [Download](https://dotnet.microsoft.com/en-us/download)
-- **Auth0 account** — required for authentication (free tier works). See [AUTH0_SETUP.md](docs/AUTH0_SETUP.md) for full setup instructions.
+- **Node.js 18+** — for TailwindCSS compilation
+- **Auth0 account** — required for authentication (free tier). See [AUTH0_SETUP.md](docs/AUTH0_SETUP.md)
+- **MongoDB** — MongoDB Atlas or local instance (or let Aspire provision via Docker)
+- **Redis** — Redis instance (or let Aspire provision via Docker)
 
 ### Setup
 
@@ -78,19 +107,25 @@ MyBlog/
    dotnet restore
    ```
 
-3. **Build the solution**
+3. **Install npm dependencies** (for TailwindCSS)
+
+   ```bash
+   npm install
+   ```
+
+4. **Build the solution**
 
    ```bash
    dotnet build
    ```
 
-4. **Run tests**
+5. **Run tests**
 
    ```bash
    dotnet test
    ```
 
-5. **Run the application** (via Aspire AppHost)
+6. **Run the application** (via Aspire AppHost)
 
    ```bash
    cd src/AppHost
@@ -101,11 +136,15 @@ MyBlog/
 
 ## Testing
 
-All 9 tests pass. Test structure:
+Multiple test tiers, all passing:
 
-- **Unit.Tests/** — Entity logic and repository behavior (7 tests)
-- **Architecture.Tests/** — Layer dependency enforcement (2 tests)
-- **Integration.Tests/** — Placeholder for future Aspire integration tests
+- **Unit.Tests** — Domain entity logic and MediatR handler behavior
+- **Architecture.Tests** — Layer dependency enforcement
+- **Integration.Tests** — Aspire integration tests
+- **AppHost.Tests** — .NET Aspire host + E2E tests
+- **Web.Tests** — Web layer unit tests
+- **Web.Tests.Bunit** — Blazor component tests (bUnit)
+- **Web.Tests.Integration** — Web integration tests
 
 Run all tests:
 
@@ -113,22 +152,25 @@ Run all tests:
 dotnet test
 ```
 
-## Learning Objectives
-
-This project teaches:
-
-1. **.NET Aspire** — Service orchestration, resource composition, health checks
-2. **Blazor Server** — Interactive server rendering, component models, form handling
-3. **Clean Architecture** — Domain/Web layer separation, repository pattern
-4. **Test-Driven Development** — Unit tests, architecture tests, xUnit/FluentAssertions
-5. **Entity Design** — Factory methods, immutable updates, domain logic
-6. **Short Naming** — Repository-level context (MyBlog) vs project names (AppHost, Domain, Web)
-
 ## Documentation
 
 - [ARCHITECTURE.md](docs/ARCHITECTURE.md) — Solution structure, layer diagram, design decisions
 - [CONTRIBUTING.md](docs/CONTRIBUTING.md) — Contribution guidelines and project setup
 - [AUTH0_SETUP.md](docs/AUTH0_SETUP.md) — Step-by-step Auth0 configuration for local development
+- [TESTING.md](docs/TESTING.md) — Test strategy and running instructions
+- [THEMING.md](docs/THEMING.md) — TailwindCSS theme system guide
+- [SECURITY.md](docs/SECURITY.md) — Security guidelines
+- [CODE_OF_CONDUCT.md](docs/CODE_OF_CONDUCT.md) — Community standards
+- [REFERENCES.md](docs/REFERENCES.md) — NuGet and npm package references
+
+## Release History
+
+| Version | Date | Highlights |
+|---------|------|------------|
+| [v1.2.0](https://github.com/mpaulosky/MyBlog/releases/tag/v1.2.0) | 2026-04-24 | **Redis & Caching** — IBlogPostCacheService L1+L2, handler cache integration |
+| [v1.1.0](https://github.com/mpaulosky/MyBlog/releases/tag/v1.1.0) | 2026-04-24 | **Themes & Testing** — TailwindCSS v4 themes, test project reorganization, E2E fixes |
+| [v1.0.1](https://github.com/mpaulosky/MyBlog/releases/tag/v1.0.1) | 2026-04-20 | Automatic semver versioning enabled |
+| [v1.0.0](https://github.com/mpaulosky/MyBlog/releases/tag/v1.0.0) | 2026-04-20 | First semantic version release |
 
 ## License
 
@@ -136,4 +178,4 @@ Licensed under the MIT License. See [LICENSE](LICENSE) file for details.
 
 ---
 
-**Status**: Training Project | **.NET 10** | **Maintained by**: @mpaulosky
+**Status**: Training Project | **.NET 10** | **v1.2.0** | **Maintained by**: @mpaulosky

--- a/docs/blog/2026-04-18-myblog-project-kickoff.md
+++ b/docs/blog/2026-04-18-myblog-project-kickoff.md
@@ -14,7 +14,7 @@ MyBlog begins with a strong architectural foundation. Built on the Blazor Server
 
 When starting a new project, the first decisions matter. We chose:
 - **Blazor Server** for rapid, interactive web development with C#
-- **.NET 10** and **.NET Aspire 13.2.2** for modern, cloud-native capabilities
+- **.NET 10** and **.NET Aspire 13.2.3** for modern, cloud-native capabilities
 - **Clean architecture** with vertical slices to keep code organized and testable as the project grows
 - **In-memory persistence** initially to keep things simple while we establish patterns
 

--- a/docs/blog/2026-04-18-myblog-project-kickoff.md
+++ b/docs/blog/2026-04-18-myblog-project-kickoff.md
@@ -1,0 +1,69 @@
+---
+title: "MyBlog Project Kickoff: Building with .NET 10 and Clean Architecture"
+date: 2026-04-18
+author: Bilbo
+tags: [aspire, blazor, clean-architecture, sprint-1]
+summary: "The MyBlog project launches with a solid foundation: Blazor Server, .NET Aspire, and clean architecture—ready for modern web development."
+---
+
+## Summary
+
+MyBlog begins with a strong architectural foundation. Built on the Blazor Server template, the project spans five well-organized projects: AppHost for orchestration, Domain for business logic, ServiceDefaults for shared infrastructure, and Web for the UI layer. Sprint 1 focused on removing template clutter, adding proper copyright headers, and establishing the first data model with in-memory persistence. The suite passes 74 tests across Architecture, Unit, and Integration layers.
+
+## Context
+
+When starting a new project, the first decisions matter. We chose:
+- **Blazor Server** for rapid, interactive web development with C#
+- **.NET 10** and **.NET Aspire 13.2.2** for modern, cloud-native capabilities
+- **Clean architecture** with vertical slices to keep code organized and testable as the project grows
+- **In-memory persistence** initially to keep things simple while we establish patterns
+
+This foundation lets us move fast without technical debt.
+
+## Key Details
+
+### Project Structure
+```
+MyBlog/
+├── AppHost/              # .NET Aspire orchestration
+├── Domain/               # Business logic + entities
+├── ServiceDefaults/      # Shared configs
+├── Web/                  # Blazor Server UI
+└── Tests/
+    ├── Architecture.Tests/
+    ├── Unit.Tests/
+    └── Integration.Tests/
+```
+
+### Early PRs
+- **PR #6:** Removed demo Blazor components (Counter, Weather)
+- **PR #7:** Added MIT license headers to all C# files
+
+### Data Model
+The `BlogPost` entity is simple but functional:
+```csharp
+public class BlogPost
+{
+    public int Id { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}
+```
+
+With an in-memory repository backing the initial feature set.
+
+### Test Coverage
+- **74 tests passing** across three test projects
+- Architecture tests enforce layer dependencies
+- Unit tests cover business logic
+- Integration tests verify the persistence layer
+
+## What's Next
+
+Sprint 2 introduces CQRS and MediatR to establish a robust command/query pattern. The in-memory repository will be joined by validation handlers and a proper vertical slice structure.
+
+---
+
+*Posted by Bilbo • Sprint 1 Foundation*

--- a/docs/blog/2026-04-20-release-v1-0-0.md
+++ b/docs/blog/2026-04-20-release-v1-0-0.md
@@ -1,0 +1,55 @@
+---
+title: "Release: v1.0.0 — Semantic Versioning and Production Readiness"
+date: 2026-04-20
+author: Bilbo
+tags: [release, semver, ci, devops]
+summary: "MyBlog reaches v1.0.0: semantic versioning replaces sprint tags, GitVersion automates releases, and we're production-ready."
+---
+
+## Summary
+
+With v1.0.0, MyBlog transitions from sprint-based versioning (v1.0.0-sprint1, v1.0.0-sprint2, v1.0.0-sprint3) to pure semantic versioning. GitVersion integration automates version bumping and tag creation on every main commit, eliminating manual release ceremonies. This is our first true semantic release and marks project stability.
+
+## Context
+
+Sprint tags served as proof-of-concept milestones, but semantic versioning is the industry standard for production software. By integrating GitVersion:
+- **Automated versioning**: Git commit messages (using conventional commits) drive version bumps
+- **Reproducible releases**: Every build on main automatically gets a unique version
+- **Clear communication**: MAJOR.MINOR.PATCH clearly signals compatibility
+- **CI integration**: GitHub Actions creates tags and releases automatically
+
+This removes friction from release workflows and aligns us with modern DevOps practices.
+
+## Key Details
+
+### GitVersion Configuration
+```yaml
+mode: Mainline
+increment: Patch
+```
+
+Commits to main trigger:
+- Automatic version calculation
+- Git tag creation
+- GitHub Release publication
+
+### Version Scheme
+- **MAJOR** (breaking changes): X.0.0
+- **MINOR** (features, non-breaking): 1.Y.0
+- **PATCH** (bug fixes, docs): 1.0.Z
+
+### What v1.0.0 Includes
+Three complete sprints of work:
+- ✓ Clean architecture foundation
+- ✓ CQRS/MediatR pattern
+- ✓ E2E testing with .NET Aspire
+- ✓ CI/CD automation
+- ✓ 74+ tests passing
+
+## What's Next
+
+v1.1.0 (Sprint 4) introduces Blazor theming with TailwindCSS v4 and reorganizes test infrastructure.
+
+---
+
+*Posted by Bilbo • Release Milestone | v1.0.0*

--- a/docs/blog/2026-04-20-sprint-2-cqrs-mediatr.md
+++ b/docs/blog/2026-04-20-sprint-2-cqrs-mediatr.md
@@ -1,0 +1,87 @@
+---
+title: "Sprint 2: CQRS and MediatR Deep Dive"
+date: 2026-04-20
+author: Bilbo
+tags: [cqrs, mediatr, testing, domain, sprint-2]
+summary: "Sprint 2 establishes command-query separation and MediatR handlers for clean, testable domain logic."
+---
+
+## Summary
+
+Sprint 2 brings the CQRS (Command Query Responsibility Segregation) pattern to life with five fully-tested MediatR handlers for BlogPost operations. We added FluentValidation integration through a ValidationBehavior pipeline, restructured Domain as vertical slices, and established the squad governance workflow. The test suite grew by 13 new tests, achieving ≥89% coverage. Release v1.0.0-sprint2 marks our first semantic versioning milestone.
+
+## Context
+
+CQRS separates reads from writes, making our code easier to reason about and optimize independently. MediatR provides the dispatch mechanism. Combined with FluentValidation, we get:
+- **Clear intent**: Commands for mutations, Queries for reads
+- **Automatic validation**: Pipeline behaviors intercept and validate before handlers execute
+- **Testability**: Each handler can be tested in isolation
+- **Scalability**: Later, we can add caching, logging, or authorization as behaviors without touching handlers
+
+This is the backbone of maintainable domain logic.
+
+## Key Details
+
+### Five MediatR Handlers
+```
+Domain/Features/BlogPosts/
+├── Commands/
+│   ├── CreateBlogPostCommand.cs
+│   ├── UpdateBlogPostCommand.cs
+│   └── DeleteBlogPostCommand.cs
+├── Queries/
+│   ├── GetAllBlogPostsQuery.cs
+│   └── GetBlogPostByIdQuery.cs
+└── Handlers/
+    ├── CreateBlogPostCommandHandler.cs
+    ├── UpdateBlogPostCommandHandler.cs
+    ├── DeleteBlogPostCommandHandler.cs
+    ├── GetAllBlogPostsQueryHandler.cs
+    └── GetBlogPostByIdQueryHandler.cs
+```
+
+### ValidationBehavior Pipeline
+```csharp
+public class ValidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : IRequest<TResponse>
+{
+    private readonly IEnumerable<IValidator<TRequest>> _validators;
+
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        var context = new ValidationContext<TRequest>(request);
+        var failures = (await Task.WhenAll(
+            _validators.Select(v => v.ValidateAsync(context, cancellationToken))))
+            .SelectMany(result => result.Errors)
+            .Where(failure => failure != null)
+            .ToList();
+
+        if (failures.Any())
+            throw new ValidationException(failures);
+
+        return await next();
+    }
+}
+```
+
+### Test Expansion
+- **13 new tests** added for command and query handlers
+- Validation tests ensure bad data is caught before persistence
+- Handler tests verify correct output and state changes
+
+### Squad Governance Milestone
+We established the **no-code-before-issue** gate:
+- Every feature starts as a GitHub issue
+- Squad members label and discuss design
+- PRs must reference the issue
+- Reviews ensure quality before merge
+
+**Related PRs:** #52, #53, #54, #55, #57, #58
+
+## What's Next
+
+Sprint 3 adds end-to-end testing with xUnit and .NET Aspire, plus CI hardening for the squad workflow.
+
+---
+
+*Posted by Bilbo • Sprint 2 | Release: v1.0.0-sprint2*

--- a/docs/blog/2026-04-20-sprint-3-e2e-tests-ci-hardening.md
+++ b/docs/blog/2026-04-20-sprint-3-e2e-tests-ci-hardening.md
@@ -1,0 +1,70 @@
+---
+title: "Sprint 3: E2E Testing and CI Hardening"
+date: 2026-04-20
+author: Bilbo
+tags: [e2e, aspire, ci, testing, sprint-3]
+summary: "Sprint 3 adds end-to-end testing with .NET Aspire xUnit and hardens the CI pipeline for squad branch workflows."
+---
+
+## Summary
+
+Sprint 3 strengthens quality and automation. We added the E2E.Tests project using .NET Aspire's xUnit integration, introduced visual distinction via Admin badge styling and RoleClaimsHelper, and hardened CI to enforce squad branch naming on sprint/* branches. Test artifacts now upload to CI runs, GitHub project board automation moves issues to Released, and the pre-push Gate 0 validates branch names. Release v1.0.0-sprint3 marks our first production-ready milestone.
+
+## Context
+
+As the project grows, we need multiple testing layers:
+- **Unit tests** verify business logic in isolation
+- **Integration tests** check persistence and service wiring
+- **E2E tests** simulate real user workflows in a live environment
+
+.NET Aspire provides the orchestration context for E2E tests, spinning up the full application and letting xUnit run scenarios end-to-end. CI automation ensures consistency—artifact uploads let us inspect test results post-run, and branch name validation prevents accidental merges to main.
+
+## Key Details
+
+### E2E Testing with .NET Aspire
+The E2E.Tests project uses AppHost's resource definitions to spin up the application:
+```csharp
+[TestClass]
+public class BlogPostE2ETests
+{
+    private readonly AspireTestExtension _aspire = new();
+
+    [TestMethod]
+    public async Task GetBlogPosts_ReturnsAllPosts()
+    {
+        var httpClient = _aspire.CreateHttpClient("webfrontend");
+        var response = await httpClient.GetAsync("/api/blog-posts");
+        Assert.IsTrue(response.IsSuccessStatusCode);
+    }
+}
+```
+
+### UI Enhancements
+- **Admin Badge**: Visual indicator for admin users in profile
+- **Role-Colored Badges**: Different colors for different roles (admin, editor, reader)
+- **RoleClaimsHelper**: Utility to safely parse and validate claims
+
+**Related PR:** #79
+
+### CI/CD Hardening
+
+#### Squad CI on Sprint Branches
+- Enabled squad-test CI workflow on sprint/* branches (PR #70)
+- Test results artifact uploads (PR #75)
+
+#### Pre-Push Gate Validation
+- Branch naming enforcement via Gate 0 (PRs #74, #78)
+- Prevents commits to main; validates sprint/* naming
+
+#### GitHub Project Automation
+- Issues automatically move to "Released" column on GitHub Release publish (PR #76)
+
+**Related PRs:** #70, #74, #75, #76, #77, #78, #79
+
+## What's Next
+
+Sprint 4 introduces Blazor theme system with TailwindCSS v4 and reorganizes test infrastructure into focused, maintainable layers.
+
+---
+
+*Posted by Bilbo • Sprint 3 | Release: v1.0.0-sprint3*

--- a/docs/blog/2026-04-24-release-v1-1-0.md
+++ b/docs/blog/2026-04-24-release-v1-1-0.md
@@ -1,0 +1,79 @@
+---
+title: "Release: v1.1.0 — Blazor Theme System with TailwindCSS v4"
+date: 2026-04-24
+author: Bilbo
+tags: [release, v1.1.0, blazor, tailwind, theme, testing, sprint-4]
+summary: "v1.1.0 ships a complete theme system with light/dark/system modes, four color schemes, and reorganized test infrastructure."
+---
+
+## Summary
+
+Sprint 4 delivers a sophisticated theme system for Blazor with TailwindCSS v4. The `ThemeProvider` cascading parameter exposes theme state, `ThemeToggle` component lets users switch between light, dark, and system modes, and four color schemes (Blue, Red, Green, Yellow) provide visual variety. Settings persist to localStorage. Parallel work reorganized the test suite into focused layers: Web.Tests, Web.Tests.Bunit, Web.Tests.Integration, and AppHost.Tests. Seven flaky E2E tests are now stable. Release v1.1.0 is live at [github.com/mpaulosky/MyBlog/releases/tag/v1.1.0](https://github.com/mpaulosky/MyBlog/releases/tag/v1.1.0).
+
+## Context
+
+User experience is defined by design and polish. A theme system gives developers and users:
+- **Accessibility**: Respects system dark mode preferences
+- **Personalization**: Users choose their color palette
+- **Consistency**: Cascading parameters propagate theme state without prop drilling
+- **Persistence**: localStorage keeps preferences across sessions
+
+Well-organized tests make future changes confident. Separating E2E, unit, Blazor component, and integration tests lets us run only what matters for a given change.
+
+## Key Details
+
+### Theme System Architecture
+```csharp
+[CascadingParameter]
+public ThemeProvider ThemeProvider { get; set; }
+
+public class ThemeProvider
+{
+    public string Mode { get; set; } // light, dark, system
+    public string ColorScheme { get; set; } // blue, red, green, yellow
+    public void SetMode(string mode) => /* update + persist */
+    public void SetColorScheme(string scheme) => /* update + persist */
+}
+```
+
+### ThemeToggle Component
+```razor
+<div class="flex gap-2">
+    <button @onclick="() => ThemeProvider.SetMode('light')">☀️</button>
+    <button @onclick="() => ThemeProvider.SetMode('dark')">🌙</button>
+    <button @onclick="() => ThemeProvider.SetMode('system')">🖥️</button>
+    
+    <select @onchange="e => ThemeProvider.SetColorScheme(e.Value)">
+        <option value="blue">Blue</option>
+        <option value="red">Red</option>
+        <option value="green">Green</option>
+        <option value="yellow">Yellow</option>
+    </select>
+</div>
+```
+
+### Color Schemes
+- **Blue**: Professional, calming (primary)
+- **Red**: Energy, urgency (alerts, warnings)
+- **Green**: Growth, success (confirmations)
+- **Yellow**: Caution, attention (highlights)
+
+Each scheme adapts across light and dark modes.
+
+### Test Infrastructure
+- **Web.Tests**: .NET unit tests for services
+- **Web.Tests.Bunit**: Blazor component tests with bUnit
+- **Web.Tests.Integration**: Full-stack integration scenarios
+- **AppHost.Tests**: E2E orchestration tests
+
+Fixed 7 flaky E2E tests by improving retry logic and timeout handling.
+
+**Related PRs:** #94, #95, #98, #100, #102, #104
+
+## What's Next
+
+v1.2.0 (Sprint 5) adds Redis caching with IBlogPostCacheService and L1/L2 cache layers.
+
+---
+
+*Posted by Bilbo • Sprint 4 | Release: v1.1.0*

--- a/docs/blog/2026-04-24-release-v1-2-0.md
+++ b/docs/blog/2026-04-24-release-v1-2-0.md
@@ -1,0 +1,129 @@
+---
+title: "Release: v1.2.0 — Redis Caching and L1/L2 Cache Strategy"
+date: 2026-04-24
+author: Bilbo
+tags: [release, v1.2.0, redis, caching, aspire, sprint-5]
+summary: "v1.2.0 introduces intelligent caching with Redis: L1 in-memory, L2 distributed, with automatic invalidation on mutations."
+---
+
+## Summary
+
+Sprint 5 ships a production-grade caching strategy. The new `IBlogPostCacheService` abstraction provides two-tier caching: L1 uses `IMemoryCache` for ultra-fast local access, L2 uses `IDistributedCache` with Redis for cross-instance consistency. All CQRS query handlers (`GetAllBlogPostsQueryHandler`, `GetBlogPostByIdQueryHandler`) are now cache-aware, and mutations (Create/Update/Delete) automatically invalidate affected cache entries. Blazor components sport new bUnit tests. CI automation now moves issues to the "Released" column when a GitHub Release is published. Release v1.2.0 is live at [github.com/mpaulosky/MyBlog/releases/tag/v1.2.0](https://github.com/mpaulosky/MyBlog/releases/tag/v1.2.0).
+
+## Context
+
+Caching transforms performance. Without it, every read hits the database. With caching:
+- **L1 (IMemoryCache)**: Sub-millisecond access, local to each server instance
+- **L2 (Redis)**: Millisecond access, shared across instances
+- **Invalidation**: When a BlogPost is modified, we clear the cache, so the next query fetches fresh data
+
+This architecture scales horizontally—add servers, they all benefit from Redis.
+
+## Key Details
+
+### IBlogPostCacheService
+```csharp
+public interface IBlogPostCacheService
+{
+    Task<IEnumerable<BlogPostResponse>> GetAllBlogPostsAsync(CancellationToken cancellationToken);
+    Task<BlogPostResponse?> GetBlogPostByIdAsync(int id, CancellationToken cancellationToken);
+    Task InvalidateAsync(int? blogPostId = null);
+}
+```
+
+### Two-Tier Implementation
+```csharp
+public class BlogPostCacheService : IBlogPostCacheService
+{
+    private readonly IMemoryCache _l1Cache;
+    private readonly IDistributedCache _l2Cache;
+    private readonly IBlogPostRepository _repository;
+
+    public async Task<IEnumerable<BlogPostResponse>> GetAllBlogPostsAsync(CancellationToken cancellationToken)
+    {
+        const string key = "all_blog_posts";
+        
+        // Check L1
+        if (_l1Cache.TryGetValue(key, out var cached))
+            return cached as IEnumerable<BlogPostResponse>;
+        
+        // Check L2
+        var json = await _l2Cache.GetStringAsync(key, cancellationToken);
+        if (json != null)
+        {
+            var result = JsonSerializer.Deserialize<IEnumerable<BlogPostResponse>>(json);
+            _l1Cache.Set(key, result, TimeSpan.FromHours(1));
+            return result;
+        }
+        
+        // Fetch from DB, populate both caches
+        var posts = await _repository.GetAllAsync(cancellationToken);
+        var response = posts.Select(p => new BlogPostResponse { /* ... */ });
+        var json = JsonSerializer.Serialize(response);
+        await _l2Cache.SetStringAsync(key, json, new DistributedCacheEntryOptions 
+        { 
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1) 
+        }, cancellationToken);
+        _l1Cache.Set(key, response, TimeSpan.FromHours(1));
+        
+        return response;
+    }
+}
+```
+
+### Query Handler Integration
+```csharp
+public class GetAllBlogPostsQueryHandler : IRequestHandler<GetAllBlogPostsQuery, IEnumerable<BlogPostResponse>>
+{
+    private readonly IBlogPostCacheService _cacheService;
+
+    public async Task<IEnumerable<BlogPostResponse>> Handle(GetAllBlogPostsQuery request, CancellationToken cancellationToken)
+    {
+        return await _cacheService.GetAllBlogPostsAsync(cancellationToken);
+    }
+}
+```
+
+### Invalidation on Mutation
+```csharp
+public class CreateBlogPostCommandHandler : IRequestHandler<CreateBlogPostCommand, BlogPostResponse>
+{
+    private readonly IBlogPostRepository _repository;
+    private readonly IBlogPostCacheService _cacheService;
+
+    public async Task<BlogPostResponse> Handle(CreateBlogPostCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _repository.CreateAsync(/* ... */, cancellationToken);
+        await _cacheService.InvalidateAsync(); // Clear all blog post caches
+        return MapToResponse(entity);
+    }
+}
+```
+
+### Blazor Component Tests with bUnit
+```csharp
+[TestClass]
+public class ThemeToggleTests
+{
+    [TestMethod]
+    public void ThemeToggle_RendersSwitchButtons()
+    {
+        using var ctx = new TestContext();
+        var cut = ctx.RenderComponent<ThemeToggle>();
+        
+        cut.FindAll("button").Count.Should().Be(3);
+    }
+}
+```
+
+### CI Automation
+- Issues in "In Progress" move to "Released" when a GitHub Release is published
+- Automated via GitHub Actions workflow
+
+## What's Next
+
+Sprint 6 explores distributed tracing with OpenTelemetry and performance profiling.
+
+---
+
+*Posted by Bilbo • Sprint 5 | Release: v1.2.0*

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -1,0 +1,47 @@
+# MyBlog Development Blog
+
+Welcome to the MyBlog technical blog! Here we document the project's evolution—from architecture decisions and feature releases to testing strategies and DevOps automation. Each post captures what we built, why it matters, and what's coming next.
+
+## Latest Posts
+
+| Date | Title | Tags |
+|------|-------|------|
+| 2026-04-24 | [Release: v1.2.0 — Redis Caching and L1/L2 Cache Strategy](./2026-04-24-release-v1-2-0.md) | release, v1.2.0, redis, caching, aspire, sprint-5 |
+| 2026-04-24 | [Release: v1.1.0 — Blazor Theme System with TailwindCSS v4](./2026-04-24-release-v1-1-0.md) | release, v1.1.0, blazor, tailwind, theme, testing, sprint-4 |
+| 2026-04-20 | [Release: v1.0.0 — Semantic Versioning and Production Readiness](./2026-04-20-release-v1-0-0.md) | release, semver, ci, devops |
+| 2026-04-20 | [Sprint 3: E2E Testing and CI Hardening](./2026-04-20-sprint-3-e2e-tests-ci-hardening.md) | e2e, aspire, ci, testing, sprint-3 |
+| 2026-04-20 | [Sprint 2: CQRS and MediatR Deep Dive](./2026-04-20-sprint-2-cqrs-mediatr.md) | cqrs, mediatr, testing, domain, sprint-2 |
+| 2026-04-18 | [MyBlog Project Kickoff: Building with .NET 10 and Clean Architecture](./2026-04-18-myblog-project-kickoff.md) | aspire, blazor, clean-architecture, sprint-1 |
+
+## By Sprint
+
+### Sprint 1: Foundation
+- [MyBlog Project Kickoff: Building with .NET 10 and Clean Architecture](./2026-04-18-myblog-project-kickoff.md)
+
+### Sprint 2: CQRS & MediatR
+- [Sprint 2: CQRS and MediatR Deep Dive](./2026-04-20-sprint-2-cqrs-mediatr.md)
+
+### Sprint 3: Testing & CI
+- [Sprint 3: E2E Testing and CI Hardening](./2026-04-20-sprint-3-e2e-tests-ci-hardening.md)
+
+### Sprint 4: Theme System
+- [Release: v1.1.0 — Blazor Theme System with TailwindCSS v4](./2026-04-24-release-v1-1-0.md)
+
+### Sprint 5: Caching
+- [Release: v1.2.0 — Redis Caching and L1/L2 Cache Strategy](./2026-04-24-release-v1-2-0.md)
+
+## Release Timeline
+
+| Release | Date | Focus |
+|---------|------|-------|
+| [v1.0.0](./2026-04-20-release-v1-0-0.md) | 2026-04-20 | Semantic versioning, production readiness |
+| [v1.1.0](./2026-04-24-release-v1-1-0.md) | 2026-04-24 | Blazor theme system, test reorganization |
+| [v1.2.0](./2026-04-24-release-v1-2-0.md) | 2026-04-24 | Redis caching, distributed cache strategy |
+
+## About This Blog
+
+Written by **Bilbo**, the MyBlog Tech Blogger. Posts document architecture, features, testing, and DevOps. For pull requests, decisions, and code, see the [GitHub repository](https://github.com/mpaulosky/MyBlog).
+
+---
+
+Last updated: 2026-04-24

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MyBlog</title>
-    <meta name="description" content="A modern Bloging application built with .NET Aspire, Blazor, and MongoDB.">
+    <meta name="description" content="A hands-on learning project for .NET Aspire orchestration, Blazor Server rendering, MongoDB, Redis caching, and CQRS with MediatR.">
     <style>
         * {
             margin: 0;
@@ -135,7 +135,7 @@
     <div class="container">
         <h1>MyBlog</h1>
 
-        <p>A modern issue tracking application built with .NET Aspire, Blazor, and MongoDB.</p>
+        <p>A hands-on learning project for .NET Aspire orchestration, Blazor Server rendering, MongoDB, Redis caching, and CQRS with MediatR.</p>
 
         <div class="badges">
             <a href="https://dotnet.microsoft.com/"><img src="https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet" alt=".NET 10"></a>
@@ -165,11 +165,18 @@
 
         <h2>Overview</h2>
 
-        <p>MyBlog is a full-stack web application for managing issues and tracking project progress. It demonstrates modern .NET development practices using the latest technologies and architectural patterns.</p>
+        <p>MyBlog is a Blazor Server blog application demonstrating .NET Aspire orchestration, CQRS with MediatR, MongoDB persistence, Redis distributed caching, Auth0 authentication, and TailwindCSS v4 theming.</p>
 
         <h2>Features</h2>
 
         <h3>Core Functionality</h3>
+
+        <ul>
+            <li><strong>Blog Management</strong>: Create, edit, delete, publish/unpublish blog posts</li>
+            <li><strong>CQRS with MediatR</strong>: All operations use MediatR command/query handlers with FluentValidation pipeline</li>
+            <li><strong>Redis Caching</strong>: L1 (in-memory) + L2 (Redis distributed) cache via <code>IBlogPostCacheService</code></li>
+            <li><strong>Auth0 Authentication</strong>: Secure login with Authorization Code + PKCE; Role-Based Authorization</li>
+        </ul>
 
         <h3>Security</h3>
 
@@ -229,20 +236,27 @@
 
         <pre><code>MyBlog/
 ├── src/
-│   ├── AppHost/                  # .NET Aspire orchestration
-│   ├── ServiceDefaults/          # Cross-cutting concerns (OpenTelemetry, health checks)
-│   ├── Web/                      # Blazor Interactive Server application
-│   │   ├── Components/Theme/     # ThemeProvider, ThemeToggle components
-│   │   ├── Styles/               # TailwindCSS source files
-│   │   └── Auth/                 # Authentication endpoints
-│   ├── Domain/                   # Business logic and entities
-│   │   ├── Models/               # Issue, Category, Status, Comment, User
-│   │   ├── DTOs/                 # Data transfer objects
-│   │   └── Abstractions/         # Result&lt;T&gt; pattern, IRepository&lt;T&gt;
-│   └── Persistence.MongoDb/      # Data access layer with MongoDB EF Core
-├── tests/                        # Unit, integration, and E2E tests
-├── docs/                         # Documentation
-└── Directory.Packages.props      # Centralized package versioning
+│   ├── AppHost/                  # .NET Aspire orchestration (MongoDB + Redis)
+│   ├── Domain/                   # BlogPost entity, MediatR handlers, validators
+│   │   ├── Abstractions/         # Result&lt;T&gt;, IBlogPostRepository, IBlogPostCacheService
+│   │   ├── Behaviors/            # ValidationBehavior pipeline
+│   │   └── Entities/             # BlogPost domain entity
+│   ├── ServiceDefaults/          # OpenTelemetry, health checks, Aspire extensions
+│   └── Web/                      # Blazor Server application
+│       ├── Features/BlogPosts/   # Vertical slice: handlers, pages
+│       ├── Infrastructure/Caching/ # BlogPostCacheService (L1+L2)
+│       ├── Components/Theme/     # TailwindCSS theme components
+│       └── Security/             # Auth0 endpoints
+├── tests/
+│   ├── Unit.Tests/               # Domain entity + handler unit tests
+│   ├── Architecture.Tests/       # Layer dependency enforcement
+│   ├── Integration.Tests/        # Aspire integration tests
+│   ├── AppHost.Tests/            # Aspire AppHost + E2E tests
+│   ├── Web.Tests/                # Web layer tests
+│   ├── Web.Tests.Bunit/          # Blazor component tests (bUnit)
+│   └── Web.Tests.Integration/    # Web integration tests
+├── docs/                         # Documentation + GitHub Pages
+└── Directory.Packages.props      # Centralized NuGet versioning (CPM)
 </code></pre>
 
         <h2>Getting Started</h2>
@@ -273,9 +287,7 @@ cd MyBlog
             </li>
             <li>
                 <p><strong>Install npm dependencies</strong> (for TailwindCSS)</p>
-                <pre><code>cd src/Web
-npm install
-cd ../..
+                <pre><code>npm install
 </code></pre>
             </li>
             <li>
@@ -300,8 +312,7 @@ dotnet run
 
         <p>For active CSS development with hot reload:</p>
 
-        <pre><code>cd src/Web
-npm run css:watch
+        <pre><code>npm run css:watch
 </code></pre>
 
         <p>This watches for changes in Razor components and automatically recompiles CSS.</p>
@@ -376,12 +387,13 @@ dotnet user-secrets set "Auth0:ClientSecret" "your-client-secret"
 
         <ul>
             <li><a href="ARCHITECTURE.md">ARCHITECTURE.md</a> - Solution architecture overview</li>
-            <li><a href="FEATURES.md">FEATURES.md</a> - Detailed feature documentation</li>
-            <li><a href="THEMING.md">THEMING.md</a> - Theming and customization guide</li>
-            <li><a href="LIBRARIES.md">LIBRARIES.md</a> - NuGet and npm package references</li>
             <li><a href="CONTRIBUTING.md">CONTRIBUTING.md</a> - Contribution guidelines</li>
+            <li><a href="AUTH0_SETUP.md">AUTH0_SETUP.md</a> - Auth0 configuration guide</li>
+            <li><a href="TESTING.md">TESTING.md</a> - Test strategy and running instructions</li>
+            <li><a href="THEMING.md">THEMING.md</a> - Theming and customization guide</li>
             <li><a href="SECURITY.md">SECURITY.md</a> - Security guidelines</li>
             <li><a href="CODE_OF_CONDUCT.md">CODE_OF_CONDUCT.md</a> - Community standards</li>
+            <li><a href="REFERENCES.md">REFERENCES.md</a> - NuGet and npm package references</li>
         </ul>
 
         <h2>Architecture</h2>
@@ -389,26 +401,19 @@ dotnet user-secrets set "Auth0:ClientSecret" "your-client-secret"
         <h3>Domain Layer</h3>
 
         <ul>
-            <li><strong>Result&lt;T&gt; Pattern</strong>: Explicit success/failure handling with <code>ResultErrorCode</code> enum</li>
-            <li><strong>Models</strong>: <code>Issue</code>, <code>Category</code>, <code>Status</code>, <code>Comment</code>, <code>User</code> (embedded document)</li>
-            <li><strong>DTOs</strong>: Strongly-typed data transfer objects for API boundaries</li>
-            <li><strong>Repository Interface</strong>: Generic <code>IRepository&lt;T&gt;</code> for data access abstraction</li>
-        </ul>
-
-        <h3>Persistence Layer</h3>
-
-        <ul>
-            <li><strong>IssueTrackerDbContext</strong>: MongoDB EF Core context with configuration</li>
-            <li><strong>Entity Configurations</strong>: Fluent API configuration for MongoDB mapping</li>
-            <li><strong>Change Tracking</strong>: Automatic persistence with async operations</li>
+            <li><strong>BlogPost Entity</strong>: Core domain entity with factory methods and immutable updates</li>
+            <li><strong>MediatR Handlers</strong>: CreateBlogPost, UpdateBlogPost, DeleteBlogPost, GetAllBlogPosts, GetBlogPostById</li>
+            <li><strong>ValidationBehavior</strong>: MediatR pipeline behavior with FluentValidation</li>
+            <li><strong>IBlogPostCacheService</strong>: Cache abstraction for L1+L2 caching strategy</li>
         </ul>
 
         <h3>Web Layer</h3>
 
         <ul>
-            <li><strong>Authentication Endpoints</strong>: <code>/login</code>, <code>/logout</code> with security hardening</li>
+            <li><strong>BlogPostCacheService</strong>: L1 (IMemoryCache) + L2 (IDistributedCache/Redis) implementation</li>
+            <li><strong>Auth0 Endpoints</strong>: <code>/login</code>, <code>/logout</code> with security hardening</li>
             <li><strong>Theme Components</strong>: <code>ThemeProvider</code> cascading parameter, <code>ThemeToggle</code> UI</li>
-            <li><strong>JavaScript Interop</strong>: <code>themeManager</code> for localStorage persistence</li>
+            <li><strong>Vertical Slices</strong>: Blog post pages co-located with handlers in <code>Web/Features/BlogPosts/</code></li>
         </ul>
 
         <h2>Testing</h2>
@@ -416,21 +421,13 @@ dotnet user-secrets set "Auth0:ClientSecret" "your-client-secret"
         <p>The project includes multiple testing layers:</p>
 
         <ul>
-            <li><strong>Unit Tests</strong>: Business logic validation with NSubstitute mocks</li>
-            <li><strong>Integration Tests</strong>: Full application testing with TestContainers</li>
-            <li><strong>Blazor Component Tests</strong>: bUnit for UI component verification</li>
-            <li><strong>E2E Tests</strong>: Playwright for browser-based testing</li>
-            <li><strong>Architecture Tests</strong>: Verify project dependencies and conventions</li>
-        </ul>
-
-        <h2>API Documentation</h2>
-
-        <p>API endpoints are documented with OpenAPI 3.0+ specifications via Scalar:</p>
-
-        <ul>
-            <li>Navigate to <code>/api/docs</code> to view interactive API documentation</li>
-            <li>All REST endpoints include XML documentation comments</li>
-            <li>Request/response schemas are auto-generated from models</li>
+            <li><strong>Unit.Tests</strong>: Domain entity logic and MediatR handler behavior</li>
+            <li><strong>Architecture.Tests</strong>: Layer dependency enforcement</li>
+            <li><strong>Integration.Tests</strong>: Aspire integration tests</li>
+            <li><strong>AppHost.Tests</strong>: .NET Aspire host + E2E tests</li>
+            <li><strong>Web.Tests</strong>: Web layer unit tests</li>
+            <li><strong>Web.Tests.Bunit</strong>: Blazor component tests (bUnit)</li>
+            <li><strong>Web.Tests.Integration</strong>: Web integration tests</li>
         </ul>
 
         <h2>Release Notes</h2>
@@ -446,29 +443,24 @@ dotnet user-secrets set "Auth0:ClientSecret" "your-client-secret"
             </thead>
             <tbody>
                 <tr>
-                    <td><a href="https://github.com/mpaulosky/MyBlog/releases/tag/v0.6.0"><strong>v0.6.0</strong></a> <span style="background:#dafbe1;color:#1a7f37;font-size:0.75em;padding:2px 6px;border-radius:10px;font-weight:600;">Latest</span></td>
-                    <td>2026-04-02</td>
-                    <td>Labels Feature — multi-value tag input, filter by label, AddLabelCommand/RemoveLabelCommand CQRS, 1,167 tests</td>
+                    <td><a href="https://github.com/mpaulosky/MyBlog/releases/tag/v1.2.0"><strong>v1.2.0</strong></a> <span style="background:#dafbe1;color:#1a7f37;font-size:0.75em;padding:2px 6px;border-radius:10px;font-weight:600;">Latest</span></td>
+                    <td>2026-04-24</td>
+                    <td>Redis &amp; Caching — IBlogPostCacheService L1+L2 abstraction, handler cache integration, bUnit tests</td>
                 </tr>
                 <tr>
-                    <td><a href="https://github.com/mpaulosky/MyBlog/releases/tag/v0.5.0">v0.5.0</a></td>
-                    <td>2026-04-02</td>
-                    <td>Admin User Management — Auth0 Management API, /admin/users, UserListTable, RoleBadge, EditUserRolesModal, UserAuditLogPanel</td>
+                    <td><a href="https://github.com/mpaulosky/MyBlog/releases/tag/v1.1.0">v1.1.0</a></td>
+                    <td>2026-04-24</td>
+                    <td>Themes &amp; Testing — TailwindCSS v4 theme system (4 colors, dark/light/system), test project reorganization, flaky E2E fixes</td>
                 </tr>
                 <tr>
-                    <td><a href="https://github.com/mpaulosky/MyBlog/releases/tag/v0.4.0">v0.4.0</a></td>
-                    <td>2026-04-01</td>
-                    <td>Voting &amp; Prioritization — upvote/unvote issues, vote badge, Top Voted sort, SignalR broadcast</td>
+                    <td><a href="https://github.com/mpaulosky/MyBlog/releases/tag/v1.0.1">v1.0.1</a></td>
+                    <td>2026-04-20</td>
+                    <td>Automatic semantic versioning enabled via GitVersion CI integration</td>
                 </tr>
                 <tr>
-                    <td><a href="https://github.com/mpaulosky/MyBlog/releases/tag/v0.3.0">v0.3.0</a></td>
-                    <td>2026-04-01</td>
-                    <td>Polish Sprint — dashboard UI fixes, Redis caching, restore command, assignee field</td>
-                </tr>
-                <tr>
-                    <td><a href="https://github.com/mpaulosky/MyBlog/releases/tag/v0.2.0">v0.2.0</a></td>
-                    <td>2026-03-30</td>
-                    <td>UI refresh, GitHub Pages blog, full test coverage audit, E2E testing infrastructure</td>
+                    <td><a href="https://github.com/mpaulosky/MyBlog/releases/tag/v1.0.0">v1.0.0</a></td>
+                    <td>2026-04-20</td>
+                    <td>First pure semantic release — CQRS/MediatR domain, E2E testing, CI hardening</td>
                 </tr>
             </tbody>
         </table>
@@ -489,34 +481,34 @@ dotnet user-secrets set "Auth0:ClientSecret" "your-client-secret"
             </thead>
             <tbody>
                 <tr>
-                    <td>2026-04-02</td>
-                    <td><a href="blog/2026-04-02-release-v0-6-0.md">Release v0.6.0 — Labels Feature</a></td>
-                    <td>release, v0.6.0, labels, cqrs, blazor, bunit</td>
+                    <td>2026-04-24</td>
+                    <td><a href="blog/2026-04-24-release-v1-2-0.md">Release v1.2.0 — Redis &amp; Caching</a></td>
+                    <td>release, v1.2.0, redis, caching, sprint-5</td>
                 </tr>
                 <tr>
-                    <td>2026-04-02</td>
-                    <td><a href="blog/2026-04-02-release-v0-5-0.md">Release v0.5.0 — Admin User Management</a></td>
-                    <td>release, v0.5.0, admin, auth0, blazor</td>
+                    <td>2026-04-24</td>
+                    <td><a href="blog/2026-04-24-release-v1-1-0.md">Release v1.1.0 — Blazor Theming &amp; Testing</a></td>
+                    <td>release, v1.1.0, blazor, tailwind, testing, sprint-4</td>
                 </tr>
                 <tr>
-                    <td>2026-04-01</td>
-                    <td><a href="blog/2026-04-01-release-v0-4-0.md">Release v0.4.0 — Voting &amp; Prioritization</a></td>
-                    <td>release, v0.4.0, voting</td>
+                    <td>2026-04-20</td>
+                    <td><a href="blog/2026-04-20-release-v1-0-0.md">Release v1.0.0 — Semantic Versioning Transition</a></td>
+                    <td>release, v1.0.0, semver, ci</td>
                 </tr>
                 <tr>
-                    <td>2026-04-01</td>
-                    <td><a href="blog/2026-04-01-release-v0-3-0.md">Release v0.3.0 — Polish Sprint</a></td>
-                    <td>release, v0.3.0, dashboard, redis</td>
+                    <td>2026-04-20</td>
+                    <td><a href="blog/2026-04-20-sprint-3-e2e-tests-ci-hardening.md">Sprint 3 — E2E Testing &amp; CI Hardening</a></td>
+                    <td>e2e, aspire, ci, testing</td>
                 </tr>
                 <tr>
-                    <td>2026-03-30</td>
-                    <td><a href="blog/2026-03-30-release-v0-2-0.md">Release v0.2.0 — Features, Fixes &amp; Developer Tooling</a></td>
-                    <td>release, v0.2.0</td>
+                    <td>2026-04-20</td>
+                    <td><a href="blog/2026-04-20-sprint-2-cqrs-mediatr.md">Sprint 2 — CQRS &amp; MediatR Domain Layer</a></td>
+                    <td>cqrs, mediatr, domain, testing</td>
                 </tr>
                 <tr>
-                    <td>2026-03-27</td>
-                    <td><a href="blog/2026-03-27-apphost-aspire-playwright-e2e-tests.md">Adding AppHost.Tests — Aspire Integration + Playwright E2E Tests</a></td>
-                    <td>tests, aspire, playwright, e2e</td>
+                    <td>2026-04-18</td>
+                    <td><a href="blog/2026-04-18-myblog-project-kickoff.md">MyBlog Project Kickoff — Sprint 1</a></td>
+                    <td>aspire, blazor, clean-architecture</td>
                 </tr>
             </tbody>
         </table>
@@ -534,7 +526,7 @@ dotnet user-secrets set "Auth0:ClientSecret" "your-client-secret"
 
         <hr>
 
-        <p><strong>Status</strong>: Active Development | <strong>Latest Release</strong>: <a href="https://github.com/mpaulosky/MyBlog/releases/tag/v0.4.0">v0.4.0</a> | <strong>Maintained By</strong>: @mpaulosky</p>
+        <p><strong>Status</strong>: Training Project | <strong>Latest Release</strong>: <a href="https://github.com/mpaulosky/MyBlog/releases/tag/v1.2.0">v1.2.0</a> | <strong>Maintained By</strong>: @mpaulosky</p>
     </div>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -312,7 +312,7 @@ dotnet run
 
         <p>For active CSS development with hot reload:</p>
 
-        <pre><code>npm run css:watch
+        <pre><code>npm run tw:watch
 </code></pre>
 
         <p>This watches for changes in Razor components and automatically recompiles CSS.</p>


### PR DESCRIPTION
## Summary

Promotes `dev` → `main` with the Sprint 5 post-release documentation update.

### Changes included
- `docs/blog/` — 7 new blog posts covering Sprint 1 through v1.2.0
- `README.md` — full rewrite for v1.2.0 (correct tech stack, project structure, release history)
- `docs/index.html` — de-staled GitHub Pages site (correct releases, architecture, blog links)

### Notes
- This is a docs-only release. No source code changes.
- All CI checks passed on branch `squad/docs-sprint5-post-release` (PR #125).
- YAML workflow fixes (PR #124) are already in `main`; this merge brings the divergent histories together.

Closes #126 (if applicable)