### PR TITLE
feat: migrate Domain.Tests to xUnit v3 (#163)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,6 +50,7 @@
 		<PackageVersion Include="coverlet.collector" Version="10.0.0" />
 		<PackageVersion Include="coverlet.msbuild" Version="10.0.0" />
 		<PackageVersion Include="xunit" Version="2.9.3" />
+		<PackageVersion Include="xunit.v3" Version="3.2.2" />
 		<PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
 	</ItemGroup>
 </Project>

--- a/tests/Domain.Tests/Domain.Tests.csproj
+++ b/tests/Domain.Tests/Domain.Tests.csproj
@@ -16,8 +16,12 @@
 		<PackageReference Include="MediatR"/>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="NSubstitute"/>
-		<PackageReference Include="xunit"/>
+		<PackageReference Include="xunit.v3"/>
 		<PackageReference Include="xunit.runner.visualstudio"/>
+	</ItemGroup>
+
+	<ItemGroup>
+		<Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/Domain.Tests/xunit.runner.json
+++ b/tests/Domain.Tests/xunit.runner.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "methodDisplay": "method",
+  "methodDisplayOptions": "all",
+  "parallelizeAssembly": true,
+  "parallelizeTestCollections": true,
+  "diagnosticMessages": false
+}


### PR DESCRIPTION
## Summary

Migrates `Domain.Tests` from xUnit v2 (2.9.3) to xUnit v3 (3.2.2) as the pilot project for Sprint 7.

Working as **Gimli** (Tester) 🪓

Closes #163

## Changes

| File | Change |
|------|--------|
| `Directory.Packages.props` | Added `xunit.v3 3.2.2` alongside existing `xunit 2.9.3` (other projects unaffected) |
| `tests/Domain.Tests/Domain.Tests.csproj` | Replaced `xunit` → `xunit.v3` package reference; added `xunit.runner.json` as content |
| `tests/Domain.Tests/xunit.runner.json` | New: v3 runner config (parallel execution, method display, no diagnostics) |

**Zero source changes required** — the 42 test files use simple `[Fact]`/`[Theory]` patterns with no `ITestOutputHelper`, `IAsyncLifetime`, or collection fixtures. The `Xunit` namespace is unchanged in v3.

## Test Results

| Suite | Result |
|-------|--------|
| Domain.Tests (xUnit v3) | ✅ 42/42 pass |
| Architecture.Tests | ✅ 11/11 pass |
| Web.Tests | ✅ 105/105 pass |
| Web.Tests.Bunit | ✅ 61/61 pass |

## Notes

- `xunit.runner.visualstudio 3.1.5` was already in place and is v3-compatible — no change needed.
- NuGet change from #162 was folded into this PR since #162 had no commits beyond the sprint base.
