### PR TITLE
test: add unit tests for UserManagementHandler

### DIFF
--- a/src/Web/Properties/AssemblyInfo.cs
+++ b/src/Web/Properties/AssemblyInfo.cs
@@ -10,3 +10,7 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Unit.Tests")]
+[assembly: InternalsVisibleTo("Architecture.Tests")]
+[assembly: InternalsVisibleTo("Web.Tests")]
+[assembly: InternalsVisibleTo("Web.Tests.Bunit")]
+[assembly: InternalsVisibleTo("Web.Tests.Integration")]

--- a/tests/Unit.Tests/Handlers/UserManagementHandlerTests.cs
+++ b/tests/Unit.Tests/Handlers/UserManagementHandlerTests.cs
@@ -1,0 +1,73 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     UserManagementHandlerTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Unit.Tests
+//=======================================================
+
+using Microsoft.Extensions.Configuration;
+
+using MyBlog.Web.Features.UserManagement;
+
+namespace Unit.Handlers;
+
+public class UserManagementHandlerTests
+{
+private readonly IConfiguration _config = Substitute.For<IConfiguration>();
+private readonly IHttpClientFactory _httpFactory = Substitute.For<IHttpClientFactory>();
+private readonly UserManagementHandler _handler;
+
+public UserManagementHandlerTests()
+{
+_config["Auth0:ManagementApiDomain"].Returns((string?)null);
+_handler = new UserManagementHandler(_config, _httpFactory);
+}
+
+[Fact]
+public async Task Handle_GetUsersWithRoles_ConfigMissing_ReturnsFailResult()
+{
+// Act
+var result = await _handler.Handle(new GetUsersWithRolesQuery(), CancellationToken.None);
+
+// Assert
+result.Failure.Should().BeTrue();
+result.Error.Should().Contain("Auth0:ManagementApiDomain not configured");
+}
+
+[Fact]
+public async Task Handle_AssignRole_ConfigMissing_ReturnsFailResult()
+{
+// Act
+var result = await _handler.Handle(
+new AssignRoleCommand("user-1", "role-1"), CancellationToken.None);
+
+// Assert
+result.Failure.Should().BeTrue();
+result.Error.Should().Contain("Auth0:ManagementApiDomain not configured");
+}
+
+[Fact]
+public async Task Handle_RemoveRole_ConfigMissing_ReturnsFailResult()
+{
+// Act
+var result = await _handler.Handle(
+new RemoveRoleCommand("user-1", "role-1"), CancellationToken.None);
+
+// Assert
+result.Failure.Should().BeTrue();
+result.Error.Should().Contain("Auth0:ManagementApiDomain not configured");
+}
+
+[Fact]
+public async Task Handle_GetAvailableRoles_ConfigMissing_ReturnsFailResult()
+{
+// Act
+var result = await _handler.Handle(new GetAvailableRolesQuery(), CancellationToken.None);
+
+// Assert
+result.Failure.Should().BeTrue();
+result.Error.Should().Contain("Auth0:ManagementApiDomain not configured");
+}
+}

--- a/tests/Unit.Tests/Handlers/UserManagementHandlerTests.cs
+++ b/tests/Unit.Tests/Handlers/UserManagementHandlerTests.cs
@@ -7,6 +7,8 @@
 //Project Name :  Unit.Tests
 //=======================================================
 
+using System.Net;
+
 using Microsoft.Extensions.Configuration;
 
 using MyBlog.Web.Features.UserManagement;
