### PR TITLE
Add xUnit v3 packages to Architecture.Tests (#176)

### DIFF
--- a/tests/Architecture.Tests/Architecture.Tests.csproj
+++ b/tests/Architecture.Tests/Architecture.Tests.csproj
@@ -14,8 +14,13 @@
 		<PackageReference Include="FluentAssertions"/>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="NetArchTest.Rules"/>
-		<PackageReference Include="xunit"/>
+		<PackageReference Include="xunit.analyzers"/>
 		<PackageReference Include="xunit.runner.visualstudio"/>
+		<PackageReference Include="xunit.v3"/>
+	</ItemGroup>
+
+	<ItemGroup>
+		<Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/Architecture.Tests/xunit.runner.json
+++ b/tests/Architecture.Tests/xunit.runner.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "methodDisplay": "method",
+  "methodDisplayOptions": "all",
+  "parallelizeAssembly": true,
+  "parallelizeTestCollections": true,
+  "diagnosticMessages": false
+}


### PR DESCRIPTION
## Summary

Closes #176

Working as **Boromir** (DevOps Engineer)

Mirrors the Sprint 7 Domain.Tests xUnit v3 pilot by upgrading Architecture.Tests from xunit 2.x to xunit.v3 3.2.2.

## Changes

- **`tests/Architecture.Tests/Architecture.Tests.csproj`**
  - Replaced `<PackageReference Include="xunit"/>` with `<PackageReference Include="xunit.v3"/>` (version 3.2.2 centralized in `Directory.Packages.props`)
  - Added `<PackageReference Include="xunit.analyzers"/>` (version 1.27.0 centralized)
  - Added `xunit.runner.json` as `Content` item (matching Domain.Tests pattern)
- **`tests/Architecture.Tests/xunit.runner.json`** — new file matching Domain.Tests Sprint 7 configuration

## Sprint 7 Pilot Context

`Directory.Packages.props` already contained `xunit.v3 3.2.2`, `xunit.v3.assert`, `xunit.v3.extensibility.core`, and `xunit.analyzers 1.27.0` from the Sprint 7 Domain.Tests pilot. This PR wires up Architecture.Tests to use those centralized entries.

## NuGet Policy Compliance

✅ All versions remain in `Directory.Packages.props` — no version pins in `.csproj`

## Local Validation

- `dotnet build`: ✅ 0 errors
- `dotnet test tests/Architecture.Tests`: ✅ 11/11 passed
- `dotnet test tests/Domain.Tests`: ✅ 42/42 passed (pilot unaffected)