### PR TITLE
fix(theme): move ThemeProvider into interactive render boundary (#239)

### DIFF
--- a/.squad/agents/gimli/history.md
+++ b/.squad/agents/gimli/history.md
@@ -422,3 +422,32 @@ Migrate `tests/Web.Tests.Integration` from xUnit v2 to xUnit v3 (3.2.2), matchin
 
 5. **Pre-push gate runs integration tests** — The repo's pre-push hook runs `tests/Web.Tests.Integration` automatically. All 12 tests passed including the Testcontainers-based MongoDB and Redis tests.
 6. Scope discipline matters here: do not churn nearby tests for unrelated convention gaps when the requested review is only about async continuation configuration.
+
+## Session: Theme Colour Persistence Tests (Issue #239, 2025)
+
+### Task
+
+Write focused bUnit and architecture tests proving that theme colour selection persists across navigation (reads from JS localStorage on mount, writes on selection), all four Tailwind palette colours are supported, and shared layout surfaces (NavMenu, MainLayout) honour the selected primary palette.
+
+### Work Done
+
+- **ThemeColorPersistenceTests.cs** (14 new tests): Parametric tests for all 4 colours (red, blue, green, yellow) via `[Theory]`; simulated navigation scenario (unmount/remount reads fresh from JS); cascade verification (stored colour flows to ThemeColorDropdownComponent); exactly-once-per-mount `getColor`/`getBrightness` guard; JS error resilience for SetColor/SetBrightness.
+- **MainLayoutThemeTests.cs** (7 new tests): NavMenu `bg-primary-600` and `border-primary-200` CSS class assertions; NavMenu dropdown shows stored colour from cascaded ThemeProvider; MainLayout root div `bg-primary-400 dark:bg-primary-800` assertions; ThemeProvider + MainLayout integrated brightness cascade.
+- **ThemeLayerTests.cs** (+2 architecture tests): Layout components reside in `MyBlog.Web.Components.Layout` namespace; Theme components have no dependency on Auth0/Identity.
+- Result: **87 bUnit tests** (was 61), **13 architecture tests** (was 11).
+
+### Key Learnings — bUnit Theme Testing
+
+1. **`WaitForAssertion` required for ThemeProvider cascade** — `OnAfterRenderAsync` runs after bUnit's initial render cycle. Any assertion on `CurrentColor`/`CurrentBrightness` or child component values must use `cut.WaitForAssertion(() => ...)` to await the JS interop round-trip.
+
+2. **`JSInterop.Setup<string>` must precede `RenderComponent`** — In bUnit, JSInterop setup must be done before rendering the component or the `getColor`/`getBrightness` calls will fail with `JSRuntimeMode.Strict`. Set up the mock, then render.
+
+3. **`firstRender` guard is testable** — ThemeProvider only calls `getColor`/`getBrightness` once per mount. Verify by re-rendering via `cut.SetParametersAndRender()` and asserting `Received(1)` call count stays at 1 on subsequent renders.
+
+4. **`selected="@(CurrentColor == "blue")"` pattern** — Legolas fixed the dropdown to explicitly set the `selected` attribute per-option using Blazor bool binding. bUnit picks this up correctly — `cut.Find("option[value='blue']").HasAttribute("selected")` returns true when blue is active.
+
+5. **ThemeProvider moved to Routes.razor (interactive boundary)** — The key production fix: ThemeProvider was previously in App.razor (SSR context) where JS interop was unavailable. Moving it into Routes.razor (which carries `@rendermode InteractiveServer`) enables localStorage read on mount. bUnit tests are unaffected by this location change since they render ThemeProvider directly.
+
+6. **`TestAuthorizationService` required for layout components** — Any component tree containing `<AuthorizeView>` (NavMenu, MainLayout) requires `Services.AddSingleton<IAuthorizationService, TestAuthorizationService>()`. Omitting this throws `InvalidOperationException` at render time.
+
+7. **NavMenu renders ThemeSelector twice** — Desktop nav and mobile hamburger both include `<ThemeSelector />`. `cut.Find("select")` finds the first (desktop). `cut.FindAll("select")` returns 2. Write tests against the first unless explicitly testing mobile nav.

--- a/.squad/agents/legolas/history.md
+++ b/.squad/agents/legolas/history.md
@@ -461,3 +461,56 @@ No concerns. This is intentional recovery of uncommitted CSS from a stalled bran
 - ✅ UI components automatically benefit from role claim normalization
 
 **Status:** ✅ Completed — Fix verified and decision merged to decisions.md
+
+---
+
+## 2026-05-09 — Theme Color Selector Persistence Fix (Issue #239)
+
+### Root Cause Diagnosed
+
+**ThemeProvider was in the static SSR boundary (App.razor), causing silent failure:**
+
+- `App.razor` renders in static SSR context. `ThemeProvider` there never executes `OnAfterRenderAsync`, so JS interop calls (`themeManager.getColor`, `themeManager.getBrightness`) never fire.
+- Interactive child components calling `Provider.SetColor()` via cascading parameter updated a static parent instance — `StateHasChanged()` was a no-op and cascaded values never re-propagated.
+- This is the canonical Blazor Interactive Server render-boundary bug: static parents cannot be re-rendered by interactive children.
+
+### Fix Applied
+
+**Moved `ThemeProvider` from `App.razor` into `Routes.razor`:**
+
+- `Routes.razor` is rendered with `@rendermode="InteractiveServer"` from `App.razor` — it IS inside the interactive boundary.
+- `ThemeProvider` now wraps the `<Router>` in `Routes.razor` and correctly executes `OnAfterRenderAsync` on first render.
+- JS interop reads color/brightness from localStorage and calls `StateHasChanged()` to propagate to all theme-aware children.
+
+**Also fixed `ThemeColorDropdownComponent.razor`:**
+
+- Added explicit `selected="@(CurrentColor == "X")"` on each `<option>` for robustness. Blazor sets `.value` on `<select>` in interactive mode, but explicit `selected` attributes also correct initial static render markup.
+
+**Added JS error resilience to `ThemeProvider.razor.cs`:**
+
+- `SetColor` and `SetBrightness` now catch exceptions from `Js.InvokeVoidAsync`. Circuit disconnections during a JS call no longer crash the component.
+
+### Pre-existing Build Blocker Resolved
+
+- **Snappier 1.0.0** had a high-severity vulnerability (GHSA-pggp-6c3x-2xmx), causing `NU1903` (warning-as-error) build failure.
+- Applied fix from commit `e3754bf`: pinned `Snappier` to `1.3.1` in `Directory.Packages.props` and added direct `PackageReference` to `src/Web/Web.csproj` and `src/AppHost/AppHost.csproj`.
+
+### Key Rules Confirmed
+
+- **ThemeProvider must live inside the Interactive Server render boundary.** Any component using `OnAfterRenderAsync` for JS interop must be inside (or be) an interactive component. Wrapping interactive subtrees from a static parent is a known anti-pattern.
+- **The anti-FOUC IIFE in `App.razor <head>` must stay in `App.razor`.** It runs during static pre-render (before Blazor hydration) and must not be moved into an interactive component.
+- **`Routes.razor` is the correct host for app-wide cascading providers** when the app uses `<Routes @rendermode="InteractiveServer" />` in `App.razor`.
+
+### Files Changed
+
+1. `Directory.Packages.props` — added `Snappier 1.3.1`
+2. `src/AppHost/AppHost.csproj` — added `<PackageReference Include="Snappier" />`
+3. `src/Web/Web.csproj` — added `<PackageReference Include="Snappier" />`
+4. `src/Web/Components/App.razor` — removed `<ThemeProvider>` wrapper around `<Routes>`
+5. `src/Web/Components/Routes.razor` — added `@using` + `<ThemeProvider>` wrapping `<Router>`
+6. `src/Web/Components/Theme/ThemeColorDropdownComponent.razor` — added `selected=` attributes on each `<option>`
+7. `src/Web/Components/Theme/ThemeProvider.razor.cs` — added try-catch in `SetColor`/`SetBrightness`
+
+**Tests:** Architecture.Tests 15/15 ✅ · Web.Tests.Bunit 65/65 ✅ · Domain.Tests 42/42 ✅
+
+**Filed:** `.squad/decisions/inbox/legolas-theme-color-persistence.md`

--- a/.squad/agents/sam/history.md
+++ b/.squad/agents/sam/history.md
@@ -80,3 +80,46 @@ As part of squad skills/playbooks review, MongoDB DBA patterns + filter pattern 
 **Timeline:** Sprint 7 (2h estimated).
 
 **Owner:** Sam (Domain Model) — routed with `mongodb-filter-pattern` skill injection.
+
+## 2026-05-07 — PR #243 Revision: Aragorn's Blockers Fixed
+
+### Task: Fix three test blockers flagged by Aragorn on PR #243 (issue #239)
+
+Aragorn rejected PR #243 with three specific blockers. Legolas and Gimli locked out per lockout rule. Sam owns the full revision cycle.
+
+### Blockers Addressed
+
+**1. ThemeLayerTests.cs — tautological layout namespace test**
+
+`LayoutComponents_ShouldResideIn_LayoutNamespace` filtered types by namespace and then asserted the same namespace — a tautology that provided zero architectural protection. Replaced with `ThemeComponents_ShouldNotDependOn_LayoutComponents`, which enforces the one-way coupling rule: layout components may consume theme components, but theme components must never depend on layout.
+
+**2. ThemeColorPersistenceTests.cs — async write path not properly awaited**
+
+Three test methods (`ThemeProviderSetColor_WritesToJs_*`, `ThemeProviderSetBrightness_WritesToJs_*`, `ThemeProvider_AfterSetColorRed_*`) were `void` and called `cut.InvokeAsync(...)` without `await`. Promoted all three to `async Task` and awaited the `InvokeAsync` call so the full `InvokeVoidAsync` write path completes before assertions run.
+
+**3. ThemeColorPersistenceTests.cs — JS-failure catch branch uncovered**
+
+Added two new tests:
+
+- `ThemeProvider_SetColor_SilentlySwallowsJsException_AndKeepsNewColor`
+- `ThemeProvider_SetBrightness_SilentlySwallowsJsException_AndKeepsNewBrightness`
+
+Both use `JSRuntimeMode.Strict` with the respective write method (`setColor`/`setBrightness`) **not** planned.
+bUnit throws on the unplanned `InvokeVoidAsync` call, exercising the catch branch.
+Tests assert that `CurrentColor`/`CurrentBrightness` is updated and no exception propagates to the caller.
+No production code change required — the bare `catch {}` blocks in `ThemeProvider.razor.cs` are already correct.
+
+### Build & Test Results
+
+- Build: 0 errors, 46 pre-existing test-project warnings (CA1707/CA1307 naming — not introduced by this change)
+- Architecture.Tests: 13/13 passed
+- Web.Tests.Bunit: 89/89 passed (up from 87 before JS-failure tests were added)
+- Domain.Tests: 42/42 passed
+- Web.Tests: 127/127 passed
+- All pre-push gates passed; pushed to `squad/239-fix-theme-color-selector-persistence`
+
+### Learnings
+
+- **Tautological architecture tests are silently useless.** `ResideInNamespace("X").Should().ResideInNamespace("X")` always passes and provides no enforcement. The meaningful pattern is `.ShouldNot().HaveDependencyOn(...)`.
+- **bUnit `InvokeAsync` must be awaited in async tests.** Fire-and-forget `InvokeAsync` in a `void` test can pass intermittently if `WaitForAssertion` retries long enough, but it doesn't pin the full async path. Always `await cut.InvokeAsync(...)` in `async Task` tests.
+- **`JSRuntimeMode.Strict` is the correct tool for catch-branch coverage.** Setting Strict mode and leaving a specific invocation unplanned causes bUnit to throw a `JSException`-derived exception on `InvokeVoidAsync`. The production `catch {}` swallows it. This cleanly exercises the error path without mocking custom exception types.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,6 +25,7 @@
 
 		<!-- Database -->
 		<PackageVersion Include="MongoDB.EntityFrameworkCore" Version="10.0.1" />
+		<PackageVersion Include="Snappier" Version="1.3.1" />
 
 		<!-- Microsoft Packages -->
 		<PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />

--- a/src/AppHost/AppHost.csproj
+++ b/src/AppHost/AppHost.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.MongoDB" />
     <PackageReference Include="Aspire.Hosting.Redis" />
+    <PackageReference Include="Snappier" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Web/Components/App.razor
+++ b/src/Web/Components/App.razor
@@ -110,9 +110,7 @@
 </head>
 
 <body>
-  <ThemeProvider>
-    <Routes @rendermode="InteractiveServer" />
-  </ThemeProvider>
+  <Routes @rendermode="InteractiveServer" />
   <ReconnectModal />
   <script src="js/theme.js"></script>
   <script src="@Assets["_framework/blazor.web.js"]"></script>

--- a/src/Web/Components/Routes.razor
+++ b/src/Web/Components/Routes.razor
@@ -1,17 +1,21 @@
-﻿<Router AppAssembly="typeof(Program).Assembly" NotFoundPage="typeof(Pages.NotFound)">
-    <Found Context="routeData">
-        <AuthorizeRouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)">
-            <NotAuthorized>
-                @if (!context.User.Identity?.IsAuthenticated ?? true)
-                {
-                    <RedirectToLogin />
-                }
-                else
-                {
-                    <p role="alert">You are not authorized to access this resource.</p>
-                }
-            </NotAuthorized>
-        </AuthorizeRouteView>
-        <FocusOnNavigate RouteData="routeData" Selector="#main-content" />
-    </Found>
-</Router>
+@using MyBlog.Web.Components.Theme
+
+<ThemeProvider>
+    <Router AppAssembly="typeof(Program).Assembly" NotFoundPage="typeof(Pages.NotFound)">
+        <Found Context="routeData">
+            <AuthorizeRouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)">
+                <NotAuthorized>
+                    @if (!context.User.Identity?.IsAuthenticated ?? true)
+                    {
+                        <RedirectToLogin />
+                    }
+                    else
+                    {
+                        <p role="alert">You are not authorized to access this resource.</p>
+                    }
+                </NotAuthorized>
+            </AuthorizeRouteView>
+            <FocusOnNavigate RouteData="routeData" Selector="#main-content" />
+        </Found>
+    </Router>
+</ThemeProvider>

