### PR TITLE
test: add unit tests for BlogPostMappings

### DIFF
--- a/tests/Unit.Tests/Data/BlogPostMappingsTests.cs
+++ b/tests/Unit.Tests/Data/BlogPostMappingsTests.cs
@@ -1,0 +1,100 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     BlogPostMappingsTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Unit.Tests
+//=======================================================
+
+namespace Unit.Data;
+
+public class BlogPostMappingsTests
+{
+[Fact]
+public void ToDto_MapsAllFields_Correctly()
+{
+// Arrange
+var post = BlogPost.Create("Test Title", "Test Content", "Test Author");
+
+// Act
+var dto = post.ToDto();
+
+// Assert
+dto.Id.Should().Be(post.Id);
+dto.Title.Should().Be(post.Title);
+dto.Content.Should().Be(post.Content);
+dto.Author.Should().Be(post.Author);
+dto.CreatedAt.Should().Be(post.CreatedAt);
+}
+
+[Fact]
+public void ToDto_UpdatedAt_IsNullOnNewPost()
+{
+// Arrange
+var post = BlogPost.Create("Title", "Content", "Author");
+
+// Act
+var dto = post.ToDto();
+
+// Assert
+dto.UpdatedAt.Should().BeNull();
+}
+
+[Fact]
+public void ToDto_UpdatedAt_IsSetAfterUpdate()
+{
+// Arrange
+var post = BlogPost.Create("Title", "Content", "Author");
+post.Update("New Title", "New Content");
+
+// Act
+var dto = post.ToDto();
+
+// Assert
+dto.UpdatedAt.Should().NotBeNull();
+dto.UpdatedAt.Should().Be(post.UpdatedAt);
+}
+
+[Fact]
+public void ToDto_IsPublished_FalseOnNewPost()
+{
+// Arrange
+var post = BlogPost.Create("Title", "Content", "Author");
+
+// Act
+var dto = post.ToDto();
+
+// Assert
+dto.IsPublished.Should().BeFalse();
+}
+
+[Fact]
+public void ToDto_IsPublished_TrueAfterPublish()
+{
+// Arrange
+var post = BlogPost.Create("Title", "Content", "Author");
+post.Publish();
+
+// Act
+var dto = post.ToDto();
+
+// Assert
+dto.IsPublished.Should().BeTrue();
+}
+
+[Fact]
+public void ToDto_IsPublished_FalseAfterUnpublish()
+{
+// Arrange
+var post = BlogPost.Create("Title", "Content", "Author");
+post.Publish();
+post.Unpublish();
+
+// Act
+var dto = post.ToDto();
+
+// Assert
+dto.IsPublished.Should().BeFalse();
+}
+}

