### PR TITLE
feat(AppHost): add WithShowStatsCommand for local dev stats

### DIFF
--- a/src/AppHost/MongoDbResourceBuilderExtensions.cs
+++ b/src/AppHost/MongoDbResourceBuilderExtensions.cs
@@ -7,6 +7,8 @@
 //Project Name :  AppHost
 //=======================================================
 
+using System.Text;
+
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 
@@ -29,6 +31,7 @@ return builder;
 
 builder.WithClearDatabaseCommand(databaseName);
 builder.WithSeedDataCommand(databaseName);
+builder.WithShowStatsCommand(databaseName);
 return builder;
 }
 
@@ -255,6 +258,97 @@ new CommandOptions
 {
 Description = "Inserts seed blog posts into the myblog database. Local development only.",
 IconName = "DatabaseArrowUp",
+UpdateState = ctx =>
+ctx.ResourceSnapshot.HealthStatus == HealthStatus.Healthy
+? ResourceCommandState.Enabled
+: ResourceCommandState.Disabled
+});
+}
+
+private static void WithShowStatsCommand(
+this IResourceBuilder<MongoDBServerResource> builder,
+string databaseName)
+{
+builder.WithCommand(
+"show-myblog-stats",
+"📊 Show MyBlog Stats",
+executeCommand: async context =>
+{
+if (!await _clearMutex.WaitAsync(0))
+{
+context.Logger.LogWarning(
+"Show MyBlog stats skipped on {ResourceName} — a database operation is already in progress.",
+context.ResourceName);
+
+return CommandResults.Failure(
+"A database operation is already in progress. Wait for the current run to finish, then try again.");
+}
+
+try
+{
+context.Logger.LogInformation(
+"Show MyBlog stats invoked on {ResourceName} — querying '{Database}'.",
+context.ResourceName, databaseName);
+
+var connectionString = await builder.Resource.ConnectionStringExpression.GetValueAsync(context.CancellationToken);
+if (connectionString is null)
+{
+context.Logger.LogError("Could not resolve MongoDB connection string for resource {ResourceName}.", context.ResourceName);
+return CommandResults.Failure("Could not resolve MongoDB connection string. Is the MongoDB resource running?");
+}
+
+var client = new MongoClient(connectionString);
+var database = client.GetDatabase(databaseName);
+
+var namesCursor = await database.ListCollectionNamesAsync(cancellationToken: context.CancellationToken);
+var collectionNames = await namesCursor.ToListAsync(context.CancellationToken);
+var userCollections = collectionNames
+.Where(static n => !n.StartsWith("system.", StringComparison.OrdinalIgnoreCase))
+.ToList();
+
+var sb = new StringBuilder();
+sb.AppendLine("| Collection | Document Count |");
+sb.AppendLine("| --- | --- |");
+
+if (userCollections.Count == 0)
+{
+sb.AppendLine("| *(no collections found)* | - |");
+}
+else
+{
+foreach (var name in userCollections)
+{
+var col = database.GetCollection<BsonDocument>(name);
+var count = await col.CountDocumentsAsync(
+FilterDefinition<BsonDocument>.Empty,
+cancellationToken: context.CancellationToken);
+sb.AppendLine($"| {name} | {count} |");
+}
+}
+
+var markdownTable = sb.ToString();
+context.Logger.LogInformation(
+"Show MyBlog stats complete: {Count} collection(s) reported.",
+userCollections.Count);
+
+return CommandResults.Success(
+$"{userCollections.Count} collection(s) found in '{databaseName}'",
+new CommandResultData
+{
+Value = markdownTable,
+Format = CommandResultFormat.Markdown,
+DisplayImmediately = true
+});
+}
+finally
+{
+_clearMutex.Release();
+}
+},
+new CommandOptions
+{
+Description = "Displays document counts per collection in the myblog database. Local development only.",
+IconName = "ChartMultiple",
 UpdateState = ctx =>
 ctx.ResourceSnapshot.HealthStatus == HealthStatus.Healthy
 ? ResourceCommandState.Enabled

--- a/tests/AppHost.Tests/Infrastructure/MongoStatsIntegrationCollection.cs
+++ b/tests/AppHost.Tests/Infrastructure/MongoStatsIntegrationCollection.cs
@@ -1,0 +1,19 @@
+// ============================================
+// Copyright (c) 2026. All rights reserved.
+// File Name :     MongoStatsIntegrationCollection.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : MyBlog
+// Project Name :  AppHost.Tests
+// =============================================
+
+namespace AppHost.Tests.Infrastructure;
+
+/// <summary>
+/// xUnit collection that shares one <see cref="ClearCommandAppFixture"/> across all tests
+/// in the "MongoStatsIntegration" collection (sequential execution, single Aspire host).
+/// </summary>
+[CollectionDefinition("MongoStatsIntegration")]
+public sealed class MongoStatsIntegrationCollection : ICollectionFixture<ClearCommandAppFixture>
+{
+}

--- a/tests/AppHost.Tests/MongoDbStatsCommandTests.cs
+++ b/tests/AppHost.Tests/MongoDbStatsCommandTests.cs
@@ -1,0 +1,186 @@
+// ============================================
+// Copyright (c) 2026. All rights reserved.
+// File Name :     MongoDbStatsCommandTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : MyBlog
+// Project Name :  AppHost.Tests
+// =============================================
+
+using System.Collections.Immutable;
+
+using Aspire.Hosting;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AppHost.Tests;
+
+/// <summary>
+/// Model-level tests for the local-only MongoDB show-stats operator command (issue #261).
+/// These tests verify the Aspire resource annotation contract only — they do not start the
+/// Aspire host, spin up containers, or touch a live database.
+/// </summary>
+public sealed class MongoDbStatsCommandTests
+{
+	private const string CommandName = "show-myblog-stats";
+
+	private static Task<IDistributedApplicationTestingBuilder> CreateBuilderAsync() =>
+		DistributedApplicationTestingBuilder.CreateAsync<Projects.AppHost>(
+			args: [],
+			configureBuilder: static (options, _) => { options.DisableDashboard = true; },
+			cancellationToken: TestContext.Current.CancellationToken);
+
+	/// <summary>
+	/// Acceptance criterion #1: The mongodb resource exposes a "show-myblog-stats" operator action.
+	/// </summary>
+	[Fact]
+	public async Task MongoDb_Resource_Exposes_ShowMyBlogStats_Command_Annotation()
+	{
+		// Arrange
+		var builder = await CreateBuilderAsync();
+		var mongoResource = builder.Resources.Single(static r => r.Name == "mongodb");
+
+		// Act
+		var annotation = mongoResource.Annotations
+			.OfType<ResourceCommandAnnotation>()
+			.SingleOrDefault(static a => a.Name == CommandName);
+
+		// Assert
+		annotation.Should().NotBeNull(
+			"the mongodb resource must expose a 'show-myblog-stats' operator action per issue #261");
+	}
+
+	/// <summary>
+	/// Acceptance criterion: The show-stats command must NOT be highlighted — it is read-only
+	/// and should not carry a danger indicator.
+	/// </summary>
+	[Fact]
+	public async Task ShowMyBlogStats_Command_Is_Not_Highlighted()
+	{
+		// Arrange
+		var builder = await CreateBuilderAsync();
+		var annotation = GetAnnotation(builder);
+
+		// Assert
+		annotation.IsHighlighted.Should().BeFalse(
+			"a read-only stats command must set IsHighlighted = false to avoid alarming the operator");
+	}
+
+	/// <summary>
+	/// Acceptance criterion: The show-stats command must NOT require a confirmation prompt.
+	/// It is a read-only query and needs no y/n dialog.
+	/// </summary>
+	[Fact]
+	public async Task ShowMyBlogStats_Command_Has_No_ConfirmationMessage()
+	{
+		// Arrange
+		var builder = await CreateBuilderAsync();
+		var annotation = GetAnnotation(builder);
+
+		// Assert
+		annotation.ConfirmationMessage.Should().BeNullOrEmpty(
+			"the stats command is read-only and must not display a confirmation dialog");
+	}
+
+	/// <summary>
+	/// Acceptance criterion: The show-stats command is enabled only when MongoDB is healthy.
+	/// </summary>
+	[Fact]
+	public async Task ShowMyBlogStats_UpdateState_Returns_Enabled_When_MongoDB_Is_Healthy()
+	{
+		// Arrange
+		var builder = await CreateBuilderAsync();
+		var annotation = GetAnnotation(builder);
+
+		var snapshot = BuildSnapshot(HealthStatus.Healthy);
+
+		var ctx = new UpdateCommandStateContext
+		{
+			ResourceSnapshot = snapshot,
+			ServiceProvider = new ServiceCollection().BuildServiceProvider(),
+		};
+
+		// Act
+		var state = annotation.UpdateState(ctx);
+
+		// Assert
+		state.Should().Be(ResourceCommandState.Enabled,
+			"the show-myblog-stats command must be available when MongoDB is healthy");
+	}
+
+	/// <summary>
+	/// Acceptance criterion: The show-stats command must be disabled when MongoDB is not healthy
+	/// to prevent queries against an unstable or stopped container.
+	/// </summary>
+	[Fact]
+	public async Task ShowMyBlogStats_UpdateState_Returns_Disabled_When_MongoDB_Is_Unhealthy()
+	{
+		// Arrange
+		var builder = await CreateBuilderAsync();
+		var annotation = GetAnnotation(builder);
+
+		var snapshot = BuildSnapshot(HealthStatus.Unhealthy);
+
+		var ctx = new UpdateCommandStateContext
+		{
+			ResourceSnapshot = snapshot,
+			ServiceProvider = new ServiceCollection().BuildServiceProvider(),
+		};
+
+		// Act
+		var state = annotation.UpdateState(ctx);
+
+		// Assert
+		state.Should().Be(ResourceCommandState.Disabled,
+			"the show-myblog-stats command must be unavailable when MongoDB is unhealthy");
+	}
+
+
+	// ---------------------------------------------------------------------------
+	// Helpers
+	// ---------------------------------------------------------------------------
+
+	private static ResourceCommandAnnotation GetAnnotation(IDistributedApplicationTestingBuilder builder)
+	{
+		var mongoResource = builder.Resources.Single(static r => r.Name == "mongodb");
+
+		return mongoResource.Annotations
+			.OfType<ResourceCommandAnnotation>()
+			.Single(static a => a.Name == CommandName);
+	}
+
+	/// <summary>
+	/// Creates a <see cref="CustomResourceSnapshot"/> with the given health status.
+	/// <para>
+	/// <see cref="CustomResourceSnapshot.HealthReports"/> has an internal init accessor and
+	/// <see cref="CustomResourceSnapshot.HealthStatus"/> is a private computed property —
+	/// both are inaccessible from external assemblies via normal C#.  Reflection is required.
+	/// </para>
+	/// </summary>
+	private static CustomResourceSnapshot BuildSnapshot(HealthStatus health)
+	{
+		var snapshot = new CustomResourceSnapshot
+		{
+			ResourceType = "MongoDB.Server",
+			Properties = [],
+		};
+
+		var reports = ImmutableArray.Create(
+			new HealthReportSnapshot("ready", health, null, null));
+
+		var type = typeof(CustomResourceSnapshot);
+		type
+			.GetProperty("HealthReports")!
+			.GetSetMethod(nonPublic: true)!
+			.Invoke(snapshot, [reports]);
+
+		type.GetProperty("HealthStatus")!
+			.GetSetMethod(nonPublic: true)!
+			.Invoke(snapshot, [(HealthStatus?)health]);
+
+		return snapshot;
+	}
+}

--- a/tests/AppHost.Tests/MongoShowStatsIntegrationTests.cs
+++ b/tests/AppHost.Tests/MongoShowStatsIntegrationTests.cs
@@ -83,7 +83,7 @@ public sealed class MongoShowStatsIntegrationTests(ClearCommandAppFixture fixtur
 	public async Task ShowMyBlogStats_Concurrent_Invocations_Allow_Only_One_Run()
 	{
 		// Arrange
-		await PrepareAsync(blogPostCount: 0);
+		await PrepareAsync(blogPostCount: 50);
 
 		var annotation = GetAnnotation();
 

--- a/tests/AppHost.Tests/MongoShowStatsIntegrationTests.cs
+++ b/tests/AppHost.Tests/MongoShowStatsIntegrationTests.cs
@@ -1,0 +1,140 @@
+// ============================================
+// Copyright (c) 2026. All rights reserved.
+// File Name :     MongoShowStatsIntegrationTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : MyBlog
+// Project Name :  AppHost.Tests
+// =============================================
+
+using AppHost.Tests.Infrastructure;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace AppHost.Tests;
+
+/// <summary>
+/// Full integration tests for the "show-myblog-stats" operator command (issue #261).
+/// <para>
+/// These tests require Docker because they boot the real Aspire host so that the handler's
+/// closure-captured <c>mongo.Resource.ConnectionStringExpression.GetValueAsync()</c> can
+/// resolve the live container's connection string.
+/// </para>
+/// </summary>
+[Collection("MongoStatsIntegration")]
+public sealed class MongoShowStatsIntegrationTests(ClearCommandAppFixture fixture)
+{
+	private const string CommandName = "show-myblog-stats";
+
+	/// <summary>
+	/// When at least one collection with documents exists, the command returns success and
+	/// reports the collection count in its message.
+	/// </summary>
+	[Fact]
+	public async Task ShowMyBlogStats_Returns_Collection_Names_And_Counts_In_Markdown()
+	{
+		// Arrange — drop db, then insert documents into blogposts
+		await PrepareAsync(blogPostCount: 1);
+
+		var annotation = GetAnnotation();
+		var ctx = MakeContext();
+
+		// Act
+		var result = await annotation.ExecuteCommand(ctx);
+
+		// Assert
+		result.Success.Should().BeTrue("the handler must succeed when MongoDB is reachable");
+		result.Message.Should().Contain("collection(s)",
+			"the success message must report the number of collections found");
+	}
+
+	/// <summary>
+	/// When the database is completely empty (no user collections), the command must still
+	/// succeed — an empty database is not an error condition.
+	/// </summary>
+	[Fact]
+	public async Task ShowMyBlogStats_Empty_Database_Returns_No_Collections_Found()
+	{
+		// Arrange — drop the entire myblog database so no collection exists
+		await PrepareAsync(blogPostCount: 0);
+
+		var annotation = GetAnnotation();
+		var ctx = MakeContext();
+
+		// Act
+		var result = await annotation.ExecuteCommand(ctx);
+
+		// Assert
+		result.Success.Should().BeTrue("an empty database must still return success — no collections is not an error");
+		result.Message.Should().Contain("0 collection(s)",
+			"the message must indicate zero collections were found in the empty database");
+	}
+
+	/// <summary>
+	/// Two simultaneous stats attempts must not run together: exactly one proceeds and
+	/// the other fails fast with operator-visible feedback.
+	/// </summary>
+	[Fact]
+	public async Task ShowMyBlogStats_Concurrent_Invocations_Allow_Only_One_Run()
+	{
+		// Arrange
+		await PrepareAsync(blogPostCount: 0);
+
+		var annotation = GetAnnotation();
+
+		// Act — fire two concurrent stats operations
+		var firstTask = annotation.ExecuteCommand(MakeContext());
+		var secondTask = annotation.ExecuteCommand(MakeContext());
+		var results = await Task.WhenAll(firstTask, secondTask);
+
+		// Assert
+		results.Count(static r => r.Success).Should().Be(1,
+			"the semaphore should allow only one stats operation to run at a time");
+		results.Count(static r => !r.Success).Should().Be(1,
+			"the overlapping stats attempt should fail fast instead of queueing");
+		results.Single(static r => !r.Success).Message.Should().Contain("already in progress",
+			"the operator needs immediate feedback when another database operation is in flight");
+	}
+
+
+	// ---------------------------------------------------------------------------
+	// Helpers
+	// ---------------------------------------------------------------------------
+
+	private async Task PrepareAsync(int blogPostCount = 0)
+	{
+		var client = new MongoClient(fixture.MongoConnectionString);
+		await client.DropDatabaseAsync("myblog", TestContext.Current.CancellationToken);
+		if (blogPostCount > 0)
+		{
+			var db = client.GetDatabase("myblog");
+			var col = db.GetCollection<BsonDocument>("blogposts");
+			var docs = Enumerable.Range(0, blogPostCount)
+				.Select(i => new BsonDocument("n", i))
+				.ToList();
+			await col.InsertManyAsync(docs, cancellationToken: TestContext.Current.CancellationToken);
+		}
+	}
+
+	private ResourceCommandAnnotation GetAnnotation()
+	{
+		var mongoResource = fixture.Builder.Resources.Single(static r => r.Name == "mongodb");
+
+		return mongoResource.Annotations
+			.OfType<ResourceCommandAnnotation>()
+			.Single(static a => a.Name == CommandName);
+	}
+
+	private static ExecuteCommandContext MakeContext() => new()
+	{
+		ResourceName = "mongodb",
+		ServiceProvider = new ServiceCollection().BuildServiceProvider(),
+		Logger = NullLogger.Instance,
+		CancellationToken = TestContext.Current.CancellationToken,
+	};
+}


### PR DESCRIPTION
Closes #261

Working as Sam (Backend/.NET)

## Changes

- Added `WithShowStatsCommand` to `MongoDbResourceBuilderExtensions`
- Command name: `show-myblog-stats`, display: `📊 Show MyBlog Stats`
- Returns Markdown table of collection document counts via `CommandResultData` with `DisplayImmediately = true`
- Empty DB returns `*(no collections found)*` row with `Success = true`
- Shared `_clearMutex` prevents concurrent operations (non-blocking `WaitAsync(0)`)
- Skips `system.*` collections consistent with clear command
- `UpdateState` gates on `HealthStatus.Healthy` → `Enabled`, else `Disabled`
- Unit tests: `MongoDbStatsCommandTests` (5 tests)
- Collection definition: `Infrastructure/MongoStatsIntegrationCollection`
- Integration tests: `MongoShowStatsIntegrationTests` (3 tests)
- All 16 prior unit tests continue to pass
