### PR TITLE
test(apphost): migrate AppHost.Tests to xUnit v3 (#207)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,7 +49,6 @@
 		<PackageVersion Include="bunit" Version="2.7.2" />
 		<PackageVersion Include="coverlet.collector" Version="10.0.0" />
 		<PackageVersion Include="coverlet.msbuild" Version="10.0.0" />
-		<PackageVersion Include="xunit" Version="2.9.3" />
 		<PackageVersion Include="xunit.analyzers" Version="1.27.0" />
 		<PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
 		<PackageVersion Include="xunit.v3" Version="3.2.2" />

--- a/tests/AppHost.Tests/AppHost.Tests.csproj
+++ b/tests/AppHost.Tests/AppHost.Tests.csproj
@@ -1,46 +1,50 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
-    <UserSecretsId>789c7356-2f72-4f40-8ab2-1813d4b1cd84</UserSecretsId>
-    <!-- Test-project suppressions:
-         CA2007 – ConfigureAwait not needed in xUnit test context
-         CA1707 – Underscore naming is standard for test methods
-         CA1848 – LoggerMessage perf delegates not needed in test infra
-         CA1873 – String allocation in test logging is acceptable
-         CA5400 – HttpClient intentionally skips CRL for self-signed CI certs
-         CA1031 – Polling loops intentionally catch all startup exceptions
-         CA1014 – CLSCompliant attribute not needed for test assemblies
-         CA1515 – xUnit requires public test fixtures and collection types
-         CA1711 – xUnit CollectionDefinition class must end in 'Collection' -->
-    <NoWarn>$(NoWarn);CA2007;CA1707;CA1848;CA1873;CA5400;CA1031;CA1014;CA1515;CA1711</NoWarn>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+		<UserSecretsId>789c7356-2f72-4f40-8ab2-1813d4b1cd84</UserSecretsId>
+		<!-- Test-project suppressions:
+		     CA2007 – ConfigureAwait not needed in xUnit test context
+		     CA1707 – Underscore naming is standard for test methods
+		     CA1848 – LoggerMessage perf delegates not needed in test infra
+		     CA1873 – String allocation in test logging is acceptable
+		     CA5400 – HttpClient intentionally skips CRL for self-signed CI certs
+		     CA1031 – Polling loops intentionally catch all startup exceptions
+		     CA1014 – CLSCompliant attribute not needed for test assemblies
+		     CA1515 – xUnit requires public test fixtures and collection types
+		     CA1711 – xUnit CollectionDefinition class must end in 'Collection' -->
+		<NoWarn>$(NoWarn);CA2007;CA1707;CA1848;CA1873;CA5400;CA1031;CA1014;CA1515;CA1711</NoWarn>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="../../src/AppHost/AppHost.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="../../src/AppHost/AppHost.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Testing" />
-    <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="Microsoft.Playwright" />
-    <PackageReference Include="coverlet.collector" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="xunit.v3" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Aspire.Hosting.Testing" />
+		<PackageReference Include="FluentAssertions" />
+		<PackageReference Include="Microsoft.Playwright" />
+		<PackageReference Include="coverlet.collector" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="xunit.runner.visualstudio" />
+		<PackageReference Include="xunit.v3" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Using Include="System.Net" />
-    <Using Include="Microsoft.Extensions.DependencyInjection" />
-    <Using Include="Aspire.Hosting.ApplicationModel" />
-    <Using Include="Aspire.Hosting.Testing" />
-    <Using Include="Microsoft.Playwright" />
-    <Using Include="Xunit" />
-  </ItemGroup>
+	<ItemGroup>
+		<Using Include="System.Net" />
+		<Using Include="Microsoft.Extensions.DependencyInjection" />
+		<Using Include="Aspire.Hosting.ApplicationModel" />
+		<Using Include="Aspire.Hosting.Testing" />
+		<Using Include="Microsoft.Playwright" />
+		<Using Include="Xunit" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+	</ItemGroup>
 
 </Project>

--- a/tests/AppHost.Tests/AppHost.Tests.csproj
+++ b/tests/AppHost.Tests/AppHost.Tests.csproj
@@ -30,8 +30,8 @@
     <PackageReference Include="Microsoft.Playwright" />
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="xunit.v3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AppHost.Tests/EnvVarTests.cs
+++ b/tests/AppHost.Tests/EnvVarTests.cs
@@ -27,7 +27,8 @@ public class EnvVarTests
 				configureBuilder: static (options, _) =>
 				{
 					options.DisableDashboard = true;
-				});
+				},
+				cancellationToken: TestContext.Current.CancellationToken);
 
 		var webResource = (IResourceWithEnvironment)appHost.Resources
 			.Single(static r => r.Name == "web");
