### PR TITLE
fix(ci): use GH_PROJECT_TOKEN for Projects V2 access in squad-mark-released

### DIFF
--- a/.github/workflows/squad-mark-released.yml
+++ b/.github/workflows/squad-mark-released.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Move Done → Released on project board
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_PROJECT_TOKEN }}
           script: |
             const PROJECT_ID        = process.env.PROJECT_ID;
             const STATUS_FIELD_ID   = process.env.STATUS_FIELD_ID;

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,9 @@
 {
 	"cSpell.words": [
 		"ASPNETCORE",
+		"cref",
 		"EECOM",
+		"inheritdoc",
 		"msbuild",
 		"rendermode",
 		"reskill",


### PR DESCRIPTION
## Summary

Fixes the `squad-mark-released` workflow which was failing with:
> `GraphqlResponseError: Resource not accessible by integration`

## Root Cause

`GITHUB_TOKEN` cannot access GitHub Projects V2 via GraphQL mutations. This is a known GitHub limitation — Projects V2 mutations require a PAT with `project` scope.

## Fix

Swap `secrets.GITHUB_TOKEN` → `secrets.GH_PROJECT_TOKEN`, which is the PAT already used by `project-board-automation.yml` and `add-issues-to-project.yml` for Projects V2 access.

## Board Update

The v1.4.0 board update was performed manually — 22 items moved from **Done → Released** directly via GraphQL.

## Related

- Fixes the `squad-mark-released` auto-trigger failure for v1.4.0
- Ensures future releases auto-update the board correctly