### PR TITLE
test: add unit tests for BlogPost, Result, and ValidationBehavior

### DIFF
--- a/src/Web/Features/BlogPosts/Create/CreateBlogPostHandler.cs
+++ b/src/Web/Features/BlogPosts/Create/CreateBlogPostHandler.cs
@@ -16,13 +16,13 @@ public sealed class CreateBlogPostHandler(
 IBlogPostRepository repo,
 IBlogPostCacheService cache) : IRequestHandler<CreateBlogPostCommand, Result<Guid>>
 {
-public async Task<Result<Guid>> Handle(CreateBlogPostCommand request, CancellationToken ct)
+public async Task<Result<Guid>> Handle(CreateBlogPostCommand request, CancellationToken cancellationToken)
 {
 try
 {
 var post = BlogPost.Create(request.Title, request.Content, request.Author);
-await repo.AddAsync(post, ct);
-await cache.InvalidateAllAsync(ct);
+await repo.AddAsync(post, cancellationToken);
+await cache.InvalidateAllAsync(cancellationToken);
 return Result.Ok<Guid>(post.Id);
 }
 catch (Exception ex)

--- a/src/Web/Features/BlogPosts/Delete/DeleteBlogPostHandler.cs
+++ b/src/Web/Features/BlogPosts/Delete/DeleteBlogPostHandler.cs
@@ -16,13 +16,13 @@ public sealed class DeleteBlogPostHandler(
 IBlogPostRepository repo,
 IBlogPostCacheService cache) : IRequestHandler<DeleteBlogPostCommand, Result>
 {
-public async Task<Result> Handle(DeleteBlogPostCommand request, CancellationToken ct)
+public async Task<Result> Handle(DeleteBlogPostCommand request, CancellationToken cancellationToken)
 {
 try
 {
-await repo.DeleteAsync(request.Id, ct);
-await cache.InvalidateAllAsync(ct);
-await cache.InvalidateByIdAsync(request.Id, ct);
+await repo.DeleteAsync(request.Id, cancellationToken);
+await cache.InvalidateAllAsync(cancellationToken);
+await cache.InvalidateByIdAsync(request.Id, cancellationToken);
 return Result.Ok();
 }
 catch (DbUpdateConcurrencyException)

--- a/src/Web/Features/BlogPosts/Edit/EditBlogPostHandler.cs
+++ b/src/Web/Features/BlogPosts/Edit/EditBlogPostHandler.cs
@@ -18,17 +18,17 @@ IBlogPostCacheService cache)
 : IRequestHandler<EditBlogPostCommand, Result>,
 IRequestHandler<GetBlogPostByIdQuery, Result<BlogPostDto?>>
 {
-public async Task<Result> Handle(EditBlogPostCommand request, CancellationToken ct)
+public async Task<Result> Handle(EditBlogPostCommand request, CancellationToken cancellationToken)
 {
 try
 {
-var post = await repo.GetByIdAsync(request.Id, ct);
+var post = await repo.GetByIdAsync(request.Id, cancellationToken);
 if (post is null)
 return Result.Fail($"BlogPost {request.Id} not found.");
 post.Update(request.Title, request.Content);
-await repo.UpdateAsync(post, ct);
-await cache.InvalidateAllAsync(ct);
-await cache.InvalidateByIdAsync(request.Id, ct);
+await repo.UpdateAsync(post, cancellationToken);
+await cache.InvalidateAllAsync(cancellationToken);
+await cache.InvalidateByIdAsync(request.Id, cancellationToken);
 return Result.Ok();
 }
 catch (DbUpdateConcurrencyException)
@@ -43,7 +43,7 @@ return Result.Fail(ex.Message);
 }
 }
 
-public async Task<Result<BlogPostDto?>> Handle(GetBlogPostByIdQuery request, CancellationToken ct)
+public async Task<Result<BlogPostDto?>> Handle(GetBlogPostByIdQuery request, CancellationToken cancellationToken)
 {
 try
 {
@@ -51,9 +51,9 @@ var dto = await cache.GetOrFetchByIdAsync(
 request.Id,
 async () =>
 {
-var post = await repo.GetByIdAsync(request.Id, ct);
+var post = await repo.GetByIdAsync(request.Id, cancellationToken);
 return post?.ToDto();
-}, ct);
+}, cancellationToken);
 return Result.Ok<BlogPostDto?>(dto);
 }
 catch (Exception ex)

--- a/src/Web/Features/BlogPosts/List/GetBlogPostsHandler.cs
+++ b/src/Web/Features/BlogPosts/List/GetBlogPostsHandler.cs
@@ -17,16 +17,16 @@ IBlogPostRepository repo,
 IBlogPostCacheService cache) : IRequestHandler<GetBlogPostsQuery, Result<IReadOnlyList<BlogPostDto>>>
 {
 public async Task<Result<IReadOnlyList<BlogPostDto>>> Handle(
-GetBlogPostsQuery request, CancellationToken ct)
+GetBlogPostsQuery request, CancellationToken cancellationToken)
 {
 try
 {
 var result = await cache.GetOrFetchAllAsync(
 async () =>
 {
-var all = await repo.GetAllAsync(ct);
+var all = await repo.GetAllAsync(cancellationToken);
 return (IReadOnlyList<BlogPostDto>)all.Select(p => p.ToDto()).ToList();
-}, ct);
+}, cancellationToken);
 return Result.Ok<IReadOnlyList<BlogPostDto>>(result);
 }
 catch (Exception ex)

