### PR TITLE
Migrate Architecture.Tests to xUnit v3 (#178)

### DIFF
--- a/tests/Architecture.Tests/CachingLayerTests.cs
+++ b/tests/Architecture.Tests/CachingLayerTests.cs
@@ -18,6 +18,7 @@ public class CachingLayerTests
 	[Fact]
 	public void Features_Should_Not_Reference_IDistributedCache_Directly()
 	{
+		// Arrange / Act
 		var result = Types.InAssembly(WebAssembly)
 				.That()
 				.ResideInNamespace("MyBlog.Web.Features")
@@ -25,6 +26,7 @@ public class CachingLayerTests
 				.HaveDependencyOnAny("Microsoft.Extensions.Caching.Distributed")
 				.GetResult();
 
+		// Assert
 		result.IsSuccessful.Should().BeTrue(
 			"VSA handlers must delegate caching to IBlogPostCacheService, not reference IDistributedCache directly");
 	}
@@ -32,6 +34,7 @@ public class CachingLayerTests
 	[Fact]
 	public void Features_Should_Not_Reference_IMemoryCache_Directly()
 	{
+		// Arrange / Act
 		var result = Types.InAssembly(WebAssembly)
 				.That()
 				.ResideInNamespace("MyBlog.Web.Features")
@@ -39,6 +42,7 @@ public class CachingLayerTests
 				.HaveDependencyOnAny("Microsoft.Extensions.Caching.Memory")
 				.GetResult();
 
+		// Assert
 		result.IsSuccessful.Should().BeTrue(
 			"VSA handlers must delegate caching to IBlogPostCacheService, not reference IMemoryCache directly");
 	}

--- a/tests/Architecture.Tests/DomainLayerTests.cs
+++ b/tests/Architecture.Tests/DomainLayerTests.cs
@@ -14,46 +14,66 @@ public class DomainLayerTests
 	[Fact]
 	public void Domain_Should_Not_Reference_Web()
 	{
-		var result = Types.InAssembly(typeof(BlogPost).Assembly)
+		// Arrange
+		var assembly = typeof(BlogPost).Assembly;
+
+		// Act
+		var result = Types.InAssembly(assembly)
 				.ShouldNot()
 				.HaveDependencyOnAny("MyBlog.Web", "Microsoft.AspNetCore")
 				.GetResult();
 
+		// Assert
 		result.IsSuccessful.Should().BeTrue();
 	}
 
 	[Fact]
 	public void Domain_Entities_Should_Be_Sealed()
 	{
-		var result = Types.InAssembly(typeof(BlogPost).Assembly)
+		// Arrange
+		var assembly = typeof(BlogPost).Assembly;
+
+		// Act
+		var result = Types.InAssembly(assembly)
 				.That()
 				.ResideInNamespace("MyBlog.Domain.Entities")
 				.Should()
 				.BeSealed()
 				.GetResult();
 
+		// Assert
 		result.IsSuccessful.Should().BeTrue();
 	}
 
 	[Fact]
 	public void Domain_Should_Not_Have_InMemoryRepository()
 	{
-		var types = Types.InAssembly(typeof(BlogPost).Assembly)
+		// Arrange
+		var assembly = typeof(BlogPost).Assembly;
+
+		// Act
+		var types = Types.InAssembly(assembly)
 				.That()
 				.HaveNameEndingWith("InMemory")
 				.GetTypes();
 
+		// Assert
 		types.Should().BeEmpty("InMemoryBlogPostRepository should have been deleted");
 	}
 
 	[Fact]
 	public void Domain_Should_Not_Have_Features()
 	{
-		var types = Types.InAssembly(typeof(BlogPost).Assembly)
+		// Arrange
+		var assembly = typeof(BlogPost).Assembly;
+
+		// Act
+		var types = Types.InAssembly(assembly)
 				.That()
 				.ResideInNamespaceStartingWith("MyBlog.Domain.Features")
 				.GetTypes();
 
+		// Assert
 		types.Should().BeEmpty("CQRS handlers and commands belong in the Web project (VSA)");
 	}
 }

--- a/tests/Architecture.Tests/ThemeLayerTests.cs
+++ b/tests/Architecture.Tests/ThemeLayerTests.cs
@@ -18,6 +18,7 @@ public class ThemeLayerTests
 	[Fact]
 	public void ThemeComponents_ShouldResideIn_ThemeNamespace()
 	{
+		// Arrange / Act
 		var result = Types.InAssembly(WebAssembly)
 				.That()
 				.ResideInNamespace("MyBlog.Web.Components.Theme")
@@ -25,12 +26,14 @@ public class ThemeLayerTests
 				.ResideInNamespace("MyBlog.Web.Components.Theme")
 				.GetResult();
 
+		// Assert
 		result.IsSuccessful.Should().BeTrue();
 	}
 
 	[Fact]
 	public void ThemeComponents_ShouldHaveNoDependencyOn_DomainOrMongoDB()
 	{
+		// Arrange / Act
 		var result = Types.InAssembly(WebAssembly)
 				.That()
 				.ResideInNamespace("MyBlog.Web.Components.Theme")
@@ -38,6 +41,7 @@ public class ThemeLayerTests
 				.HaveDependencyOnAny("MyBlog.Domain", "MongoDB")
 				.GetResult();
 
+		// Assert
 		result.IsSuccessful.Should().BeTrue();
 	}
 }

