### PR TITLE
fix(quality): rename ct to cancellationToken in all MediatR handlers

### DIFF
--- a/src/Web/Features/BlogPosts/Create/CreateBlogPostHandler.cs
+++ b/src/Web/Features/BlogPosts/Create/CreateBlogPostHandler.cs
@@ -16,13 +16,13 @@ public sealed class CreateBlogPostHandler(
 IBlogPostRepository repo,
 IBlogPostCacheService cache) : IRequestHandler<CreateBlogPostCommand, Result<Guid>>
 {
-public async Task<Result<Guid>> Handle(CreateBlogPostCommand request, CancellationToken ct)
+public async Task<Result<Guid>> Handle(CreateBlogPostCommand request, CancellationToken cancellationToken)
 {
 try
 {
 var post = BlogPost.Create(request.Title, request.Content, request.Author);
-await repo.AddAsync(post, ct);
-await cache.InvalidateAllAsync(ct);
+await repo.AddAsync(post, cancellationToken);
+await cache.InvalidateAllAsync(cancellationToken);
 return Result.Ok<Guid>(post.Id);
 }
 catch (Exception ex)

--- a/src/Web/Features/BlogPosts/Delete/DeleteBlogPostHandler.cs
+++ b/src/Web/Features/BlogPosts/Delete/DeleteBlogPostHandler.cs
@@ -16,13 +16,13 @@ public sealed class DeleteBlogPostHandler(
 IBlogPostRepository repo,
 IBlogPostCacheService cache) : IRequestHandler<DeleteBlogPostCommand, Result>
 {
-public async Task<Result> Handle(DeleteBlogPostCommand request, CancellationToken ct)
+public async Task<Result> Handle(DeleteBlogPostCommand request, CancellationToken cancellationToken)
 {
 try
 {
-await repo.DeleteAsync(request.Id, ct);
-await cache.InvalidateAllAsync(ct);
-await cache.InvalidateByIdAsync(request.Id, ct);
+await repo.DeleteAsync(request.Id, cancellationToken);
+await cache.InvalidateAllAsync(cancellationToken);
+await cache.InvalidateByIdAsync(request.Id, cancellationToken);
 return Result.Ok();
 }
 catch (DbUpdateConcurrencyException)

--- a/src/Web/Features/BlogPosts/Edit/EditBlogPostHandler.cs
+++ b/src/Web/Features/BlogPosts/Edit/EditBlogPostHandler.cs
@@ -18,17 +18,17 @@ IBlogPostCacheService cache)
 : IRequestHandler<EditBlogPostCommand, Result>,
 IRequestHandler<GetBlogPostByIdQuery, Result<BlogPostDto?>>
 {
-public async Task<Result> Handle(EditBlogPostCommand request, CancellationToken ct)
+public async Task<Result> Handle(EditBlogPostCommand request, CancellationToken cancellationToken)
 {
 try
 {
-var post = await repo.GetByIdAsync(request.Id, ct);
+var post = await repo.GetByIdAsync(request.Id, cancellationToken);
 if (post is null)
 return Result.Fail($"BlogPost {request.Id} not found.");
 post.Update(request.Title, request.Content);
-await repo.UpdateAsync(post, ct);
-await cache.InvalidateAllAsync(ct);
-await cache.InvalidateByIdAsync(request.Id, ct);
+await repo.UpdateAsync(post, cancellationToken);
+await cache.InvalidateAllAsync(cancellationToken);
+await cache.InvalidateByIdAsync(request.Id, cancellationToken);
 return Result.Ok();
 }
 catch (DbUpdateConcurrencyException)
@@ -43,7 +43,7 @@ return Result.Fail(ex.Message);
 }
 }
 
-public async Task<Result<BlogPostDto?>> Handle(GetBlogPostByIdQuery request, CancellationToken ct)
+public async Task<Result<BlogPostDto?>> Handle(GetBlogPostByIdQuery request, CancellationToken cancellationToken)
 {
 try
 {
@@ -51,9 +51,9 @@ var dto = await cache.GetOrFetchByIdAsync(
 request.Id,
 async () =>
 {
-var post = await repo.GetByIdAsync(request.Id, ct);
+var post = await repo.GetByIdAsync(request.Id, cancellationToken);
 return post?.ToDto();
-}, ct);
+}, cancellationToken);
 return Result.Ok<BlogPostDto?>(dto);
 }
 catch (Exception ex)

--- a/src/Web/Features/BlogPosts/List/GetBlogPostsHandler.cs
+++ b/src/Web/Features/BlogPosts/List/GetBlogPostsHandler.cs
@@ -17,16 +17,16 @@ IBlogPostRepository repo,
 IBlogPostCacheService cache) : IRequestHandler<GetBlogPostsQuery, Result<IReadOnlyList<BlogPostDto>>>
 {
 public async Task<Result<IReadOnlyList<BlogPostDto>>> Handle(
-GetBlogPostsQuery request, CancellationToken ct)
+GetBlogPostsQuery request, CancellationToken cancellationToken)
 {
 try
 {
 var result = await cache.GetOrFetchAllAsync(
 async () =>
 {
-var all = await repo.GetAllAsync(ct);
+var all = await repo.GetAllAsync(cancellationToken);
 return (IReadOnlyList<BlogPostDto>)all.Select(p => p.ToDto()).ToList();
-}, ct);
+}, cancellationToken);
 return Result.Ok<IReadOnlyList<BlogPostDto>>(result);
 }
 catch (Exception ex)