--- a/src/Web/Features/UserManagement/UserManagementHandler.cs
+++ b/src/Web/Features/UserManagement/UserManagementHandler.cs
@@ -23,17 +23,17 @@ IRequestHandler<RemoveRoleCommand, Result>,
 IRequestHandler<GetAvailableRolesQuery, Result<IReadOnlyList<RoleDto>>>
 {
 public async Task<Result<IReadOnlyList<UserWithRolesDto>>> Handle(
-GetUsersWithRolesQuery request, CancellationToken ct)
+GetUsersWithRolesQuery request, CancellationToken cancellationToken)
 {
 try
 {
-var client = await GetManagementClientAsync(ct);
-var usersPager = await client.Users.ListAsync(new ListUsersRequestParameters(), cancellationToken: ct);
+var client = await GetManagementClientAsync(cancellationToken);
+var usersPager = await client.Users.ListAsync(new ListUsersRequestParameters(), cancellationToken: cancellationToken);
 var result = new List<UserWithRolesDto>();
 await foreach (var user in usersPager)
 {
 var rolesPager = await client.Users.Roles.ListAsync(
-user.UserId ?? string.Empty, new ListUserRolesRequestParameters(), cancellationToken: ct);
+user.UserId ?? string.Empty, new ListUserRolesRequestParameters(), cancellationToken: cancellationToken);
 var roles = new List<string>();
 await foreach (var role in rolesPager)
 {
@@ -53,15 +53,15 @@ return Result.Fail<IReadOnlyList<UserWithRolesDto>>(ex.Message);
 }
 }
 
-public async Task<Result> Handle(AssignRoleCommand request, CancellationToken ct)
+public async Task<Result> Handle(AssignRoleCommand request, CancellationToken cancellationToken)
 {
 try
 {
-var client = await GetManagementClientAsync(ct);
+var client = await GetManagementClientAsync(cancellationToken);
 await client.Users.Roles.AssignAsync(
 request.UserId,
 new AssignUserRolesRequestContent { Roles = [request.RoleId] },
-cancellationToken: ct);
+cancellationToken: cancellationToken);
 return Result.Ok();
 }
 catch (Exception ex)
@@ -70,15 +70,15 @@ return Result.Fail(ex.Message);
 }
 }
 