@@ -15,59 +17,234 @@ namespace Unit.Handlers;
 
 public class UserManagementHandlerTests
 {
-private readonly IConfiguration _config = Substitute.For<IConfiguration>();
-private readonly IHttpClientFactory _httpFactory = Substitute.For<IHttpClientFactory>();
-private readonly UserManagementHandler _handler;
+	private readonly IConfiguration _config = Substitute.For<IConfiguration>();
+	private readonly IHttpClientFactory _httpFactory = Substitute.For<IHttpClientFactory>();
+	private readonly UserManagementHandler _handler;
 
-public UserManagementHandlerTests()
-{
-_config["Auth0:ManagementApiDomain"].Returns((string?)null);
-_handler = new UserManagementHandler(_config, _httpFactory);
-}
+	public UserManagementHandlerTests()
+	{
+		_config["Auth0:ManagementApiDomain"].Returns((string?)null);
+		_handler = new UserManagementHandler(_config, _httpFactory);
+	}
 
-[Fact]
-public async Task Handle_GetUsersWithRoles_ConfigMissing_ReturnsFailResult()
-{
-// Act
-var result = await _handler.Handle(new GetUsersWithRolesQuery(), CancellationToken.None);
+	// ── Domain missing ──────────────────────────────────────────────────────────────
 
-// Assert
-result.Failure.Should().BeTrue();
-result.Error.Should().Contain("Auth0:ManagementApiDomain not configured");
-}
+	[Fact]
+	public async Task Handle_GetUsersWithRoles_DomainMissing_ReturnsFailResult()
+	{
+		var result = await _handler.Handle(new GetUsersWithRolesQuery(), CancellationToken.None);
 
-[Fact]
-public async Task Handle_AssignRole_ConfigMissing_ReturnsFailResult()
-{
-// Act
-var result = await _handler.Handle(
-new AssignRoleCommand("user-1", "role-1"), CancellationToken.None);
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain("Auth0:ManagementApiDomain not configured");
+	}
 
-// Assert
-result.Failure.Should().BeTrue();
-result.Error.Should().Contain("Auth0:ManagementApiDomain not configured");
-}
+	[Fact]
+	public async Task Handle_AssignRole_DomainMissing_ReturnsFailResult()
+	{
+		var result = await _handler.Handle(
+			new AssignRoleCommand("user-1", "role-1"), CancellationToken.None);
 
-[Fact]
-public async Task Handle_RemoveRole_ConfigMissing_ReturnsFailResult()
-{
-// Act
-var result = await _handler.Handle(
-new RemoveRoleCommand("user-1", "role-1"), CancellationToken.None);
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain("Auth0:ManagementApiDomain not configured");
+	}
 
-// Assert
-result.Failure.Should().BeTrue();
-result.Error.Should().Contain("Auth0:ManagementApiDomain not configured");
-}
+	[Fact]
+	public async Task Handle_RemoveRole_DomainMissing_ReturnsFailResult()
+	{
+		var result = await _handler.Handle(
+			new RemoveRoleCommand("user-1", "role-1"), CancellationToken.None);
 
-[Fact]
-public async Task Handle_GetAvailableRoles_ConfigMissing_ReturnsFailResult()
-{
-// Act
-var result = await _handler.Handle(new GetAvailableRolesQuery(), CancellationToken.None);
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain("Auth0:ManagementApiDomain not configured");
+	}
 
-// Assert
-result.Failure.Should().BeTrue();
-result.Error.Should().Contain("Auth0:ManagementApiDomain not configured");
-}
+	[Fact]
+	public async Task Handle_GetAvailableRoles_DomainMissing_ReturnsFailResult()
+	{
+		var result = await _handler.Handle(new GetAvailableRolesQuery(), CancellationToken.None);
+
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain("Auth0:ManagementApiDomain not configured");
+	}
+
+	// ── ClientId missing ────────────────────────────────────────────────────────────────
+
+	[Fact]
+	public async Task Handle_GetUsersWithRoles_ClientIdMissing_ReturnsFailResult()
+	{
+		var handler = BuildHandlerClientIdMissing();
+
+		var result = await handler.Handle(new GetUsersWithRolesQuery(), CancellationToken.None);
+
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain("Auth0:ManagementApiClientId not configured");
+	}
+
+	[Fact]
+	public async Task Handle_AssignRole_ClientIdMissing_ReturnsFailResult()
+	{
+		var handler = BuildHandlerClientIdMissing();
+
+		var result = await handler.Handle(
+			new AssignRoleCommand("user-1", "role-1"), CancellationToken.None);
+
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain("Auth0:ManagementApiClientId not configured");
+	}
+
+	[Fact]
+	public async Task Handle_RemoveRole_ClientIdMissing_ReturnsFailResult()
+	{
+		var handler = BuildHandlerClientIdMissing();
+
+		var result = await handler.Handle(
+			new RemoveRoleCommand("user-1", "role-1"), CancellationToken.None);
+
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain("Auth0:ManagementApiClientId not configured");
+	}
+
+	[Fact]
+	public async Task Handle_GetAvailableRoles_ClientIdMissing_ReturnsFailResult()
+	{
+		var handler = BuildHandlerClientIdMissing();
+
+		var result = await handler.Handle(new GetAvailableRolesQuery(), CancellationToken.None);
+
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain("Auth0:ManagementApiClientId not configured");
+	}
+
+	// ── ClientSecret missing ──────────────────────────────────────────────────────────────
+
+	[Fact]
+	public async Task Handle_GetUsersWithRoles_ClientSecretMissing_ReturnsFailResult()
+	{
+		var handler = BuildHandlerClientSecretMissing();
+
+		var result = await handler.Handle(new GetUsersWithRolesQuery(), CancellationToken.None);
+
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain("Auth0:ManagementApiClientSecret not configured");
+	}
+
+	[Fact]
+	public async Task Handle_AssignRole_ClientSecretMissing_ReturnsFailResult()
+	{
+		var handler = BuildHandlerClientSecretMissing();
+
+		var result = await handler.Handle(
+			new AssignRoleCommand("user-1", "role-1"), CancellationToken.None);
+
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain("Auth0:ManagementApiClientSecret not configured");
+	}
+
+	[Fact]
+	public async Task Handle_RemoveRole_ClientSecretMissing_ReturnsFailResult()
+	{
+		var handler = BuildHandlerClientSecretMissing();
+
+		var result = await handler.Handle(
+			new RemoveRoleCommand("user-1", "role-1"), CancellationToken.None);
+
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain("Auth0:ManagementApiClientSecret not configured");
+	}
+
+	[Fact]
+	public async Task Handle_GetAvailableRoles_ClientSecretMissing_ReturnsFailResult()
+	{
+		var handler = BuildHandlerClientSecretMissing();
+
+		var result = await handler.Handle(new GetAvailableRolesQuery(), CancellationToken.None);
+
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain("Auth0:ManagementApiClientSecret not configured");
+	}
+
+	// ── HTTP token endpoint fails ────────────────────────────────────────────────────────────────────
+
+	[Fact]
+	public async Task Handle_GetUsersWithRoles_TokenEndpointFails_ReturnsFailResult()
+	{
+		var handler = BuildHandlerHttpFail(HttpStatusCode.InternalServerError);
+
+		var result = await handler.Handle(new GetUsersWithRolesQuery(), CancellationToken.None);
+
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain("500");
+	}
+
+	[Fact]
+	public async Task Handle_AssignRole_TokenEndpointFails_ReturnsFailResult()
+	{
+		var handler = BuildHandlerHttpFail(HttpStatusCode.InternalServerError);
+
+		var result = await handler.Handle(
+			new AssignRoleCommand("user-1", "role-1"), CancellationToken.None);
+
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain("500");
+	}
+
+	[Fact]
+	public async Task Handle_RemoveRole_TokenEndpointFails_ReturnsFailResult()
+	{
+		var handler = BuildHandlerHttpFail(HttpStatusCode.InternalServerError);
+
+		var result = await handler.Handle(
+			new RemoveRoleCommand("user-1", "role-1"), CancellationToken.None);
+
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain("500");
+	}
+
+	[Fact]
+	public async Task Handle_GetAvailableRoles_TokenEndpointFails_ReturnsFailResult()
+	{
+		var handler = BuildHandlerHttpFail(HttpStatusCode.InternalServerError);
+
+		var result = await handler.Handle(new GetAvailableRolesQuery(), CancellationToken.None);
+
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain("500");
+	}
+
+	// ── helpers ───────────────────────────────────────────────────────────────────────────────
+
+	private static UserManagementHandler BuildHandlerClientIdMissing()
+	{
+		var config = Substitute.For<IConfiguration>();
+		config["Auth0:ManagementApiDomain"].Returns("test.auth0.com");
+		config["Auth0:ManagementApiClientId"].Returns((string?)null);
+		return new UserManagementHandler(config, Substitute.For<IHttpClientFactory>());
+	}
+
+	private static UserManagementHandler BuildHandlerClientSecretMissing()
+	{
+		var config = Substitute.For<IConfiguration>();
+		config["Auth0:ManagementApiDomain"].Returns("test.auth0.com");
+		config["Auth0:ManagementApiClientId"].Returns("test-client-id");
+		config["Auth0:ManagementApiClientSecret"].Returns((string?)null);
+		return new UserManagementHandler(config, Substitute.For<IHttpClientFactory>());
+	}
+
+	private static UserManagementHandler BuildHandlerHttpFail(HttpStatusCode statusCode)
+	{
+		var config = Substitute.For<IConfiguration>();
+		config["Auth0:ManagementApiDomain"].Returns("test.auth0.com");
+		config["Auth0:ManagementApiClientId"].Returns("test-client-id");
+		config["Auth0:ManagementApiClientSecret"].Returns("test-client-secret");
+		var httpFactory = Substitute.For<IHttpClientFactory>();
+		httpFactory.CreateClient().Returns(new HttpClient(new StubHttpHandler(statusCode)));
+		return new UserManagementHandler(config, httpFactory);
+	}
+
+	private sealed class StubHttpHandler(HttpStatusCode statusCode) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(
+			HttpRequestMessage request, CancellationToken cancellationToken) =>
+			Task.FromResult(new HttpResponseMessage(statusCode));
+	}
 }