--- a/src/Web/Components/Theme/ThemeColorDropdownComponent.razor
+++ b/src/Web/Components/Theme/ThemeColorDropdownComponent.razor
@@ -5,10 +5,10 @@
         class="text-sm rounded border border-primary-200 dark:border-primary-800 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-2 py-1 cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary-400"
         aria-label="Choose color theme"
         title="Select colour theme">
-	<option value="red">🔴 Red</option>
-	<option value="blue">🔵 Blue</option>
-	<option value="green">🟢 Green</option>
-	<option value="yellow">🟡 Yellow</option>
+	<option value="red" selected="@(CurrentColor == "red")">🔴 Red</option>
+	<option value="blue" selected="@(CurrentColor == "blue")">🔵 Blue</option>
+	<option value="green" selected="@(CurrentColor == "green")">🟢 Green</option>
+	<option value="yellow" selected="@(CurrentColor == "yellow")">🟡 Yellow</option>
 </select>
 
 @code {

--- a/src/Web/Components/Theme/ThemeProvider.razor.cs
+++ b/src/Web/Components/Theme/ThemeProvider.razor.cs
@@ -50,13 +50,27 @@ public partial class ThemeProvider : ComponentBase
 	{
 		CurrentColor = color;
 		StateHasChanged();
-		await Js.InvokeVoidAsync("themeManager.setColor", color);
+		try
+		{
+			await Js.InvokeVoidAsync("themeManager.setColor", color);
+		}
+		catch
+		{
+			// Ignore JS errors (circuit disconnect, localStorage unavailable)
+		}
 	}
 
 	public async Task SetBrightness(string brightness)
 	{
 		CurrentBrightness = brightness;
 		StateHasChanged();
-		await Js.InvokeVoidAsync("themeManager.setBrightness", brightness);
+		try
+		{
+			await Js.InvokeVoidAsync("themeManager.setBrightness", brightness);
+		}
+		catch
+		{
+			// Ignore JS errors (circuit disconnect, localStorage unavailable)
+		}
 	}
 }

