### PR TITLE
sprint(13): merge sprint 13 — xUnit v3 cleanup & docs (#14)

### DIFF
--- a/.github/workflows/milestone-blog.yml
+++ b/.github/workflows/milestone-blog.yml
@@ -40,13 +40,15 @@ jobs:
           PUBLISH_DATE=$(date -d "${CLOSED_AT}" '+%Y-%m-%d' 2>/dev/null || date '+%Y-%m-%d')
           LAST_TAG=$(gh api "repos/${{ github.repository }}/releases?per_page=1" --jq '.[0].tag_name // "none"')
 
-          echo "issues<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$ISSUES" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
-          echo "count=$ISSUE_COUNT" >> "$GITHUB_OUTPUT"
-          echo "feature_count=$FEATURE_COUNT" >> "$GITHUB_OUTPUT"
-          echo "publish_date=$PUBLISH_DATE" >> "$GITHUB_OUTPUT"
-          echo "last_tag=$LAST_TAG" >> "$GITHUB_OUTPUT"
+          {
+            echo "issues<<EOF"
+            echo "$ISSUES"
+            echo "EOF"
+            echo "count=$ISSUE_COUNT"
+            echo "feature_count=$FEATURE_COUNT"
+            echo "publish_date=$PUBLISH_DATE"
+            echo "last_tag=$LAST_TAG"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create Ralph review issue
         env:
@@ -103,6 +105,7 @@ jobs:
           *Triggered by milestone close at ${PUBLISH_DATE}. Workflow: \`milestone-blog.yml\`*"
 
           gh issue create \
+            --repo "${{ github.repository }}" \
             --title "📋 Milestone Review: ${MILESTONE_TITLE} — release or blog?" \
             --body "$BODY" \
             --label "squad:ralph,pending-review"

--- a/.github/workflows/milestone-release-decision.yml
+++ b/.github/workflows/milestone-release-decision.yml
@@ -41,9 +41,10 @@ jobs:
           BUMP=$(echo "$ISSUE_BODY" | grep -oE 'bump[: ]+(major|minor|patch)' | grep -oE '(major|minor|patch)' | head -1)
           BUMP=${BUMP:-minor}
 
-          echo "milestone_title=$MILESTONE_TITLE" >> "$GITHUB_OUTPUT"
-          echo "bump=$BUMP" >> "$GITHUB_OUTPUT"
-          echo "issue_number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          {
+            echo "milestone_title=$MILESTONE_TITLE"
+            echo "bump=$BUMP"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Trigger release workflow
         env:
@@ -51,8 +52,8 @@ jobs:
           BUMP: ${{ steps.info.outputs.bump }}
         run: |
           gh workflow run squad-milestone-release.yml \
-            --field bump="${BUMP}" \
-            --field milestone_number="${{ github.event.issue.number }}"
+            --repo "${{ github.repository }}" \
+            --field bump="${BUMP}"
           echo "✅ Triggered squad-milestone-release.yml (bump: ${BUMP})"
 
       - name: Add release-triggered comment and close review issue
@@ -61,7 +62,7 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           BUMP: ${{ steps.info.outputs.bump }}
         run: |
-          gh issue comment "$ISSUE_NUMBER" --body "✅ **Release flow triggered.**
+          gh issue comment "$ISSUE_NUMBER" --repo "${{ github.repository }}" --body "✅ **Release flow triggered.**
 
           - Version bump: \`${BUMP}\`
           - \`squad-milestone-release.yml\` dispatched — this will create the tag, push it, and publish a GitHub Release.
@@ -70,7 +71,7 @@ jobs:
 
           Closing this review issue."
 
-          gh issue close "$ISSUE_NUMBER" --reason completed
+          gh issue close "$ISSUE_NUMBER" --repo "${{ github.repository }}" --reason completed
 
   # ─────────────────────────────────────────────────────────────────────────────
   # PATH B: Blog Only
@@ -91,12 +92,11 @@ jobs:
           PUBLISH_DATE=$(date '+%Y-%m-%d')
           SLUG=$(echo "$MILESTONE_TITLE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-\|-$//g')
 
-          # Pull closed issues list from the review issue body
-          ISSUES_BLOCK=$(echo "${{ github.event.issue.body }}" | sed -n '/### Closed Issues/,/---/p' | head -50)
-
-          echo "milestone_title=$MILESTONE_TITLE" >> "$GITHUB_OUTPUT"
-          echo "publish_date=$PUBLISH_DATE" >> "$GITHUB_OUTPUT"
-          echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
+          {
+            echo "milestone_title=$MILESTONE_TITLE"
+            echo "publish_date=$PUBLISH_DATE"
+            echo "slug=$SLUG"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create Bilbo blog brief issue
         env:
@@ -130,6 +130,7 @@ jobs:
           - Close both this issue and the review issue (#${REVIEW_ISSUE_NUMBER}) in the PR description"
 
           gh issue create \
+            --repo "${{ github.repository }}" \
             --title "Blog post: ${MILESTONE_TITLE} — milestone recap" \
             --body "$BODY" \
             --label "squad:bilbo"
@@ -139,7 +140,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          gh issue comment "$ISSUE_NUMBER" --body "📝 **Blog-only path selected.**
+          gh issue comment "$ISSUE_NUMBER" --repo "${{ github.repository }}" --body "📝 **Blog-only path selected.**
 
           A \`squad:bilbo\` blog brief issue has been created. Once Bilbo's PR merges:
           - \`docs/blog/index.md\` will be updated (the blog page)
@@ -147,4 +148,4 @@ jobs:
 
           Closing this review issue."
 
-          gh issue close "$ISSUE_NUMBER" --reason completed
+          gh issue close "$ISSUE_NUMBER" --repo "${{ github.repository }}" --reason completed

--- a/.github/workflows/release-blog.yml
+++ b/.github/workflows/release-blog.yml
@@ -30,9 +30,11 @@ jobs:
           PREV_TAG=$(gh api "repos/${{ github.repository }}/releases" \
             --jq '[.[] | select(.tag_name != "'"${TAG}"'")] | sort_by(.published_at) | reverse | .[0].tag_name // "HEAD~50"')
 
-          echo "publish_date=$PUBLISH_DATE" >> "$GITHUB_OUTPUT"
-          echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
-          echo "prev_tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
+          {
+            echo "publish_date=$PUBLISH_DATE"
+            echo "slug=$SLUG"
+            echo "prev_tag=$PREV_TAG"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create Bilbo blog brief issue
         env:
@@ -73,6 +75,7 @@ jobs:
           - Close this issue in the PR description with \`Closes #<this-issue>\`"
 
           gh issue create \
+            --repo "${{ github.repository }}" \
             --title "Blog post: ${RELEASE_NAME} — release recap" \
             --body "$BODY" \
             --label "squad:bilbo"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,7 +49,6 @@
 		<PackageVersion Include="bunit" Version="2.7.2" />
 		<PackageVersion Include="coverlet.collector" Version="10.0.0" />
 		<PackageVersion Include="coverlet.msbuild" Version="10.0.0" />
-		<PackageVersion Include="xunit" Version="2.9.3" />
 		<PackageVersion Include="xunit.analyzers" Version="1.27.0" />
 		<PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
 		<PackageVersion Include="xunit.v3" Version="3.2.2" />

--- a/tests/AppHost.Tests/AppHost.Tests.csproj
+++ b/tests/AppHost.Tests/AppHost.Tests.csproj
@@ -1,46 +1,50 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
-    <UserSecretsId>789c7356-2f72-4f40-8ab2-1813d4b1cd84</UserSecretsId>
-    <!-- Test-project suppressions:
-         CA2007 – ConfigureAwait not needed in xUnit test context
-         CA1707 – Underscore naming is standard for test methods
-         CA1848 – LoggerMessage perf delegates not needed in test infra
-         CA1873 – String allocation in test logging is acceptable
-         CA5400 – HttpClient intentionally skips CRL for self-signed CI certs
-         CA1031 – Polling loops intentionally catch all startup exceptions
-         CA1014 – CLSCompliant attribute not needed for test assemblies
-         CA1515 – xUnit requires public test fixtures and collection types
-         CA1711 – xUnit CollectionDefinition class must end in 'Collection' -->
-    <NoWarn>$(NoWarn);CA2007;CA1707;CA1848;CA1873;CA5400;CA1031;CA1014;CA1515;CA1711</NoWarn>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+		<UserSecretsId>789c7356-2f72-4f40-8ab2-1813d4b1cd84</UserSecretsId>
+		<!-- Test-project suppressions:
+		     CA2007 – ConfigureAwait not needed in xUnit test context
+		     CA1707 – Underscore naming is standard for test methods
+		     CA1848 – LoggerMessage perf delegates not needed in test infra
+		     CA1873 – String allocation in test logging is acceptable
+		     CA5400 – HttpClient intentionally skips CRL for self-signed CI certs
+		     CA1031 – Polling loops intentionally catch all startup exceptions
+		     CA1014 – CLSCompliant attribute not needed for test assemblies
+		     CA1515 – xUnit requires public test fixtures and collection types
+		     CA1711 – xUnit CollectionDefinition class must end in 'Collection' -->
+		<NoWarn>$(NoWarn);CA2007;CA1707;CA1848;CA1873;CA5400;CA1031;CA1014;CA1515;CA1711</NoWarn>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="../../src/AppHost/AppHost.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="../../src/AppHost/AppHost.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Testing" />
-    <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="Microsoft.Playwright" />
-    <PackageReference Include="coverlet.collector" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Aspire.Hosting.Testing" />
+		<PackageReference Include="FluentAssertions" />
+		<PackageReference Include="Microsoft.Playwright" />
+		<PackageReference Include="coverlet.collector" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="xunit.runner.visualstudio" />
+		<PackageReference Include="xunit.v3" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Using Include="System.Net" />
-    <Using Include="Microsoft.Extensions.DependencyInjection" />
-    <Using Include="Aspire.Hosting.ApplicationModel" />
-    <Using Include="Aspire.Hosting.Testing" />
-    <Using Include="Microsoft.Playwright" />
-    <Using Include="Xunit" />
-  </ItemGroup>
+	<ItemGroup>
+		<Using Include="System.Net" />
+		<Using Include="Microsoft.Extensions.DependencyInjection" />
+		<Using Include="Aspire.Hosting.ApplicationModel" />
+		<Using Include="Aspire.Hosting.Testing" />
+		<Using Include="Microsoft.Playwright" />
+		<Using Include="Xunit" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+	</ItemGroup>
 
 </Project>

--- a/tests/AppHost.Tests/EnvVarTests.cs
+++ b/tests/AppHost.Tests/EnvVarTests.cs
@@ -27,7 +27,8 @@ public class EnvVarTests
 				configureBuilder: static (options, _) =>
 				{
 					options.DisableDashboard = true;
-				});
+				},
+				cancellationToken: TestContext.Current.CancellationToken);
 
 		var webResource = (IResourceWithEnvironment)appHost.Resources
 			.Single(static r => r.Name == "web");
@@ -52,7 +53,8 @@ public class EnvVarTests
 				configureBuilder: static (options, _) =>
 				{
 					options.DisableDashboard = true;
-				});
+				},
+				cancellationToken: TestContext.Current.CancellationToken);
 
 		var webResource = (IResourceWithEnvironment)appHost.Resources
 			.Single(static r => r.Name == "web");

--- a/tests/AppHost.Tests/Infrastructure/AspireManager.cs
+++ b/tests/AppHost.Tests/Infrastructure/AspireManager.cs
@@ -206,15 +206,16 @@ public class AspireManager : IAsyncLifetime
 	}
 
 
-	public async Task InitializeAsync()
+	public async ValueTask InitializeAsync()
 	{
 		await PlaywrightManager.InitializeAsync();
 		await StartAppAsync();
 	}
-	public async Task DisposeAsync()
+	public async ValueTask DisposeAsync()
 	{
 		await PlaywrightManager.DisposeAsync();
 
 		await (App?.DisposeAsync() ?? ValueTask.CompletedTask);
+		GC.SuppressFinalize(this);
 	}
 }

--- a/tests/AppHost.Tests/Infrastructure/PlaywrightManager.cs
+++ b/tests/AppHost.Tests/Infrastructure/PlaywrightManager.cs
@@ -24,7 +24,7 @@ public class PlaywrightManager : IAsyncLifetime
 
 	internal IBrowser Browser { get; set; } = null!;
 
-	public async Task InitializeAsync()
+	public async ValueTask InitializeAsync()
 	{
 		Assertions.SetDefaultExpectTimeout(10_000);
 
@@ -38,10 +38,11 @@ public class PlaywrightManager : IAsyncLifetime
 		Browser = await _playwright.Chromium.LaunchAsync(options).ConfigureAwait(false);
 	}
 
-	public async Task DisposeAsync()
+	public async ValueTask DisposeAsync()
 	{
 		await Browser.CloseAsync();
 
 		_playwright?.Dispose();
+		GC.SuppressFinalize(this);
 	}
 }

--- a/tests/AppHost.Tests/xunit.runner.json
+++ b/tests/AppHost.Tests/xunit.runner.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "methodDisplay": "method",
+  "methodDisplayOptions": "all",
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": true
+}


### PR DESCRIPTION
Closes milestone: Sprint 13 — xUnit v3 Cleanup & Docs

## Sprint Summary
- repaired the milestone review workflow chain and missing label setup from Sprint 12 fallout
- migrated `tests/AppHost.Tests` to `xunit.v3`
- removed the unused central package management entry for `xunit`
- restored local and CI Playwright-backed AppHost E2E execution with the xUnit v3 migration updates

## Issues Closed
- Closes #204
- Closes #207

## Checklist
- [x] All sprint issues closed
- [x] CI green
- [x] Milestone at 100%