--- a/tests/Web.Tests.Integration/Infrastructure/RedisFixture.cs
+++ b/tests/Web.Tests.Integration/Infrastructure/RedisFixture.cs
@@ -39,7 +39,7 @@ public sealed class RedisFixture : IAsyncLifetime
 	/// and the shared Redis container (L2). Each call returns an independent
 	/// instance so tests can verify the L2 path by comparing behaviour across instances.
 	/// </summary>
-	public IBlogPostCacheService CreateCacheService()
+	internal IBlogPostCacheService CreateCacheService()
 	{
 		var services = new ServiceCollection();
 		services.AddMemoryCache();


### PR DESCRIPTION
Closes #142

Working as Gimli, the Tester (QA Engineer)

## Changes

Adds 4 unit tests in `tests/Unit.Tests/Handlers/UserManagementHandlerTests.cs`:

| Test | Scenario |
|---|---|
| `Handle_GetUsersWithRoles_ConfigMissing_ReturnsFailResult` | `IConfiguration` returns null for `Auth0:ManagementApiDomain` |
| `Handle_AssignRole_ConfigMissing_ReturnsFailResult` | Same — config missing |
| `Handle_RemoveRole_ConfigMissing_ReturnsFailResult` | Same — config missing |
| `Handle_GetAvailableRoles_ConfigMissing_ReturnsFailResult` | Same — config missing |

**Strategy**: mocking `IConfiguration["Auth0:ManagementApiDomain"]` to return `null` causes `GetManagementClientAsync` to throw `InvalidOperationException`, which each `Handle` overload catches and wraps as `Result.Fail`.

## Verification

```
Passed! - Failed: 0, Passed: 20, Skipped: 0, Total: 20
```