--- a/src/Web/Web.csproj
+++ b/src/Web/Web.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="MediatR" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="MongoDB.EntityFrameworkCore" />
+    <PackageReference Include="Snappier" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/tests/Architecture.Tests/ThemeLayerTests.cs
+++ b/tests/Architecture.Tests/ThemeLayerTests.cs
@@ -46,17 +46,15 @@ public class ThemeLayerTests
 	}
 
 	[Fact]
-	public void LayoutComponents_ShouldResideIn_LayoutNamespace()
+	public void ThemeComponents_ShouldNotDependOn_LayoutComponents()
 	{
-		// Arrange
-		var layoutAssembly = WebAssembly;
-
-		// Act
-		var result = Types.InAssembly(layoutAssembly)
+		// Theme components are a lower-level UI primitive: layout may consume them,
+		// but theme components must never take a dependency on layout (one-way coupling).
+		var result = Types.InAssembly(WebAssembly)
 				.That()
-				.ResideInNamespace("MyBlog.Web.Components.Layout")
-				.Should()
-				.ResideInNamespace("MyBlog.Web.Components.Layout")
+				.ResideInNamespace("MyBlog.Web.Components.Theme")
+				.ShouldNot()
+				.HaveDependencyOn("MyBlog.Web.Components.Layout")
 				.GetResult();
 
 		// Assert

--- a/tests/Architecture.Tests/ThemeLayerTests.cs
+++ b/tests/Architecture.Tests/ThemeLayerTests.cs
@@ -44,4 +44,41 @@ public class ThemeLayerTests
 		// Assert
 		result.IsSuccessful.Should().BeTrue();
 	}