@@ -52,7 +53,8 @@ public class EnvVarTests
 				configureBuilder: static (options, _) =>
 				{
 					options.DisableDashboard = true;
-				});
+				},
+				cancellationToken: TestContext.Current.CancellationToken);
 
 		var webResource = (IResourceWithEnvironment)appHost.Resources
 			.Single(static r => r.Name == "web");

--- a/tests/AppHost.Tests/Infrastructure/AspireManager.cs
+++ b/tests/AppHost.Tests/Infrastructure/AspireManager.cs
@@ -206,15 +206,16 @@ public class AspireManager : IAsyncLifetime
 	}
 
 
-	public async Task InitializeAsync()
+	public async ValueTask InitializeAsync()
 	{
 		await PlaywrightManager.InitializeAsync();
 		await StartAppAsync();
 	}
-	public async Task DisposeAsync()
+	public async ValueTask DisposeAsync()
 	{
 		await PlaywrightManager.DisposeAsync();
 
 		await (App?.DisposeAsync() ?? ValueTask.CompletedTask);
+		GC.SuppressFinalize(this);
 	}
 }

--- a/tests/AppHost.Tests/Infrastructure/PlaywrightManager.cs
+++ b/tests/AppHost.Tests/Infrastructure/PlaywrightManager.cs
@@ -24,7 +24,7 @@ public class PlaywrightManager : IAsyncLifetime
 
 	internal IBrowser Browser { get; set; } = null!;
 
-	public async Task InitializeAsync()
+	public async ValueTask InitializeAsync()
 	{
 		Assertions.SetDefaultExpectTimeout(10_000);
 
@@ -38,10 +38,11 @@ public class PlaywrightManager : IAsyncLifetime
 		Browser = await _playwright.Chromium.LaunchAsync(options).ConfigureAwait(false);
 	}
 
-	public async Task DisposeAsync()
+	public async ValueTask DisposeAsync()
 	{
 		await Browser.CloseAsync();
 
 		_playwright?.Dispose();
+		GC.SuppressFinalize(this);
 	}
 }

--- a/tests/AppHost.Tests/xunit.runner.json
+++ b/tests/AppHost.Tests/xunit.runner.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "methodDisplay": "method",
+  "methodDisplayOptions": "all",
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": true
+}


### PR DESCRIPTION
Closes #207

## Changes
- switch `tests/AppHost.Tests` from `xunit` to `xunit.v3`
- remove the unused central package management entry for `xunit`
- update AppHost test fixtures to the xUnit v3 `IAsyncLifetime` `ValueTask` signatures
- align `EnvVarTests` with xUnit v3 analyzer expectations
- verify the Playwright runtime so the browser-backed AppHost E2E suite runs locally again

## Testing
- [x] `dotnet build tests/AppHost.Tests/AppHost.Tests.csproj --configuration Release`
- [x] `dotnet test tests/AppHost.Tests/AppHost.Tests.csproj --configuration Release --filter FullyQualifiedName~EnvVarTests`
- [x] `dotnet test tests/AppHost.Tests/AppHost.Tests.csproj --configuration Release`
- [x] local pre-push gate passed

## Notes
- Local Playwright browser provisioning was done via the generated script at `tests/AppHost.Tests/bin/Release/net10.0/playwright.ps1` rather than by adding automatic install behavior to the test harness.