--- a/tests/Unit.Tests/Data/BlogPostMappingsTests.cs
+++ b/tests/Unit.Tests/Data/BlogPostMappingsTests.cs
@@ -11,90 +11,90 @@ namespace Unit.Data;
 
 public class BlogPostMappingsTests
 {
-[Fact]
-public void ToDto_MapsAllFields_Correctly()
-{
-// Arrange
-var post = BlogPost.Create("Test Title", "Test Content", "Test Author");
+	[Fact]
+	public void ToDto_MapsAllFields_Correctly()
+	{
+		// Arrange
+		var post = BlogPost.Create("Test Title", "Test Content", "Test Author");
 
-// Act
-var dto = post.ToDto();
+		// Act
+		var dto = post.ToDto();
 
-// Assert
-dto.Id.Should().Be(post.Id);
-dto.Title.Should().Be(post.Title);
-dto.Content.Should().Be(post.Content);
-dto.Author.Should().Be(post.Author);
-dto.CreatedAt.Should().Be(post.CreatedAt);
-}
+		// Assert
+		dto.Id.Should().Be(post.Id);
+		dto.Title.Should().Be(post.Title);
+		dto.Content.Should().Be(post.Content);
+		dto.Author.Should().Be(post.Author);
+		dto.CreatedAt.Should().Be(post.CreatedAt);
+	}
 
-[Fact]
-public void ToDto_UpdatedAt_IsNullOnNewPost()
-{
-// Arrange
-var post = BlogPost.Create("Title", "Content", "Author");
+	[Fact]
+	public void ToDto_UpdatedAt_IsNullOnNewPost()
+	{
+		// Arrange
+		var post = BlogPost.Create("Title", "Content", "Author");
 
-// Act
-var dto = post.ToDto();
+		// Act
+		var dto = post.ToDto();
 
-// Assert
-dto.UpdatedAt.Should().BeNull();
-}
+		// Assert
+		dto.UpdatedAt.Should().BeNull();
+	}
 
-[Fact]
-public void ToDto_UpdatedAt_IsSetAfterUpdate()
-{
-// Arrange
-var post = BlogPost.Create("Title", "Content", "Author");
-post.Update("New Title", "New Content");
+	[Fact]
+	public void ToDto_UpdatedAt_IsSetAfterUpdate()
+	{
+		// Arrange
+		var post = BlogPost.Create("Title", "Content", "Author");
+		post.Update("New Title", "New Content");
 
-// Act
-var dto = post.ToDto();
+		// Act
+		var dto = post.ToDto();
 
-// Assert
-dto.UpdatedAt.Should().NotBeNull();
-dto.UpdatedAt.Should().Be(post.UpdatedAt);
-}
+		// Assert
+		dto.UpdatedAt.Should().NotBeNull();
+		dto.UpdatedAt.Should().Be(post.UpdatedAt);
+	}
 
-[Fact]
-public void ToDto_IsPublished_FalseOnNewPost()
-{
-// Arrange
-var post = BlogPost.Create("Title", "Content", "Author");
+	[Fact]
+	public void ToDto_IsPublished_FalseOnNewPost()
+	{
+		// Arrange
+		var post = BlogPost.Create("Title", "Content", "Author");
 
-// Act
-var dto = post.ToDto();
+		// Act
+		var dto = post.ToDto();
 
-// Assert
-dto.IsPublished.Should().BeFalse();
-}
+		// Assert
+		dto.IsPublished.Should().BeFalse();
+	}
 
-[Fact]
-public void ToDto_IsPublished_TrueAfterPublish()
-{
-// Arrange
-var post = BlogPost.Create("Title", "Content", "Author");
-post.Publish();
+	[Fact]
+	public void ToDto_IsPublished_TrueAfterPublish()
+	{
+		// Arrange
+		var post = BlogPost.Create("Title", "Content", "Author");
+		post.Publish();
 
-// Act
-var dto = post.ToDto();
+		// Act
+		var dto = post.ToDto();
 
-// Assert
-dto.IsPublished.Should().BeTrue();
-}
+		// Assert
+		dto.IsPublished.Should().BeTrue();
+	}
 
-[Fact]
-public void ToDto_IsPublished_FalseAfterUnpublish()
-{
-// Arrange
-var post = BlogPost.Create("Title", "Content", "Author");
-post.Publish();
-post.Unpublish();
+	[Fact]
+	public void ToDto_IsPublished_FalseAfterUnpublish()
+	{
+		// Arrange
+		var post = BlogPost.Create("Title", "Content", "Author");
+		post.Publish();
+		post.Unpublish();
 
-// Act
-var dto = post.ToDto();
+		// Act
+		var dto = post.ToDto();
 
-// Assert
-dto.IsPublished.Should().BeFalse();
-}
+		// Assert
+		dto.IsPublished.Should().BeFalse();
+	}
 }


### PR DESCRIPTION
Closes #143

Working as Gimli, the Tester (QA Engineer)

## Changes

Adds 6 unit tests in `tests/Unit.Tests/Data/BlogPostMappingsTests.cs`:

| Test | Scenario |
|---|---|
| `ToDto_MapsAllFields_Correctly` | Id, Title, Content, Author, CreatedAt all map to matching DTO fields |
| `ToDto_UpdatedAt_IsNullOnNewPost` | `UpdatedAt` is null immediately after `BlogPost.Create` |
| `ToDto_UpdatedAt_IsSetAfterUpdate` | `UpdatedAt` is non-null after calling `post.Update(...)` |
| `ToDto_IsPublished_FalseOnNewPost` | `IsPublished` is false by default |
| `ToDto_IsPublished_TrueAfterPublish` | `IsPublished` is true after `post.Publish()` |
| `ToDto_IsPublished_FalseAfterUnpublish` | `IsPublished` is false after `post.Publish()` then `post.Unpublish()` |

`BlogPostMappings.ToDto()` is internal — access granted via `[assembly: InternalsVisibleTo("Unit.Tests")]` in `AssemblyInfo.cs`.

## Verification

```
Passed! - Failed: 0, Passed: 22, Skipped: 0, Total: 22
```