-public async Task<Result> Handle(RemoveRoleCommand request, CancellationToken ct)
+public async Task<Result> Handle(RemoveRoleCommand request, CancellationToken cancellationToken)
 {
 try
 {
-var client = await GetManagementClientAsync(ct);
+var client = await GetManagementClientAsync(cancellationToken);
 await client.Users.Roles.DeleteAsync(
 request.UserId,
 new DeleteUserRolesRequestContent { Roles = [request.RoleId] },
-cancellationToken: ct);
+cancellationToken: cancellationToken);
 return Result.Ok();
 }
 catch (Exception ex)
@@ -87,12 +87,12 @@ return Result.Fail(ex.Message);
 }
 }
 
-public async Task<Result<IReadOnlyList<RoleDto>>> Handle(GetAvailableRolesQuery request, CancellationToken ct)
+public async Task<Result<IReadOnlyList<RoleDto>>> Handle(GetAvailableRolesQuery request, CancellationToken cancellationToken)
 {
 try
 {
-var client = await GetManagementClientAsync(ct);
-var rolesPager = await client.Roles.ListAsync(new ListRolesRequestParameters(), cancellationToken: ct);
+var client = await GetManagementClientAsync(cancellationToken);
+var rolesPager = await client.Roles.ListAsync(new ListRolesRequestParameters(), cancellationToken: cancellationToken);
 var roles = new List<RoleDto>();
 await foreach (var role in rolesPager)
 {
@@ -106,7 +106,7 @@ return Result.Fail<IReadOnlyList<RoleDto>>(ex.Message);
 }
 }
 
-private async Task<ManagementApiClient> GetManagementClientAsync(CancellationToken ct)
+private async Task<ManagementApiClient> GetManagementClientAsync(CancellationToken cancellationToken)
 {
 var domain = configuration["Auth0:ManagementApiDomain"]
 ?? throw new InvalidOperationException("Auth0:ManagementApiDomain not configured.");
@@ -124,9 +124,9 @@ client_id = clientId,
 client_secret = clientSecret,
 audience = $"https://{domain}/api/v2/",
 grant_type = "client_credentials"
-}, ct);
+}, cancellationToken);
 tokenResponse.EnsureSuccessStatusCode();
-var tokenData = await tokenResponse.Content.ReadFromJsonAsync<TokenResponse>(ct);
+var tokenData = await tokenResponse.Content.ReadFromJsonAsync<TokenResponse>(cancellationToken);
 return new ManagementApiClient(
 token: tokenData!.AccessToken,
 clientOptions: new ClientOptions { BaseUrl = $"https://{domain}/api/v2" });

--- a/tests/Domain.Tests/Abstractions/ResultTests.cs
+++ b/tests/Domain.Tests/Abstractions/ResultTests.cs
@@ -98,7 +98,7 @@ public class ResultTests
 	}
 
 	[Fact]