+
+	[Fact]
+	public void LayoutComponents_ShouldResideIn_LayoutNamespace()
+	{
+		// Arrange
+		var layoutAssembly = WebAssembly;
+
+		// Act
+		var result = Types.InAssembly(layoutAssembly)
+				.That()
+				.ResideInNamespace("MyBlog.Web.Components.Layout")
+				.Should()
+				.ResideInNamespace("MyBlog.Web.Components.Layout")
+				.GetResult();
+
+		// Assert
+		result.IsSuccessful.Should().BeTrue();
+	}
+
+	[Fact]
+	public void ThemeComponents_ShouldHaveNoDependencyOn_Auth0OrIdentityServer()
+	{
+		// Arrange
+		var assembly = WebAssembly;
+
+		// Act — theme components must not couple to authentication services;
+		// they receive auth context only via Blazor's cascading AuthenticationState
+		var result = Types.InAssembly(assembly)
+				.That()
+				.ResideInNamespace("MyBlog.Web.Components.Theme")
+				.ShouldNot()
+				.HaveDependencyOnAny("Auth0", "Microsoft.AspNetCore.Identity", "IdentityServer")
+				.GetResult();
+
+		// Assert
+		result.IsSuccessful.Should().BeTrue();
+	}
 }

--- a/tests/Web.Tests.Bunit/Components/Layout/MainLayoutThemeTests.cs
+++ b/tests/Web.Tests.Bunit/Components/Layout/MainLayoutThemeTests.cs
@@ -1,0 +1,164 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     MainLayoutThemeTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web.Tests.Bunit
+//=======================================================
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+
+using MyBlog.Web.Components.Layout;
+using MyBlog.Web.Components.Theme;
+
+using Web.Testing;
+
+namespace Web.Components.Layout;
+
+/// <summary>
+/// Tests that shared layout surfaces (NavMenu, MainLayout) honour the selected
+/// primary colour palette — issue #239: "key common UI like nav menu and footer
+/// should reflect those colours consistently."
+/// </summary>
+public sealed class MainLayoutThemeTests : BunitContext
+{
+	public MainLayoutThemeTests()
+	{
+		Services.AddAuthorizationCore();
+		Services.AddSingleton<IAuthorizationService, TestAuthorizationService>();
+		JSInterop.Mode = JSRuntimeMode.Loose;
+	}
+
+	// ─── NavMenu layout surface ───────────────────────────────────────────────
+
+	[Fact]
+	public void NavMenu_NavElement_HasPrimaryColorBackgroundClass()
+	{
+		// Arrange (none)
+		// Act
+		var cut = Render<NavMenu>(parameters => parameters
+			.AddCascadingValue(Task.FromResult(new AuthenticationState(CreatePrincipal()))));
+
+		// Assert — NavMenu must use bg-primary-* classes so the active palette is reflected across pages
+		cut.Find("nav").OuterHtml.Should().Contain("bg-primary-600",
+			because: "the NavMenu nav element must use bg-primary-600 to honour the selected colour theme");
+	}
+
+	[Fact]
+	public void NavMenu_NavElement_HasPrimaryBorderClass()
+	{
+		// Arrange (none)
+		// Act
+		var cut = Render<NavMenu>(parameters => parameters
+			.AddCascadingValue(Task.FromResult(new AuthenticationState(CreatePrincipal()))));
+
+		// Assert
+		cut.Find("nav").OuterHtml.Should().Contain("border-primary-",
+			because: "NavMenu must use primary-colour borders to stay consistent with the selected palette");
+	}
+
+	[Fact]
+	public void NavMenu_RenderedInsideThemeProvider_DropdownShowsStoredColor()
+	{
+		// Arrange — ThemeProvider holds the stored colour "red"
+		JSInterop.Setup<string>("themeManager.getColor").SetResult("red");
+		JSInterop.Setup<string>("themeManager.getBrightness").SetResult("light");
+
+		var principal = CreatePrincipal();
+
+		// Act — ThemeProvider wraps NavMenu (matches production: App.razor → ThemeProvider → NavMenu)
+		var cut = Render<ThemeProvider>(parameters => parameters
+			.AddCascadingValue(Task.FromResult(new AuthenticationState(principal)))
+			.AddChildContent<NavMenu>());
+
+		// Assert — NavMenu's ThemeSelector dropdown reflects the stored colour via cascade
+		cut.WaitForAssertion(() =>
+			cut.Find("select").GetAttribute("value").Should().Be("red",
+				because: "NavMenu's ThemeSelector must display the stored colour after navigation via cascade"));
+	}
+
+	[Fact]
+	public void NavMenu_RenderedInsideThemeProvider_BrightnessToggleReflectsStoredDarkMode()
+	{
+		// Arrange — stored brightness is dark
+		JSInterop.Setup<string>("themeManager.getColor").SetResult("blue");
+		JSInterop.Setup<string>("themeManager.getBrightness").SetResult("dark");
+
+		var principal = CreatePrincipal();
+
+		// Act
+		var cut = Render<ThemeProvider>(parameters => parameters
+			.AddCascadingValue(Task.FromResult(new AuthenticationState(principal)))
+			.AddChildContent<NavMenu>());
+
+		// Assert — brightness toggle aria-label reflects the dark state cascaded from ThemeProvider
+		cut.WaitForAssertion(() =>
+			cut.Find("button[aria-label]").GetAttribute("aria-label").Should().Contain("dark",
+				because: "the brightness toggle must reflect persisted dark mode via the ThemeProvider cascade"));
+	}
+
+	// ─── MainLayout layout surface ────────────────────────────────────────────
+
+	[Fact]
+	public void MainLayout_RootDiv_HasPrimaryColorBackgroundClass()
+	{
+		// Arrange
+		// Act
+		var cut = Render<MainLayout>(parameters => parameters
+			.AddCascadingValue(Task.FromResult(new AuthenticationState(CreatePrincipal("Layout User", ["Author"]))))
+			.Add(p => p.Body, (RenderFragment)(builder => builder.AddContent(0, "page body"))));
+
+		// Assert — root layout element must use primary-* colours so all pages reflect the active palette
+		cut.Markup.Should().Contain("bg-primary-400",
+			because: "MainLayout root element must use bg-primary-400 to reflect the selected colour theme");
+	}
+
+	[Fact]
+	public void MainLayout_RootDiv_HasDarkModePrimaryBackgroundClass()
+	{
+		// Arrange
+		// Act
+		var cut = Render<MainLayout>(parameters => parameters
+			.AddCascadingValue(Task.FromResult(new AuthenticationState(CreatePrincipal("Layout User", ["Author"]))))
+			.Add(p => p.Body, (RenderFragment)(builder => builder.AddContent(0, string.Empty))));
+
+		// Assert — dark mode variant must also use primary palette
+		cut.Markup.Should().Contain("dark:bg-primary-800",
+			because: "MainLayout must use dark:bg-primary-800 so dark mode also reflects the selected colour theme");
+	}
+
+	[Fact]
+	public void MainLayout_RootDiv_HasPrimaryTextColorClass()
+	{
+		// Arrange
+		// Act
+		var cut = Render<MainLayout>(parameters => parameters
+			.AddCascadingValue(Task.FromResult(new AuthenticationState(CreatePrincipal("Layout User", ["Author"]))))
+			.Add(p => p.Body, (RenderFragment)(builder => builder.AddContent(0, string.Empty))));
+
+		// Assert — text colour must also follow the primary palette
+		cut.Markup.Should().Contain("text-primary-",
+			because: "MainLayout text colour must use primary-palette classes for visual consistency");
+	}
+
+	// ─── Helpers ──────────────────────────────────────────────────────────────
+
+	private static ClaimsPrincipal CreatePrincipal(string? name = null, string[]? roles = null)
+	{
+		if (name is null)
+		{
+			return new ClaimsPrincipal(new ClaimsIdentity());
+		}
+
+		var claims = new List<Claim> { new(ClaimTypes.Name, name) };
+
+		if (roles is not null)
+		{
+			claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+		}
+
+		return new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth", ClaimTypes.Name, ClaimTypes.Role));
+	}
+}

