### PR TITLE
fix(ci): add pre-flight token validation and fix permissions block in squad-mark-released

### DIFF
--- a/.github/workflows/squad-mark-released.yml
+++ b/.github/workflows/squad-mark-released.yml
@@ -5,8 +5,12 @@ on:
     types: [published, released]
   workflow_dispatch: {}
 
+# NOTE: The default GITHUB_TOKEN cannot access GitHub Projects V2 via GraphQL.
+# This workflow requires a repository secret named GH_PROJECT_TOKEN set to a
+# classic Personal Access Token (PAT) with the `project` OAuth scope.
+# See: https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/using-the-api-to-manage-projects
 permissions:
-  repository-projects: write
+  contents: read
 
 env:
   PROJECT_ID:        PVT_kwHOA5k0b84BVFTy
@@ -21,8 +25,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Validate GH_PROJECT_TOKEN secret is configured
+        env:
+          TOKEN_CHECK: ${{ secrets.GH_PROJECT_TOKEN }}
+        run: |
+          if [ -z "$TOKEN_CHECK" ]; then
+            echo "::error::GH_PROJECT_TOKEN secret is not set."
+            echo "::error::Add a classic PAT with the 'project' OAuth scope as a repository secret named GH_PROJECT_TOKEN."
+            echo "::error::See: Settings → Secrets and variables → Actions → New repository secret"
+            exit 1
+          fi
+          echo "✅ GH_PROJECT_TOKEN secret is present."
+
       - name: Move Done → Released on project board
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GH_PROJECT_TOKEN }}
           script: |

--- a/.squad/agents/boromir/history.md
+++ b/.squad/agents/boromir/history.md
@@ -57,6 +57,26 @@
 **Key insight:** The `permissions: contents: write` block was already present. No new secrets or PAT bypass needed. One-line change.
 
 **Decision:** Captured in `.squad/decisions/inbox/boromir-269-readme-sync-target.md`.
+### 2026-05-08 — Issue #268: Fix squad-mark-released GraphQL Permission Error
+
+**Root cause:**
+The `permissions: repository-projects: write` block in the workflow was incorrect — it applies only to `GITHUB_TOKEN`, not to a custom PAT. The workflow uses `${{ secrets.GH_PROJECT_TOKEN }}`, but:
+
+1. If the secret is not set, `actions/github-script` receives an empty string and falls back to `GITHUB_TOKEN`
+2. `GITHUB_TOKEN` cannot access GitHub Projects V2 GraphQL API, producing `Resource not accessible by integration`
+3. Even if set, the PAT needs the `project` OAuth scope (classic PAT) for Projects V2 mutations
+
+**What was fixed:**
+
+1. Changed `permissions: repository-projects: write` → `permissions: contents: read` (correct for a workflow that only uses a custom PAT — no GITHUB_TOKEN escalation needed)
+2. Added a pre-flight validation step that explicitly checks `GH_PROJECT_TOKEN` is set, failing early with an actionable error message including setup instructions
+3. Downgraded `actions/github-script@v9` → `@v7` (stable LTS version)
+4. Added a top-of-file comment documenting the required PAT scope (`project`)
+
+**Key lesson:** For GitHub Projects V2 GraphQL, `GITHUB_TOKEN` is never sufficient regardless of `permissions` block settings. A classic PAT with `project` OAuth scope (or fine-grained PAT with Projects read/write) is required. Always add a pre-flight secret validation step so failures are immediately actionable.
+
+**Files changed:** `.github/workflows/squad-mark-released.yml`
+**Related decisions inbox:** `boromir-268-project-token.md`
 
 ---
 


### PR DESCRIPTION
## Summary

Working as Boromir (DevOps)

Closes #268

## Root Cause

The workflow was failing with `Resource not accessible by integration` because:

1. `permissions: repository-projects: write` only controls `GITHUB_TOKEN` — it has **no effect** on a custom PAT passed via `github-token:`
2. When `GH_PROJECT_TOKEN` secret is not set, `actions/github-script` receives an empty string and falls back to using `GITHUB_TOKEN`, which **cannot** access GitHub Projects V2 GraphQL regardless of the permissions block

## Changes

- **Fix permissions block**: `repository-projects: write` → `contents: read` (correct for workflows that rely exclusively on a custom PAT)
- **Add pre-flight validation step**: Checks `GH_PROJECT_TOKEN` is set; fails early with an actionable error message if missing (includes setup instructions and required scope)
- **Downgrade `actions/github-script@v9` → `@v7`** (stable LTS version)
- **Add top-of-file comment** documenting that a classic PAT with `project` OAuth scope is required

## Setup Required

To make this workflow functional, add `GH_PROJECT_TOKEN` as a repository secret:
1. Create a classic PAT at https://github.com/settings/tokens with `project` scope
2. Add it: Settings → Secrets and variables → Actions → New repository secret → `GH_PROJECT_TOKEN`