--- a/src/Web/Features/UserManagement/UserManagementHandler.cs
+++ b/src/Web/Features/UserManagement/UserManagementHandler.cs
@@ -23,17 +23,17 @@ IRequestHandler<RemoveRoleCommand, Result>,
 IRequestHandler<GetAvailableRolesQuery, Result<IReadOnlyList<RoleDto>>>
 {
 public async Task<Result<IReadOnlyList<UserWithRolesDto>>> Handle(
-GetUsersWithRolesQuery request, CancellationToken ct)
+GetUsersWithRolesQuery request, CancellationToken cancellationToken)
 {
 try
 {
-var client = await GetManagementClientAsync(ct);
-var usersPager = await client.Users.ListAsync(new ListUsersRequestParameters(), cancellationToken: ct);
+var client = await GetManagementClientAsync(cancellationToken);
+var usersPager = await client.Users.ListAsync(new ListUsersRequestParameters(), cancellationToken: cancellationToken);
 var result = new List<UserWithRolesDto>();
 await foreach (var user in usersPager)
 {
 var rolesPager = await client.Users.Roles.ListAsync(
-user.UserId ?? string.Empty, new ListUserRolesRequestParameters(), cancellationToken: ct);
+user.UserId ?? string.Empty, new ListUserRolesRequestParameters(), cancellationToken: cancellationToken);
 var roles = new List<string>();
 await foreach (var role in rolesPager)
 {
@@ -53,15 +53,15 @@ return Result.Fail<IReadOnlyList<UserWithRolesDto>>(ex.Message);
 }
 }
 
-public async Task<Result> Handle(AssignRoleCommand request, CancellationToken ct)
+public async Task<Result> Handle(AssignRoleCommand request, CancellationToken cancellationToken)
 {
 try
 {
-var client = await GetManagementClientAsync(ct);
+var client = await GetManagementClientAsync(cancellationToken);
 await client.Users.Roles.AssignAsync(
 request.UserId,
 new AssignUserRolesRequestContent { Roles = [request.RoleId] },
-cancellationToken: ct);
+cancellationToken: cancellationToken);
 return Result.Ok();
 }
 catch (Exception ex)
@@ -70,15 +70,15 @@ return Result.Fail(ex.Message);
 }
 }
 
-public async Task<Result> Handle(RemoveRoleCommand request, CancellationToken ct)
+public async Task<Result> Handle(RemoveRoleCommand request, CancellationToken cancellationToken)
 {
 try
 {
-var client = await GetManagementClientAsync(ct);
+var client = await GetManagementClientAsync(cancellationToken);
 await client.Users.Roles.DeleteAsync(
 request.UserId,
 new DeleteUserRolesRequestContent { Roles = [request.RoleId] },
-cancellationToken: ct);
+cancellationToken: cancellationToken);
 return Result.Ok();
 }
 catch (Exception ex)
@@ -87,12 +87,12 @@ return Result.Fail(ex.Message);
 }
 }
 
-public async Task<Result<IReadOnlyList<RoleDto>>> Handle(GetAvailableRolesQuery request, CancellationToken ct)
+public async Task<Result<IReadOnlyList<RoleDto>>> Handle(GetAvailableRolesQuery request, CancellationToken cancellationToken)
 {
 try
 {
-var client = await GetManagementClientAsync(ct);
-var rolesPager = await client.Roles.ListAsync(new ListRolesRequestParameters(), cancellationToken: ct);
+var client = await GetManagementClientAsync(cancellationToken);
+var rolesPager = await client.Roles.ListAsync(new ListRolesRequestParameters(), cancellationToken: cancellationToken);
 var roles = new List<RoleDto>();
 await foreach (var role in rolesPager)
 {
@@ -106,7 +106,7 @@ return Result.Fail<IReadOnlyList<RoleDto>>(ex.Message);
 }
 }
 
-private async Task<ManagementApiClient> GetManagementClientAsync(CancellationToken ct)
+private async Task<ManagementApiClient> GetManagementClientAsync(CancellationToken cancellationToken)
 {
 var domain = configuration["Auth0:ManagementApiDomain"]
 ?? throw new InvalidOperationException("Auth0:ManagementApiDomain not configured.");
@@ -124,9 +124,9 @@ client_id = clientId,
 client_secret = clientSecret,
 audience = $"https://{domain}/api/v2/",
 grant_type = "client_credentials"
-}, ct);
+}, cancellationToken);
 tokenResponse.EnsureSuccessStatusCode();
-var tokenData = await tokenResponse.Content.ReadFromJsonAsync<TokenResponse>(ct);
+var tokenData = await tokenResponse.Content.ReadFromJsonAsync<TokenResponse>(cancellationToken);
 return new ManagementApiClient(
 token: tokenData!.AccessToken,
 clientOptions: new ClientOptions { BaseUrl = $"https://{domain}/api/v2" });


### PR DESCRIPTION
Closes #137

Working as Sam (Backend Developer)

Renames the `ct` parameter to `cancellationToken` in every `Handle` method signature and all usages inside the method body across all MediatR handlers, plus the private `GetManagementClientAsync` helper in `UserManagementHandler`. Addresses CA1725.