--- a/tests/Web.Tests.Bunit/Components/Theme/ThemeColorPersistenceTests.cs
+++ b/tests/Web.Tests.Bunit/Components/Theme/ThemeColorPersistenceTests.cs
@@ -1,0 +1,252 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     ThemeColorPersistenceTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web.Tests.Bunit
+//=======================================================
+
+using Microsoft.JSInterop;
+
+using MyBlog.Web.Components.Theme;
+
+namespace Web.Components.Theme;
+
+/// <summary>
+/// Focused tests for issue #239: colour selection persists across navigation and
+/// reload, all four Tailwind palette colours are supported end-to-end, and layout
+/// surfaces receive the persisted colour via cascading values.
+/// </summary>
+public sealed class ThemeColorPersistenceTests : BunitContext
+{
+	public ThemeColorPersistenceTests()
+	{
+		JSInterop.Mode = JSRuntimeMode.Loose;
+	}
+
+	// ─── Persistence: reading back the stored value on a fresh mount ──────────
+
+	[Theory]
+	[InlineData("red")]
+	[InlineData("blue")]
+	[InlineData("green")]
+	[InlineData("yellow")]
+	public void ThemeProviderAdoptsAllFourStoredColors_OnFirstRender(string storedColor)
+	{
+		// Arrange — localStorage (via themeManager.getColor) holds the previously stored colour
+		JSInterop.Setup<string>("themeManager.getColor").SetResult(storedColor);
+		JSInterop.Setup<string>("themeManager.getBrightness").SetResult("light");
+
+		// Act — new ThemeProvider instance mounts (simulates what happens after page navigation)
+		var cut = Render<ThemeProvider>();
+
+		// Assert — component adopts the persisted colour so the page reflects the stored palette
+		cut.WaitForAssertion(() =>
+			cut.Instance.CurrentColor.Should().Be(storedColor,
+				because: $"ThemeProvider must read '{storedColor}' back from JS/localStorage on mount"));
+	}
+
+	[Theory]
+	[InlineData("light")]
+	[InlineData("dark")]
+	public void ThemeProviderAdoptsBothStoredBrightnessValues_OnFirstRender(string storedBrightness)
+	{
+		// Arrange
+		JSInterop.Setup<string>("themeManager.getColor").SetResult("blue");
+		JSInterop.Setup<string>("themeManager.getBrightness").SetResult(storedBrightness);
+
+		// Act
+		var cut = Render<ThemeProvider>();
+
+		// Assert
+		cut.WaitForAssertion(() =>
+			cut.Instance.CurrentBrightness.Should().Be(storedBrightness,
+				because: $"ThemeProvider must read '{storedBrightness}' back from JS/localStorage on mount"));
+	}
+
+	// ─── Persistence: writing to storage on colour selection ─────────────────
+
+	[Theory]
+	[InlineData("red")]
+	[InlineData("blue")]
+	[InlineData("green")]
+	[InlineData("yellow")]
+	public void ThemeProviderSetColor_WritesToJs_ForAllSupportedPaletteColors(string newColor)
+	{
+		// Arrange
+		JSInterop.Setup<string>("themeManager.getColor").SetResult("blue");
+		JSInterop.Setup<string>("themeManager.getBrightness").SetResult("light");
+
+		var cut = Render<ThemeProvider>();
+
+		// Act
+		cut.InvokeAsync(() => cut.Instance.SetColor(newColor));
+
+		// Assert — JS setColor is invoked, which writes to localStorage (read back on next page load)
+		cut.WaitForAssertion(() =>
+			JSInterop.Invocations.Should().Contain(i =>
+				i.Identifier == "themeManager.setColor" &&
+				i.Arguments.Contains(newColor),
+				because: $"SetColor('{newColor}') must persist to localStorage via themeManager.setColor"));
+	}
+
+	[Theory]
+	[InlineData("light")]
+	[InlineData("dark")]
+	public void ThemeProviderSetBrightness_WritesToJs_ForBothSupportedValues(string newBrightness)
+	{
+		// Arrange
+		JSInterop.Setup<string>("themeManager.getColor").SetResult("blue");
+		JSInterop.Setup<string>("themeManager.getBrightness").SetResult("light");
+
+		var cut = Render<ThemeProvider>();
+
+		// Act
+		cut.InvokeAsync(() => cut.Instance.SetBrightness(newBrightness));
+
+		// Assert
+		cut.WaitForAssertion(() =>
+			JSInterop.Invocations.Should().Contain(i =>
+				i.Identifier == "themeManager.setBrightness" &&
+				i.Arguments.Contains(newBrightness),
+				because: $"SetBrightness('{newBrightness}') must persist to localStorage via themeManager.setBrightness"));
+	}
+
+	// ─── Navigation simulation: new ThemeProvider instance reads stored value ─
+
+	[Fact]
+	public void ThemeProvider_SimulatedNavigation_ReadsStoredColorFromJs()
+	{
+		// Arrange — simulate: user previously selected "green" and it was written to localStorage
+		JSInterop.Setup<string>("themeManager.getColor").SetResult("green");
+		JSInterop.Setup<string>("themeManager.getBrightness").SetResult("light");
+
+		// Act — simulate page navigation: a new ThemeProvider instance mounts on the destination page
+		var cut = Render<ThemeProvider>(parameters => parameters
+			.AddChildContent("<span id='destination'>Destination Page</span>"));
+
+		// Assert — the new page reflects the stored colour from localStorage
+		cut.WaitForAssertion(() =>
+		{
+			cut.Instance.CurrentColor.Should().Be("green",
+				because: "after navigation the new page must display the previously persisted colour");
+			cut.Find("#destination").TextContent.Should().Be("Destination Page");
+		});
+	}
+
+	[Fact]
+	public void ThemeProvider_SimulatedNavigation_ReadsStoredDarkBrightnessFromJs()
+	{
+		// Arrange — simulate: user previously enabled dark mode
+		JSInterop.Setup<string>("themeManager.getColor").SetResult("blue");
+		JSInterop.Setup<string>("themeManager.getBrightness").SetResult("dark");
+
+		// Act — simulate navigation
+		var cut = Render<ThemeProvider>();
+
+		// Assert
+		cut.WaitForAssertion(() =>
+			cut.Instance.CurrentBrightness.Should().Be("dark",
+				because: "brightness preference must survive navigation via localStorage"));
+	}
+
+	// ─── Cascade: layout surfaces receive the persisted colour ────────────────
+
+	[Fact]
+	public void ThemeProvider_CascadesStoredColor_ToColorDropdown()
+	{
+		// Arrange — stored colour is "yellow"
+		JSInterop.Setup<string>("themeManager.getColor").SetResult("yellow");
+		JSInterop.Setup<string>("themeManager.getBrightness").SetResult("light");
+
+		// Act — ThemeProvider wraps ThemeSelector (same as production: App → ThemeProvider → NavMenu → ThemeSelector)
+		var cut = Render<ThemeProvider>(parameters => parameters
+			.AddChildContent<ThemeSelector>());
+
+		// Assert — the colour dropdown reflects "yellow" through the cascading value
+		cut.WaitForAssertion(() =>
+			cut.Find("select").GetAttribute("value").Should().Be("yellow",
+				because: "the colour dropdown must display the persisted colour after a new page mounts"));
+	}
+
+	[Fact]
+	public void ThemeProvider_CascadesDarkBrightness_ToBrightnessToggleAriaLabel()
+	{
+		// Arrange — stored brightness is dark
+		JSInterop.Setup<string>("themeManager.getColor").SetResult("blue");
+		JSInterop.Setup<string>("themeManager.getBrightness").SetResult("dark");
+
+		// Act
+		var cut = Render<ThemeProvider>(parameters => parameters
+			.AddChildContent<ThemeSelector>());
+
+		// Assert — brightness toggle reflects dark state through the cascaded value
+		cut.WaitForAssertion(() =>
+			cut.Find("button[aria-label]").GetAttribute("aria-label").Should().Contain("dark",
+				because: "the brightness toggle must reflect the persisted dark mode after navigation"));
+	}
+
+	// ─── SetColor updates the internal state AND cascades ─────────────────────
+
+	[Fact]
+	public void ThemeProvider_AfterSetColorRed_CurrentColorIsRed_AndColorDropdownReflectsIt()
+	{
+		// Arrange — starts with blue
+		JSInterop.Setup<string>("themeManager.getColor").SetResult("blue");
+		JSInterop.Setup<string>("themeManager.getBrightness").SetResult("light");
+
+		var cut = Render<ThemeProvider>(parameters => parameters
+			.AddChildContent<ThemeSelector>());
+
+		// Act — user picks red
+		cut.InvokeAsync(() => cut.Instance.SetColor("red"));
+
+		// Assert — internal state updated AND cascaded to child dropdown
+		cut.WaitForAssertion(() =>
+		{
+			cut.Instance.CurrentColor.Should().Be("red");
+			cut.Find("select").GetAttribute("value").Should().Be("red",
+				because: "the colour dropdown must immediately reflect the newly selected colour");
+		});
+	}
+
+	// ─── Guard: getColor / getBrightness called exactly once per mount ────────
+
+	[Fact]
+	public void ThemeProvider_GetColor_IsInvokedExactlyOnce_PerMount()
+	{
+		// Arrange
+		JSInterop.Setup<string>("themeManager.getColor").SetResult("blue");
+		JSInterop.Setup<string>("themeManager.getBrightness").SetResult("light");
+
+		// Act
+		var cut = Render<ThemeProvider>();
+
+		// Wait for the first-render async path to complete
+		cut.WaitForAssertion(() =>
+			JSInterop.Invocations.Should().Contain(i => i.Identifier == "themeManager.getColor"));
+
+		// Assert — exactly one call; the firstRender guard prevents repeated localStorage reads
+		JSInterop.Invocations.Count(i => i.Identifier == "themeManager.getColor")
+			.Should().Be(1, because: "ThemeProvider must read colour from JS only on firstRender, not on every re-render");
+	}
+
+	[Fact]
+	public void ThemeProvider_GetBrightness_IsInvokedExactlyOnce_PerMount()
+	{
+		// Arrange
+		JSInterop.Setup<string>("themeManager.getColor").SetResult("blue");
+		JSInterop.Setup<string>("themeManager.getBrightness").SetResult("light");
+
+		// Act
+		var cut = Render<ThemeProvider>();
+
+		cut.WaitForAssertion(() =>
+			JSInterop.Invocations.Should().Contain(i => i.Identifier == "themeManager.getBrightness"));
+
+		// Assert
+		JSInterop.Invocations.Count(i => i.Identifier == "themeManager.getBrightness")
+			.Should().Be(1, because: "ThemeProvider must read brightness from JS only on firstRender");
+	}
+}

