### PR TITLE
fix(headers): preserve original year when normalizing headers

### DIFF
--- a/.github/prompts/copyright-header-update-prompt.md
+++ b/.github/prompts/copyright-header-update-prompt.md
@@ -12,7 +12,7 @@ README files you write are appealing, informative, and easy to read.
 
 ## Plan
 
-This plan details how to review and update copyright headers in C# files, supporting both single-file and solution-wide operations. It ensures every file has the correct header, updating or inserting as needed.
+This plan details how to review and update copyright headers in C# files, supporting both single-file and solution-wide operations. It ensures every file has the correct header, preserves the original/earliest existing copyright year when normalizing an existing header, and collapses duplicate header blocks into one canonical header.
 
 **Header Example (as required):**
 
@@ -31,14 +31,14 @@ This plan details how to review and update copyright headers in C# files, suppor
 **Steps:**
 
 1. Identify all target `.cs` files, excluding those in `bin/` and `obj/` folders.
-2. For each file, check for an existing header at the very first line.
-3. If a header exists, update it with the correct format and metadata, ensuring every line starts with `//`.
-4. If no header exists, insert the new header at the very first line of the file, with every line C# line commented (start with `//`).
-5. Validate that the header is present, correctly formatted, and at the top of each file after editing.
+2. For each file, check for one or more existing header-like comment blocks at the very first line.
+3. If one or more header blocks exist, treat the entire leading header region as a single unit: preserve the original/earliest copyright year already present, normalize the metadata to the canonical format, and replace the region with exactly one header block.
+4. If no header exists, insert the new header at the very first line of the file, with every line C# line commented (start with `//`). When there is no existing year to preserve, use the file's creation year.
+5. Validate that exactly one canonical header is present, correctly formatted, and at the top of each file after editing.
 6. Output a summary of the files reviewed and the files changed.
 
 **Open Questions:**
 
 1. Should the header update logic support additional file types, or strictly `.cs` files?
-2. Is there a preferred way to determine the file's creation year if metadata is unavailable?
+2. If metadata is unavailable and no existing header year is present, is there a preferred fallback year source?
 3. Should the solution/project name be parsed from the `.sln`/`.csproj` files or hardcoded?

--- a/src/Domain/Abstractions/Result.cs
+++ b/src/Domain/Abstractions/Result.cs
@@ -1,5 +1,5 @@
 //=======================================================
-//Copyright (c) 2026. All rights reserved.
+//Copyright (c) 2025. All rights reserved.
 //File Name :     Result.cs
 //Company :       mpaulosky
 //Author :        Matthew Paulosky
@@ -7,17 +7,7 @@
 //Project Name :  Domain
 //=======================================================
 
-// =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     Result.cs
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : MyBlog
-// Project Name :  Domain
-// =======================================================
-
 using System.Diagnostics.CodeAnalysis;
-
 namespace MyBlog.Domain.Abstractions;
 
 public enum ResultErrorCode


### PR DESCRIPTION
## Summary
- preserve the original copyright year when normalizing an existing header block
- collapse duplicate top-of-file copyright headers into one canonical header
- document the year-preservation rule in the header update prompt

## Validation
- `dotnet build MyBlog.slnx --configuration Release --no-restore`
- `dotnet test tests/Architecture.Tests/Architecture.Tests.csproj --configuration Release --no-build`
- `dotnet test tests/Domain.Tests/Domain.Tests.csproj --configuration Release --no-build`
- `dotnet test tests/Web.Tests/Web.Tests.csproj --configuration Release --no-build`
- `dotnet test tests/Web.Tests.Bunit/Web.Tests.Bunit.csproj --configuration Release --no-build`
- `dotnet test tests/Web.Tests.Integration/Web.Tests.Integration.csproj --configuration Release --no-build`
- `dotnet test tests/AppHost.Tests/AppHost.Tests.csproj --configuration Release --no-build`

Closes #284