-	public void FromValue_NullValue_ReturnsFailureResultWithNullMessage()
+	public void FromValue_NullValue_ReturnsFailureResultWithProvidedValueIsNullError()
 	{
 		// Arrange / Act
 		var result = Result.FromValue<string>(null);

--- a/tests/Domain.Tests/Abstractions/ResultTests.cs
+++ b/tests/Domain.Tests/Abstractions/ResultTests.cs
@@ -1,0 +1,167 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     ResultTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Domain.Tests
+//=======================================================
+
+namespace Tests.Domain.Abstractions;
+
+public class ResultTests
+{
+	[Fact]
+	public void Ok_ReturnsSuccessResultWithNoError()
+	{
+		// Arrange / Act
+		var result = Result.Ok();
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Failure.Should().BeFalse();
+		result.Error.Should().BeNull();
+	}
+
+	[Fact]
+	public void Fail_WithMessage_ReturnsFailureResultWithMessage()
+	{
+		// Arrange
+		const string errorMessage = "Something went wrong";
+
+		// Act
+		var result = Result.Fail(errorMessage);
+
+		// Assert
+		result.Success.Should().BeFalse();
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Be(errorMessage);
+	}
+
+	[Fact]
+	public void Fail_WithMessageAndErrorCode_ReturnsFailureResultWithCode()
+	{
+		// Arrange
+		const string errorMessage = "Not found";
+
+		// Act
+		var result = Result.Fail(errorMessage, ResultErrorCode.NotFound);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Be(errorMessage);
+		result.ErrorCode.Should().Be(ResultErrorCode.NotFound);
+	}
+
+	[Fact]
+	public void OkT_ReturnsSuccessResultWithValue()
+	{
+		// Arrange
+		const string value = "hello";
+
+		// Act
+		var result = Result.Ok<string>(value);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().Be(value);
+		result.Error.Should().BeNull();
+	}
+
+	[Fact]
+	public void FailT_WithMessage_ReturnsFailureResultWithNullValue()
+	{
+		// Arrange
+		const string errorMessage = "bad input";
+
+		// Act
+		var result = Result.Fail<string>(errorMessage);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Be(errorMessage);
+		result.Value.Should().BeNull();
+	}
+
+	[Fact]
+	public void FromValue_NonNullValue_ReturnsSuccessResult()
+	{
+		// Arrange
+		const int value = 42;
+
+		// Act
+		var result = Result.FromValue<int?>(value);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().Be(value);
+	}
+
+	[Fact]
+	public void FromValue_NullValue_ReturnsFailureResultWithNullMessage()
+	{
+		// Arrange / Act
+		var result = Result.FromValue<string>(null);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Be("Provided value is null.");
+	}
+
+	[Fact]
+	public void ImplicitConversion_ValueToResultT_ProducesSuccessResult()
+	{
+		// Arrange / Act
+		Result<string> result = "world";
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().Be("world");
+	}
+
+	[Fact]
+	public void ImplicitConversion_ResultTToValue_ReturnsValue()
+	{
+		// Arrange
+		var result = Result.Ok<string>("data");
+
+		// Act
+		string? value = result;
+
+		// Assert
+		value.Should().Be("data");
+	}
+
+	[Fact]
+	public void ImplicitConversion_NullResultTToValue_ReturnsNull()
+	{
+		// Arrange
+		Result<string>? result = null;
+
+		// Act
+		string? value = result;
+
+		// Assert
+		value.Should().BeNull();
+	}
+
+	[Fact]
+	public void Ok_ErrorCode_IsNone()
+	{
+		// Arrange / Act
+		var result = Result.Ok();
+
+		// Assert
+		result.ErrorCode.Should().Be(ResultErrorCode.None);
+	}
+
+	[Fact]
+	public void Fail_WithoutCode_ErrorCode_IsNone()
+	{
+		// Arrange / Act
+		var result = Result.Fail("error");
+
+		// Assert
+		result.ErrorCode.Should().Be(ResultErrorCode.None);
+	}
+}

--- a/tests/Domain.Tests/Behaviors/ValidationBehaviorTests.cs
+++ b/tests/Domain.Tests/Behaviors/ValidationBehaviorTests.cs
@@ -1,0 +1,206 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     ValidationBehaviorTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Domain.Tests
+//=======================================================
+
+namespace Tests.Domain.Behaviors;
+
+/// <summary>Test request returning a plain Result.</summary>
+public sealed record TestRequest : IRequest<Result>;
+
+/// <summary>Test request returning a Result with a typed value.</summary>
+public sealed record TestRequestT : IRequest<Result<string>>;
+
+public class ValidationBehaviorTests
+{
+	[Fact]
+	public async Task Handle_NoValidators_CallsNextAndReturnsItsResult()
+	{
+		// Arrange
+		var behavior = new ValidationBehavior<TestRequest, Result>([]);
+		var expected = Result.Ok();
+		RequestHandlerDelegate<Result> next = _ => Task.FromResult(expected);
+
+		// Act
+		var result = await behavior.Handle(new TestRequest(), next, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task Handle_PassingValidator_CallsNextAndReturnsItsResult()
+	{
+		// Arrange
+		var validator = Substitute.For<IValidator<TestRequest>>();
+		validator.Validate(Arg.Any<ValidationContext<TestRequest>>())
+			.Returns(new ValidationResult());
+
+		var behavior = new ValidationBehavior<TestRequest, Result>([validator]);
+		var expected = Result.Ok();
+		RequestHandlerDelegate<Result> next = _ => Task.FromResult(expected);
+
+		// Act
+		var result = await behavior.Handle(new TestRequest(), next, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task Handle_FailingValidator_ReturnsFailResultWithErrorMessage()
+	{
+		// Arrange
+		const string errorMessage = "Title is required";
+		var failure = new ValidationFailure("Title", errorMessage);
+
+		var validator = Substitute.For<IValidator<TestRequest>>();
+		validator.Validate(Arg.Any<ValidationContext<TestRequest>>())
+			.Returns(new ValidationResult([failure]));
+
+		var behavior = new ValidationBehavior<TestRequest, Result>([validator]);
+		RequestHandlerDelegate<Result> next = _ => Task.FromResult(Result.Ok());
+
+		// Act
+		var result = await behavior.Handle(new TestRequest(), next, CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain(errorMessage);
+	}
+
+	[Fact]
+	public async Task Handle_FailingValidator_ErrorCodeIsValidation()
+	{
+		// Arrange
+		var failure = new ValidationFailure("Content", "Content is required");
+
+		var validator = Substitute.For<IValidator<TestRequest>>();
+		validator.Validate(Arg.Any<ValidationContext<TestRequest>>())
+			.Returns(new ValidationResult([failure]));
+
+		var behavior = new ValidationBehavior<TestRequest, Result>([validator]);
+		RequestHandlerDelegate<Result> next = _ => Task.FromResult(Result.Ok());
+
+		// Act
+		var result = await behavior.Handle(new TestRequest(), next, CancellationToken.None);
+
+		// Assert
+		result.ErrorCode.Should().Be(ResultErrorCode.Validation);
+	}
+
+	[Fact]
+	public async Task Handle_MultipleFailingValidators_JoinsAllErrorMessages()
+	{
+		// Arrange
+		var validator1 = Substitute.For<IValidator<TestRequest>>();
+		validator1.Validate(Arg.Any<ValidationContext<TestRequest>>())
+			.Returns(new ValidationResult([new ValidationFailure("Title", "Title required")]));
+
+		var validator2 = Substitute.For<IValidator<TestRequest>>();
+		validator2.Validate(Arg.Any<ValidationContext<TestRequest>>())
+			.Returns(new ValidationResult([new ValidationFailure("Content", "Content required")]));
+
+		var behavior = new ValidationBehavior<TestRequest, Result>([validator1, validator2]);
+		RequestHandlerDelegate<Result> next = _ => Task.FromResult(Result.Ok());
+
+		// Act
+		var result = await behavior.Handle(new TestRequest(), next, CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain("Title required");
+		result.Error.Should().Contain("Content required");
+	}
+
+	[Fact]
+	public async Task Handle_NoValidators_ResultT_CallsNextAndReturnsItsResult()
+	{
+		// Arrange
+		var behavior = new ValidationBehavior<TestRequestT, Result<string>>([]);
+		var expected = Result.Ok("response");
+		RequestHandlerDelegate<Result<string>> next = _ => Task.FromResult(expected);
+
+		// Act
+		var result = await behavior.Handle(new TestRequestT(), next, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().Be("response");
+	}
+
+	[Fact]
+	public async Task Handle_FailingValidator_ResultT_ReturnsFailResultWithErrorMessage()
+	{
+		// Arrange
+		const string errorMessage = "Author is required";
+		var failure = new ValidationFailure("Author", errorMessage);
+
+		var validator = Substitute.For<IValidator<TestRequestT>>();
+		validator.Validate(Arg.Any<ValidationContext<TestRequestT>>())
+			.Returns(new ValidationResult([failure]));
+
+		var behavior = new ValidationBehavior<TestRequestT, Result<string>>([validator]);
+		RequestHandlerDelegate<Result<string>> next = _ => Task.FromResult(Result.Ok("ok"));
+
+		// Act
+		var result = await behavior.Handle(new TestRequestT(), next, CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain(errorMessage);
+		result.Value.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task Handle_PassingValidator_NextIsCalledExactlyOnce()
+	{
+		// Arrange
+		var validator = Substitute.For<IValidator<TestRequest>>();
+		validator.Validate(Arg.Any<ValidationContext<TestRequest>>())
+			.Returns(new ValidationResult());
+
+		var behavior = new ValidationBehavior<TestRequest, Result>([validator]);
+		var callCount = 0;
+		RequestHandlerDelegate<Result> next = _ =>
+		{
+			callCount++;
+			return Task.FromResult(Result.Ok());
+		};
+
+		// Act
+		await behavior.Handle(new TestRequest(), next, CancellationToken.None);
+
+		// Assert
+		callCount.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task Handle_FailingValidator_NextIsNeverCalled()
+	{
+		// Arrange
+		var failure = new ValidationFailure("Title", "required");
+
+		var validator = Substitute.For<IValidator<TestRequest>>();
+		validator.Validate(Arg.Any<ValidationContext<TestRequest>>())
+			.Returns(new ValidationResult([failure]));
+
+		var behavior = new ValidationBehavior<TestRequest, Result>([validator]);
+		var nextCalled = false;
+		RequestHandlerDelegate<Result> next = _ =>
+		{
+			nextCalled = true;
+			return Task.FromResult(Result.Ok());
+		};
+
+		// Act
+		await behavior.Handle(new TestRequest(), next, CancellationToken.None);
+
+		// Assert
+		nextCalled.Should().BeFalse();
+	}
+}

--- a/tests/Domain.Tests/Domain.Tests.csproj
+++ b/tests/Domain.Tests/Domain.Tests.csproj
@@ -1,31 +1,31 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-<PropertyGroup>
-<TargetFramework>net10.0</TargetFramework>
-<ImplicitUsings>enable</ImplicitUsings>
-<Nullable>enable</Nullable>
-<IsPackable>false</IsPackable>
-<IsTestProject>true</IsTestProject>
-<RootNamespace>MyBlog.Domain.Tests</RootNamespace>
-</PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+		<RootNamespace>MyBlog.Domain.Tests</RootNamespace>
+	</PropertyGroup>
 
-<ItemGroup>
-<PackageReference Include="coverlet.collector"/>
-<PackageReference Include="FluentAssertions"/>
-<PackageReference Include="FluentValidation"/>
-<PackageReference Include="MediatR"/>
-<PackageReference Include="Microsoft.NET.Test.Sdk" />
-<PackageReference Include="NSubstitute"/>
-<PackageReference Include="xunit"/>
-<PackageReference Include="xunit.runner.visualstudio"/>
-</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector"/>
+		<PackageReference Include="FluentAssertions"/>
+		<PackageReference Include="FluentValidation"/>
+		<PackageReference Include="MediatR"/>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="NSubstitute"/>
+		<PackageReference Include="xunit"/>
+		<PackageReference Include="xunit.runner.visualstudio"/>
+	</ItemGroup>
 
-<ItemGroup>
-<Using Include="Xunit"/>
-</ItemGroup>
+	<ItemGroup>
+		<Using Include="Xunit"/>
+	</ItemGroup>
 
-<ItemGroup>
-<ProjectReference Include="..\..\src\Domain\Domain.csproj"/>
-</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Domain\Domain.csproj"/>
+	</ItemGroup>
 
 </Project>

--- a/tests/Domain.Tests/Domain.Tests.csproj
+++ b/tests/Domain.Tests/Domain.Tests.csproj
@@ -1,28 +1,31 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net10.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<IsPackable>false</IsPackable>
-		<IsTestProject>true</IsTestProject>
-		<RootNamespace>MyBlog.Domain.Tests</RootNamespace>
-	</PropertyGroup>
+<PropertyGroup>
+<TargetFramework>net10.0</TargetFramework>
+<ImplicitUsings>enable</ImplicitUsings>
+<Nullable>enable</Nullable>
+<IsPackable>false</IsPackable>
+<IsTestProject>true</IsTestProject>
+<RootNamespace>MyBlog.Domain.Tests</RootNamespace>
+</PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="coverlet.collector"/>
-		<PackageReference Include="FluentAssertions"/>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" />
-		<PackageReference Include="xunit"/>
-		<PackageReference Include="xunit.runner.visualstudio"/>
-	</ItemGroup>
+<ItemGroup>
+<PackageReference Include="coverlet.collector"/>
+<PackageReference Include="FluentAssertions"/>
+<PackageReference Include="FluentValidation"/>
+<PackageReference Include="MediatR"/>
+<PackageReference Include="Microsoft.NET.Test.Sdk" />
+<PackageReference Include="NSubstitute"/>
+<PackageReference Include="xunit"/>
+<PackageReference Include="xunit.runner.visualstudio"/>
+</ItemGroup>
 
-	<ItemGroup>
-		<Using Include="Xunit"/>
-	</ItemGroup>
+<ItemGroup>
+<Using Include="Xunit"/>
+</ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\Domain\Domain.csproj"/>
-	</ItemGroup>
+<ItemGroup>
+<ProjectReference Include="..\..\src\Domain\Domain.csproj"/>
+</ItemGroup>
 
 </Project>

--- a/tests/Domain.Tests/Entities/BlogPostTests.cs
+++ b/tests/Domain.Tests/Entities/BlogPostTests.cs
@@ -1,0 +1,187 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     BlogPostTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Domain.Tests
+//=======================================================
+
+namespace Tests.Domain.Entities;
+
+public class BlogPostTests
+{
+	[Fact]
+	public void Create_ValidArguments_ReturnsEntityWithCorrectFields()
+	{
+		// Arrange
+		const string title = "Test Title";
+		const string content = "Test Content";
+		const string author = "Test Author";
+
+		// Act
+		var post = BlogPost.Create(title, content, author);
+
+		// Assert
+		post.Title.Should().Be(title);
+		post.Content.Should().Be(content);
+		post.Author.Should().Be(author);
+	}
+
+	[Fact]
+	public void Create_ValidArguments_IdIsNonEmptyGuid()
+	{
+		// Arrange / Act
+		var post = BlogPost.Create("Title", "Content", "Author");
+
+		// Assert
+		post.Id.Should().NotBeEmpty();
+	}
+
+	[Fact]
+	public void Create_ValidArguments_CreatedAtIsSet()
+	{
+		// Arrange
+		var before = DateTime.UtcNow;
+
+		// Act
+		var post = BlogPost.Create("Title", "Content", "Author");
+
+		// Assert
+		post.CreatedAt.Should().BeOnOrAfter(before);
+		post.CreatedAt.Should().BeOnOrBefore(DateTime.UtcNow);
+	}
+
+	[Fact]
+	public void Create_ValidArguments_UpdatedAtIsNull()
+	{
+		// Arrange / Act
+		var post = BlogPost.Create("Title", "Content", "Author");
+
+		// Assert
+		post.UpdatedAt.Should().BeNull();
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void Create_NullOrWhiteSpaceTitle_ThrowsArgumentException(string? title)
+	{
+		// Arrange / Act
+		var act = () => BlogPost.Create(title!, "Content", "Author");
+
+		// Assert
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void Create_NullOrWhiteSpaceContent_ThrowsArgumentException(string? content)
+	{
+		// Arrange / Act
+		var act = () => BlogPost.Create("Title", content!, "Author");
+
+		// Assert
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void Create_NullOrWhiteSpaceAuthor_ThrowsArgumentException(string? author)
+	{
+		// Arrange / Act
+		var act = () => BlogPost.Create("Title", "Content", author!);
+
+		// Assert
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	public void Update_ValidArguments_UpdatesFieldsAndSetsUpdatedAt()
+	{
+		// Arrange
+		var post = BlogPost.Create("Original Title", "Original Content", "Author");
+		var before = DateTime.UtcNow;
+
+		// Act
+		post.Update("New Title", "New Content");
+
+		// Assert
+		post.Title.Should().Be("New Title");
+		post.Content.Should().Be("New Content");
+		post.UpdatedAt.Should().NotBeNull();
+		post.UpdatedAt!.Value.Should().BeOnOrAfter(before);
+	}
+
+	[Fact]
+	public void Update_ValidArguments_UpdatedAtIsNullBeforeUpdate_NonNullAfter()
+	{
+		// Arrange
+		var post = BlogPost.Create("Title", "Content", "Author");
+		post.UpdatedAt.Should().BeNull();
+
+		// Act
+		post.Update("New Title", "New Content");
+
+		// Assert
+		post.UpdatedAt.Should().NotBeNull();
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void Update_NullOrWhiteSpaceTitle_ThrowsArgumentException(string? title)
+	{
+		// Arrange
+		var post = BlogPost.Create("Title", "Content", "Author");
+
+		// Act
+		var act = () => post.Update(title!, "New Content");
+
+		// Assert
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	public void Publish_SetsIsPublishedTrue()
+	{
+		// Arrange
+		var post = BlogPost.Create("Title", "Content", "Author");
+
+		// Act
+		post.Publish();
+
+		// Assert
+		post.IsPublished.Should().BeTrue();
+	}
+
+	[Fact]
+	public void Unpublish_SetsIsPublishedFalse()
+	{
+		// Arrange
+		var post = BlogPost.Create("Title", "Content", "Author");
+		post.Publish();
+
+		// Act
+		post.Unpublish();
+
+		// Assert
+		post.IsPublished.Should().BeFalse();
+	}
+
+	[Fact]
+	public void Create_NewPost_IsPublishedIsFalse()
+	{
+		// Arrange / Act
+		var post = BlogPost.Create("Title", "Content", "Author");
+
+		// Assert
+		post.IsPublished.Should().BeFalse();
+	}
+}

--- a/tests/Domain.Tests/GlobalUsings.cs
+++ b/tests/Domain.Tests/GlobalUsings.cs
@@ -8,4 +8,10 @@
 //=======================================================
 
 global using FluentAssertions;
+global using FluentValidation;
+global using FluentValidation.Results;
+global using MediatR;
+global using MyBlog.Domain.Abstractions;
+global using MyBlog.Domain.Behaviors;
 global using MyBlog.Domain.Entities;
+global using NSubstitute;


### PR DESCRIPTION
Closes #141

Working as Gimli, the Tester (QA Engineer)

## Changes

Adds 42 unit tests across three new test files in `tests/Domain.Tests/`:

| File | Tests | Coverage |
|---|---|---|
| `Entities/BlogPostTests.cs` | 14 | `BlogPost.Create`, `Update`, `Publish`, `Unpublish`, guard clauses |
| `Abstractions/ResultTests.cs` | 13 | `Result.Ok`, `Result.Fail`, `Result.Ok<T>`, `Result.Fail<T>`, `Result.FromValue<T>`, implicit conversions |
| `Behaviors/ValidationBehaviorTests.cs` | 9 | No-validators path, passing validator, failing validator, multi-validator join, `next` delegation |

Also adds `NSubstitute`, `FluentValidation`, and `MediatR` package references to `Domain.Tests.csproj` and the corresponding global usings.

## Verification

```
Passed! - Failed: 0, Passed: 42, Skipped: 0, Total: 42
```