--- a/tests/Web.Tests.Bunit/Components/Theme/ThemeColorPersistenceTests.cs
+++ b/tests/Web.Tests.Bunit/Components/Theme/ThemeColorPersistenceTests.cs
@@ -72,7 +72,7 @@ public sealed class ThemeColorPersistenceTests : BunitContext
 	[InlineData("blue")]
 	[InlineData("green")]
 	[InlineData("yellow")]
-	public void ThemeProviderSetColor_WritesToJs_ForAllSupportedPaletteColors(string newColor)
+	public async Task ThemeProviderSetColor_WritesToJs_ForAllSupportedPaletteColors(string newColor)
 	{
 		// Arrange
 		JSInterop.Setup<string>("themeManager.getColor").SetResult("blue");
@@ -80,21 +80,20 @@ public sealed class ThemeColorPersistenceTests : BunitContext
 
 		var cut = Render<ThemeProvider>();
 
-		// Act
-		cut.InvokeAsync(() => cut.Instance.SetColor(newColor));
+		// Act — await so the full async write path (InvokeVoidAsync) completes before asserting
+		await cut.InvokeAsync(() => cut.Instance.SetColor(newColor));
 
 		// Assert — JS setColor is invoked, which writes to localStorage (read back on next page load)
-		cut.WaitForAssertion(() =>
-			JSInterop.Invocations.Should().Contain(i =>
-				i.Identifier == "themeManager.setColor" &&
-				i.Arguments.Contains(newColor),
-				because: $"SetColor('{newColor}') must persist to localStorage via themeManager.setColor"));
+		JSInterop.Invocations.Should().Contain(i =>
+			i.Identifier == "themeManager.setColor" &&
+			i.Arguments.Contains(newColor),
+			because: $"SetColor('{newColor}') must persist to localStorage via themeManager.setColor");
 	}
 
 	[Theory]
 	[InlineData("light")]
 	[InlineData("dark")]
