### PR TITLE
fix(ui): redirect to /blog when post not found in Edit page (#307)

### DIFF
--- a/src/Web/Features/BlogPosts/Edit/Edit.razor
+++ b/src/Web/Features/BlogPosts/Edit/Edit.razor
@@ -86,7 +86,8 @@ else if (_model is not null)
             }
             else
             {
-                _model = null;
+                Navigation.NavigateTo("/blog");
+                return;
             }
         }
         else

--- a/tests/Web.Tests.Bunit/Features/EditAclTests.cs
+++ b/tests/Web.Tests.Bunit/Features/EditAclTests.cs
@@ -32,6 +32,29 @@ public class EditAclTests : BunitContext
 	}
 
 	[Fact]
+	public void EditRedirectsToBlogWhenPostNotFound()
+	{
+		// Arrange
+		var sender = Substitute.For<ISender>();
+		var postId = Guid.NewGuid();
+
+		sender.Send(Arg.Any<GetBlogPostByIdQuery>(), Arg.Any<CancellationToken>())
+				.Returns(Task.FromResult(Result.Ok<BlogPostDto?>(null)));
+
+		Services.AddSingleton(sender);
+
+		var navigation = Services.GetRequiredService<NavigationManager>();
+
+		// Act
+		RenderWithUser<Edit>(
+				CreatePrincipalWithSub("auth0|some-user", ["Author"]),
+				parameters => parameters.Add(p => p.Id, postId));
+
+		// Assert
+		navigation.Uri.Should().EndWith("/blog");
+	}
+
+	[Fact]
 	public void EditRedirectsToBlogWhenAuthorIsNotPostOwner()
 	{
 		// Arrange


### PR DESCRIPTION
## Summary

Fixes a bug where `Edit.razor` would show an infinite 'Loading...' spinner when the requested blog post does not exist.

## Root Cause

`GetBlogPostByIdQuery` returns `Result.Ok<BlogPostDto?>(null)` when a post is not found (success with null value). The `OnParametersSetAsync` handler set `_model = null` in this path and left `_error` as null. The template's `@if (_model is null && _error is null)` then rendered 'Loading...' indefinitely.

This was identified in the Copilot review of PR #304 but missed before merge.

## Changes

- `Edit.razor`: null-value branch now calls `Navigation.NavigateTo("/blog")` and returns, consistent with the non-owner/non-admin redirect
- `EditAclTests.cs`: added `EditRedirectsToBlogWhenPostNotFound` bUnit test covering `Result.Ok(null)` path

## Tests

- 89/89 bUnit tests pass ✅
- 154/154 unit tests pass ✅

Closes #307