### PR TITLE
squad(224): consolidate identity/now.md — move metadata to YAML front-matter

### DIFF
--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -1,11 +1,10 @@
 ---
-updated_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-06T00:00:00Z
+focus_area: Squad maintenance — charter audit, markdown lint, and identity cleanup
+active_issues: [224, 226, 227]
 ---
 
 # Focus Area
-
-focus_area: Squad maintenance pass completed — issue #222
-active_issues: [222]
 
 ## What We're Focused On
 


### PR DESCRIPTION
## Summary

Resolves the format inconsistency in `.squad/identity/now.md` where `updated_at` lived in the YAML front-matter while `focus_area` and `active_issues` were formatted as quasi-YAML in the Markdown body.

Closes #224

## Changes

- Moved `focus_area` and `active_issues` into the YAML front-matter block alongside `updated_at`
- Removed the quasi-YAML key:value pairs from the Markdown body
- Updated `focus_area` and `active_issues` values to reflect current work queue (#224, #226, #227)
- Updated `updated_at` to today

## Decision

Chose **YAML front-matter only** for machine-readable fields — `updated_at`, `focus_area`, `active_issues` are all metadata and belong in the front-matter. The Markdown body retains only human-readable narrative content.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>