-	public void ThemeProviderSetBrightness_WritesToJs_ForBothSupportedValues(string newBrightness)
+	public async Task ThemeProviderSetBrightness_WritesToJs_ForBothSupportedValues(string newBrightness)
 	{
 		// Arrange
 		JSInterop.Setup<string>("themeManager.getColor").SetResult("blue");
@@ -102,15 +101,14 @@ public sealed class ThemeColorPersistenceTests : BunitContext
 
 		var cut = Render<ThemeProvider>();
 
-		// Act
-		cut.InvokeAsync(() => cut.Instance.SetBrightness(newBrightness));
+		// Act — await so the full async write path completes before asserting
+		await cut.InvokeAsync(() => cut.Instance.SetBrightness(newBrightness));
 
 		// Assert
-		cut.WaitForAssertion(() =>
-			JSInterop.Invocations.Should().Contain(i =>
-				i.Identifier == "themeManager.setBrightness" &&
-				i.Arguments.Contains(newBrightness),
-				because: $"SetBrightness('{newBrightness}') must persist to localStorage via themeManager.setBrightness"));
+		JSInterop.Invocations.Should().Contain(i =>
+			i.Identifier == "themeManager.setBrightness" &&
+			i.Arguments.Contains(newBrightness),
+			because: $"SetBrightness('{newBrightness}') must persist to localStorage via themeManager.setBrightness");
 	}
 
 	// ─── Navigation simulation: new ThemeProvider instance reads stored value ─
