### PR TITLE
fix(ci): Blog → README Sync — push to dev instead of main

### DIFF
--- a/.github/workflows/blog-readme-sync.yml
+++ b/.github/workflows/blog-readme-sync.yml
@@ -78,5 +78,5 @@ jobs:
           git diff --quiet README.md || (
             git add README.md &&
             git commit -m "docs: sync Dev Blog section from docs/blog/index.md [skip ci]" &&
-            git push
+            git push origin HEAD:dev
           )

--- a/.squad/agents/boromir/history.md
+++ b/.squad/agents/boromir/history.md
@@ -48,6 +48,18 @@
 
 ## Learnings
 
+### 2026-05-XX — Issue #269: Blog → README Sync workflow branch protection fix
+
+**Problem:** `blog-readme-sync.yml` pushed directly to `main` after updating `README.md`, which is blocked by branch protection rules (direct pushes forbidden, "Build Solution" check required).
+
+**Fix (Option C):** Changed `git push` to `git push origin HEAD:dev` in the "Commit updated README" step. The workflow still triggers on `push: branches: [main]` (reading `docs/blog/index.md` from main), but the README update is pushed to `dev` — the normal development branch — and flows through the standard dev→main release cycle.
+
+**Key insight:** The `permissions: contents: write` block was already present. No new secrets or PAT bypass needed. One-line change.
+
+**Decision:** Captured in `.squad/decisions/inbox/boromir-269-readme-sync-target.md`.
+
+---
+
 ### 2026-05-08 — Issue #249: AppHost Mongo Clear Hardening
 
 **What was done:**


### PR DESCRIPTION
## Summary

The `blog-readme-sync.yml` workflow was pushing `README.md` updates directly to `main`, which is blocked by branch protection rules.

## Fix (Option C)

Changed the push target from `git push` (implicit HEAD → main) to `git push origin HEAD:dev`.

- The workflow still **triggers** on `push: branches: [main]` (reads `docs/blog/index.md` from main)
- The **README update** is now pushed to `dev`, flowing through the normal dev→main release cycle
- No new secrets or PAT bypass permissions required
- `permissions: contents: write` was already present

## Root Cause

```
remote: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - Required status check "Build Solution" is expected.
```

Closes #269

Working as Boromir (DevOps)