--- a/tests/Architecture.Tests/VsaLayerTests.cs
+++ b/tests/Architecture.Tests/VsaLayerTests.cs
@@ -18,21 +18,22 @@ public class VsaLayerTests
 	[Fact]
 	public void Features_Should_Not_Reference_Each_Other()
 	{
-		// BlogPosts slice should not reference UserManagement and vice versa
-		var blogPostsResult = Types.InAssembly(WebAssembly)
+		// Arrange / Act — BlogPosts slice should not reference UserManagement and vice versa
+		var result = Types.InAssembly(WebAssembly)
 				.That()
 				.ResideInNamespace("MyBlog.Web.Features.BlogPosts")
 				.ShouldNot()
 				.HaveDependencyOnAny("MyBlog.Web.Features.UserManagement")
 				.GetResult();
 
-		blogPostsResult.IsSuccessful.Should().BeTrue();
+		// Assert
+		result.IsSuccessful.Should().BeTrue();
 	}
 
 	[Fact]
 	public void Handlers_Should_HaveNameEndingWithHandler_And_BeSealed()
 	{
-		// All types named *Handler in Web assembly should be sealed classes
+		// Arrange / Act — All types named *Handler in Web assembly should be sealed classes
 		var result = Types.InAssembly(WebAssembly)
 				.That()
 				.HaveNameEndingWith("Handler")
@@ -40,18 +41,23 @@ public class VsaLayerTests
 				.BeSealed()
 				.GetResult();
 
+		// Assert
 		result.IsSuccessful.Should().BeTrue();
 	}
 
 	[Fact]
 	public void Data_Layer_Should_Not_Be_Referenced_Outside_Web()
 	{
-		// Domain assembly must NOT depend on MyBlog.Web.Data
-		var result = Types.InAssembly(typeof(BlogPost).Assembly)
+		// Arrange
+		var domainAssembly = typeof(BlogPost).Assembly;
+
+		// Act — Domain assembly must NOT depend on MyBlog.Web.Data
+		var result = Types.InAssembly(domainAssembly)
 				.ShouldNot()
 				.HaveDependencyOnAny("MyBlog.Web.Data")
 				.GetResult();
 
+		// Assert
 		result.IsSuccessful.Should().BeTrue();
 	}
 }


### PR DESCRIPTION
## Summary

Migrates Architecture.Tests test methods to xUnit v3 API conventions, following the Sprint 7 Domain.Tests pilot pattern.

Closes #178

**Working as Gimli (Tester)**

---

## What Changed

All 4 test files updated with proper xUnit v3 migration conventions:

| File | Tests | Change |
|------|-------|--------|
| `DomainLayerTests.cs` | 4 | AAA comments + extract `assembly` variable for clean Arrange/Act split |
| `VsaLayerTests.cs` | 3 | AAA comments + extract `domainAssembly` variable |
| `ThemeLayerTests.cs` | 2 | AAA comments |
| `CachingLayerTests.cs` | 2 | AAA comments |

**Total: 11 tests migrated**

## xUnit v3 API Observations

- `[Fact]` attribute is **identical** in xUnit v2 and v3 — no attribute changes required
- No async/await patterns in architecture tests — no lifecycle changes needed
- No `IClassFixture` / `ICollectionFixture` — stateless tests, no collection changes needed
- FluentAssertions `.Should()` works unchanged with xUnit v3
- Parallelization via `xunit.runner.json` was already configured in Wave 1 (#182)

## Pattern Reference (Sprint 7 Domain.Tests Pilot)

Followed the same approach as the Sprint 7 Domain.Tests migration:
- xUnit v3 meta-package via `<PackageReference Include="xunit.v3"/>` ✅ (Wave 1)
- `xunit.runner.json` with `parallelizeAssembly: true` ✅ (Wave 1)
- Gimli Rule #3: AAA comments on all test methods ✅ (this PR)
- Gimli Rule #6: File headers present on all files ✅ (pre-existing)

## Test Results

```
Passed! - Failed: 0, Passed: 11, Skipped: 0, Total: 11 — Architecture.Tests.dll
Passed! - Failed: 0, Passed: 42, Skipped: 0, Total: 42 — Domain.Tests.dll
```

Zero failures. Ready to merge to `sprint/8-xunit-v3-pilot`.