@@ -190,7 +188,7 @@ public sealed class ThemeColorPersistenceTests : BunitContext
 	// ─── SetColor updates the internal state AND cascades ─────────────────────
 
 	[Fact]
-	public void ThemeProvider_AfterSetColorRed_CurrentColorIsRed_AndColorDropdownReflectsIt()
+	public async Task ThemeProvider_AfterSetColorRed_CurrentColorIsRed_AndColorDropdownReflectsIt()
 	{
 		// Arrange — starts with blue
 		JSInterop.Setup<string>("themeManager.getColor").SetResult("blue");
@@ -199,8 +197,8 @@ public sealed class ThemeColorPersistenceTests : BunitContext
 		var cut = Render<ThemeProvider>(parameters => parameters
 			.AddChildContent<ThemeSelector>());
 
-		// Act — user picks red
-		cut.InvokeAsync(() => cut.Instance.SetColor("red"));
+		// Act — user picks red; await the full async write path
+		await cut.InvokeAsync(() => cut.Instance.SetColor("red"));
 
 		// Assert — internal state updated AND cascaded to child dropdown
 		cut.WaitForAssertion(() =>
@@ -248,5 +246,48 @@ public sealed class ThemeColorPersistenceTests : BunitContext
 		// Assert
 		JSInterop.Invocations.Count(i => i.Identifier == "themeManager.getBrightness")
 			.Should().Be(1, because: "ThemeProvider must read brightness from JS only on firstRender");
+	}
+
+	// ─── JS-failure branch: catch block swallows the exception ──────────────
+
+	[Fact]
+	public async Task ThemeProvider_SetColor_SilentlySwallowsJsException_AndKeepsNewColor()
+	{
+		// Arrange — Strict mode: themeManager.setColor is not planned, so bUnit throws JSException;
+		// the catch block in SetColor must absorb it without propagating to the caller.
+		JSInterop.Mode = JSRuntimeMode.Strict;
+		JSInterop.Setup<string>("themeManager.getColor").SetResult("blue");
+		JSInterop.Setup<string>("themeManager.getBrightness").SetResult("light");
+		// themeManager.setColor deliberately NOT planned — exercises the catch branch
+
+		var cut = Render<ThemeProvider>();
+		cut.WaitForAssertion(() => cut.Instance.CurrentColor.Should().Be("blue"));
+
+		// Act — must not throw even though JS persistence will fail
+		await cut.InvokeAsync(() => cut.Instance.SetColor("red"));
+
+		// Assert — CurrentColor updated to the new value despite the JS failure
+		cut.Instance.CurrentColor.Should().Be("red",
+			because: "SetColor must update CurrentColor even when the JS persistence call throws");
+	}
+
+	[Fact]
+	public async Task ThemeProvider_SetBrightness_SilentlySwallowsJsException_AndKeepsNewBrightness()
+	{
+		// Arrange — Strict mode: themeManager.setBrightness is not planned
+		JSInterop.Mode = JSRuntimeMode.Strict;
+		JSInterop.Setup<string>("themeManager.getColor").SetResult("blue");
+		JSInterop.Setup<string>("themeManager.getBrightness").SetResult("light");
+		// themeManager.setBrightness deliberately NOT planned — exercises the catch branch
+
+		var cut = Render<ThemeProvider>();
+		cut.WaitForAssertion(() => cut.Instance.CurrentBrightness.Should().Be("light"));
+
+		// Act — must not throw even though JS persistence will fail
+		await cut.InvokeAsync(() => cut.Instance.SetBrightness("dark"));
+
+		// Assert
+		cut.Instance.CurrentBrightness.Should().Be("dark",
+			because: "SetBrightness must update CurrentBrightness even when the JS persistence call throws");
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the theme color selector not persisting across navigation and page reloads.

Working as **Legolas** (Frontend/Blazor specialist)

## Root Cause

`ThemeProvider` was placed in `App.razor` (static SSR context). Static Blazor components **never** execute `OnAfterRenderAsync`, so JS interop calls to `themeManager.getColor/getBrightness` never fired. Interactive children calling `SetColor()` via cascading parameter updated a static parent instance — `StateHasChanged()` was a no-op and the cascade never re-propagated.

## Fix

**Move `ThemeProvider` from `App.razor` into `Routes.razor`** — which is rendered with `@rendermode="InteractiveServer"` from `App.razor`. ThemeProvider now correctly executes `OnAfterRenderAsync` on first interactive render, reads the persisted color/brightness from localStorage, and propagates via cascading value to all theme-aware children.

## Changes

| File | Change |
|------|--------|
| `App.razor` | Remove `<ThemeProvider>` wrapper (ThemeProvider moves to Routes) |
| `Routes.razor` | Wrap `<Router>` in `<ThemeProvider>` (inside interactive boundary) |
| `ThemeColorDropdownComponent.razor` | Add `selected="@(CurrentColor == X)"` on each `<option>` for robustness |
| `ThemeProvider.razor.cs` | Add try-catch to `SetColor`/`SetBrightness` for circuit disconnect resilience |
| `Directory.Packages.props` | Pin `Snappier 1.3.1` (pre-existing build blocker NU1903) |
| `Web.csproj` + `AppHost.csproj` | Add direct Snappier PackageReference |

## Tests

- Architecture.Tests: **15/15** ✅
- bUnit (Web.Tests.Bunit): **87/87** ✅ (22 new tests for color persistence and layout theme coverage)
- Domain.Tests: **42/42** ✅

## Notes

The anti-FOUC IIFE in `App.razor <head>` intentionally remains in place — it runs during static pre-render before Blazor hydration to prevent theme flash on load.

Closes #239