### PR TITLE
ci: add Domain.Tests job to squad-test.yml for xUnit v3 CI validation (#165)

### DIFF
--- a/.github/workflows/squad-test.yml
+++ b/.github/workflows/squad-test.yml
@@ -189,6 +189,66 @@ jobs:
           name: architecture-test-results
           path: test-results
 
+  test-domain:
+    name: "Domain.Tests (xUnit v3 pilot)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          path: ${{ github.workspace }}/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build Domain Tests
+        run: dotnet build tests/Domain.Tests --configuration Release --no-restore
+
+      - name: Run Domain Tests
+        id: domain-tests
+        run: |
+          mkdir -p test-results
+          if [ ! -d "tests/Domain.Tests" ]; then
+            echo "::notice::Domain test project not found at tests/Domain.Tests - skipping"
+            exit 0
+          fi
+
+          # xUnit v3 is fully compatible with dotnet test + XPlat Code Coverage + TRX logger
+          dotnet test tests/Domain.Tests \
+            --configuration Release \
+            --no-build \
+            --logger "trx;LogFileName=domain.trx" \
+            --results-directory "$GITHUB_WORKSPACE/test-results" \
+            --collect:"XPlat Code Coverage" \
+            -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
+          exit_code=$?
+
+          if [ $exit_code -ne 0 ]; then
+            echo "::error::Domain tests failed"
+          fi
+          exit $exit_code
+
+      - name: Upload Domain Test Results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: domain-test-results
+          path: test-results
+
   test-bunit:
     name: "Web.Tests.Bunit"
     runs-on: ubuntu-latest
@@ -430,6 +490,7 @@ jobs:
     needs:
       - test-web
       - test-architecture
+      - test-domain
       - test-bunit
       - test-integration
       - test-apphost
@@ -500,6 +561,7 @@ jobs:
       - build
       - test-web
       - test-architecture
+      - test-domain
       - test-bunit
       - test-integration
       - test-apphost
@@ -533,6 +595,7 @@ jobs:
           echo "- **Build:** ${{ needs.build.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Web.Tests:** ${{ needs.test-web.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Architecture.Tests:** ${{ needs.test-architecture.result }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Domain.Tests (xUnit v3 pilot):** ${{ needs.test-domain.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Web.Tests.Bunit:** ${{ needs.test-bunit.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Web.Tests.Integration:** ${{ needs.test-integration.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- **AppHost.Tests (Aspire + Playwright E2E):** ${{ needs.test-apphost.result }}" >> $GITHUB_STEP_SUMMARY
@@ -546,12 +609,14 @@ jobs:
           build_status="${{ needs.build.result }}"
           web_status="${{ needs.test-web.result }}"
           arch_status="${{ needs.test-architecture.result }}"
+          domain_status="${{ needs.test-domain.result }}"
           bunit_status="${{ needs.test-bunit.result }}"
           integration_status="${{ needs.test-integration.result }}"
           apphost_status="${{ needs.test-apphost.result }}"
 
           if [[ "$build_status" == "failure" || "$web_status" == "failure" || \
-                "$arch_status" == "failure" || "$bunit_status" == "failure" || \
+                "$arch_status" == "failure" || "$domain_status" == "failure" || \
+                "$bunit_status" == "failure" || \
                 "$integration_status" == "failure" || "$apphost_status" == "failure" ]]; then
             echo "❌ **Overall Status:** FAILED" >> $GITHUB_STEP_SUMMARY
           else


### PR DESCRIPTION
## Summary

Adds a `test-domain` job to `squad-test.yml` to validate that Domain.Tests runs correctly in CI under xUnit v3. This unblocks Gimli's migration work (#163/#164) — the CI pipeline is ready before test code is written.

## Changes

**`.github/workflows/squad-test.yml`** — 3 targeted edits:

1. **New `test-domain` job** — runs `tests/Domain.Tests` with the same pattern as other test jobs:
   - `dotnet build` + `dotnet test --no-build` (Release config)
   - `--collect:"XPlat Code Coverage"` with Cobertura format
   - TRX logger → `domain-test-results` artifact
   - Guard clause: skips gracefully if project not found

2. **`coverage` job** — added `test-domain` to `needs` list so Domain.Tests coverage is included in the report

3. **`report` job** — added `test-domain` to `needs` list and job summary output; added `domain_status` to the overall failure gate

## xUnit v3 CI Compatibility

No runner/tool changes were required:

| Tool | v2 compat | v3 compat | Notes |
|------|-----------|-----------|-------|
| `dotnet test` | ✅ | ✅ | No changes needed |
| `XPlat Code Coverage` | ✅ | ✅ | Coverlet collector works unchanged |
| TRX logger | ✅ | ✅ | Standard .NET test output |
| `EnricoMi/publish-unit-test-result-action` | ✅ | ✅ | Reads TRX, not xUnit-specific |
| `coverlet.collector` 10.0.0 | ✅ | ✅ | Already in Directory.Packages.props |

## Depends on

PR #173 (feat: add xUnit v3 packages to Directory.Packages.props) should merge first so the NuGet packages are available.

Closes #165

---
*Working as Boromir (DevOps engineer) — CI/CD pipeline management*