### PR TITLE
fix(ui): refresh Edit page loading state on post-ID changes

### DIFF
--- a/.squad/agents/legolas/history.md
+++ b/.squad/agents/legolas/history.md
@@ -881,3 +881,54 @@ Then each variant only declares its colour-specific overrides. This is idiomatic
 - `NavigationManager.NavigateTo` in bUnit changes `.Uri` but does NOT unmount the component — so loading states must be explicitly cleared, not relied on navigation to resolve them
 
 **Filed:** `.squad/decisions/inbox/legolas-issue307-ui.md`
+
+---
+
+## 2026-05-11 — PR #310 Unblock: Stale-State Fix on Route Parameter Changes
+
+### Task
+
+Resolve reviewer CHANGES_REQUESTED blockers on PR #310 (branch `squad/307-fix-edit-null-post-redirect`):
+
+1. Merge conflict with dev (caused by prior rebase/squash of PR #309)
+2. Stale-state bug: `_model`, `_error`, `_concurrencyError` not reset before each fetch cycle
+3. Missing regression tests for the stale-content paths
+
+### What Was Done
+
+**Merge conflict resolution:** rebased branch onto `origin/dev` using `git rebase`. Commits `8c7b15f` and `8076fc6` were already upstream (merged as `5e176dc` via PR #309); git skipped them cleanly. Only the new commit `e18b851` was replayed as `37f68a2`.
+
+**Stale-state fix in `Edit.razor`:** added three reset lines at the top of `OnParametersSetAsync` before `_isLoading = true`:
+
+```csharp
+_model = null;
+_error = null;
+_concurrencyError = false;
+```
+
+This guarantees all display state is clean before every fetch cycle, not just `_isLoading`.
+
+**New bUnit regression tests (EditAclTests.cs):**
+
+- `EditClearsStaleContentOnErrorAfterSuccessfulLoad` — first fetch succeeds (post A loaded), second fetch fails with error → old form content gone, error shown
+- `EditClearsStaleContentOnNullAfterSuccessfulLoad` — first fetch succeeds, second returns null (not found) → redirect to /blog, no stale form content
+
+### Test Counts
+
+- Before: 90 bUnit tests
+- After: 92 bUnit tests (all pass)
+- Full Gate 4 suite: Architecture (16), Domain (42), Web (154), bUnit (92) — all green
+
+### Learnings
+
+**Stale-state pattern in Blazor route pages:**
+
+- Resetting ONLY `_isLoading` is insufficient — ALL display state (`_model`, `_error`, `_concurrencyError`) must be cleared at the top of `OnParametersSetAsync` before the async operation
+- If only `_isLoading` is reset, previous successful load data remains and the UI renders stale content alongside new error messages during route parameter changes
+
+**Rebase vs merge for de-duplicating squash-merged commits:**
+
+- When upstream squash-merges commits from a branch, a later rebase will skip those commits automatically (`dropping ... patch contents already upstream`) — no manual conflict resolution needed for the already-merged commits
+- Use `git rebase --skip` when the first conflict is a commit already upstream
+
+**Filed:** `.squad/decisions/inbox/legolas-pr310-unblock.md`

--- a/src/Web/Features/BlogPosts/Edit/Edit.razor
+++ b/src/Web/Features/BlogPosts/Edit/Edit.razor
@@ -66,6 +66,7 @@ else if (_model is not null)
 
     protected override async Task OnParametersSetAsync()
     {
+        _isLoading = true;
         try
         {
             var result = await Sender.Send(new GetBlogPostByIdQuery(Id));

--- a/src/Web/Features/BlogPosts/Edit/Edit.razor
+++ b/src/Web/Features/BlogPosts/Edit/Edit.razor
@@ -66,6 +66,9 @@ else if (_model is not null)
 
     protected override async Task OnParametersSetAsync()
     {
+        _model = null;
+        _error = null;
+        _concurrencyError = false;
         _isLoading = true;
         try
         {

--- a/tests/Web.Tests.Bunit/Features/EditAclTests.cs
+++ b/tests/Web.Tests.Bunit/Features/EditAclTests.cs
@@ -166,6 +166,42 @@ public class EditAclTests : BunitContext
 		cut.Markup.Should().Contain("Edit Post");
 	}
 
+	[Fact]
+	public void EditShowsNewPostContentAfterParameterChange()
+	{
+		// Arrange
+		var sender = Substitute.For<ISender>();
+		var firstPostId = Guid.NewGuid();
+		var secondPostId = Guid.NewGuid();
+		const string OwnerSub = "auth0|owner-user";
+
+		var firstPost = new BlogPostDto(firstPostId, "First Post Title", "First Content", OwnerSub, "Owner", string.Empty, [], DateTime.UtcNow, null, false);
+		var secondPost = new BlogPostDto(secondPostId, "Second Post Title", "Second Content", OwnerSub, "Owner", string.Empty, [], DateTime.UtcNow, null, false);
+
+		sender.Send(Arg.Is<GetBlogPostByIdQuery>(q => q.Id == firstPostId), Arg.Any<CancellationToken>())
+				.Returns(Task.FromResult(Result.Ok<BlogPostDto?>(firstPost)));
+		sender.Send(Arg.Is<GetBlogPostByIdQuery>(q => q.Id == secondPostId), Arg.Any<CancellationToken>())
+				.Returns(Task.FromResult(Result.Ok<BlogPostDto?>(secondPost)));
+
+		Services.AddSingleton(sender);
+
+		// Act — first render
+		var cut = RenderWithUser<Edit>(
+				CreatePrincipalWithSub(OwnerSub, ["Author"]),
+				parameters => parameters.Add(p => p.Id, firstPostId));
+
+		cut.Markup.Should().Contain("First Post Title");
+		cut.Markup.Should().NotContain("Loading...");
+
+		// Act — change parameters to a different post
+		cut.Render(parameters => parameters.Add(p => p.Id, secondPostId));
+
+		// Assert — second post content shown, loading indicator gone, no stale first-post content
+		cut.Markup.Should().Contain("Second Post Title");
+		cut.Markup.Should().NotContain("First Post Title");
+		cut.Markup.Should().NotContain("Loading...");
+	}
+
 	private IRenderedComponent<TComponent> RenderWithUser<TComponent>(
 			ClaimsPrincipal principal,
 			Action<ComponentParameterCollectionBuilder<TComponent>>? configure = null)

--- a/tests/Web.Tests.Bunit/Features/EditAclTests.cs
+++ b/tests/Web.Tests.Bunit/Features/EditAclTests.cs
@@ -202,6 +202,75 @@ public class EditAclTests : BunitContext
 		cut.Markup.Should().NotContain("Loading...");
 	}
 
+	[Fact]
+	public void EditClearsStaleContentOnErrorAfterSuccessfulLoad()
+	{
+		// Arrange: first load succeeds, second load fails
+		var sender = Substitute.For<ISender>();
+		var firstPostId = Guid.NewGuid();
+		var secondPostId = Guid.NewGuid();
+		const string OwnerSub = "auth0|owner-user";
+
+		var firstPost = new BlogPostDto(firstPostId, "First Post Title", "First Content", OwnerSub, "Owner", string.Empty, [], DateTime.UtcNow, null, false);
+
+		sender.Send(Arg.Is<GetBlogPostByIdQuery>(q => q.Id == firstPostId), Arg.Any<CancellationToken>())
+				.Returns(Task.FromResult(Result.Ok<BlogPostDto?>(firstPost)));
+		sender.Send(Arg.Is<GetBlogPostByIdQuery>(q => q.Id == secondPostId), Arg.Any<CancellationToken>())
+				.Returns(Task.FromResult(Result.Fail<BlogPostDto?>("Post could not be loaded.")));
+
+		Services.AddSingleton(sender);
+
+		// Act — first render succeeds
+		var cut = RenderWithUser<Edit>(
+				CreatePrincipalWithSub(OwnerSub, ["Author"]),
+				parameters => parameters.Add(p => p.Id, firstPostId));
+
+		cut.Markup.Should().Contain("First Post Title");
+
+		// Act — second render returns error
+		cut.Render(parameters => parameters.Add(p => p.Id, secondPostId));
+
+		// Assert — stale form content gone, error shown
+		cut.Markup.Should().NotContain("First Post Title");
+		cut.Markup.Should().NotContain("Loading...");
+		cut.Markup.Should().Contain("Post could not be loaded.");
+	}
+
+	[Fact]
+	public void EditClearsStaleContentOnNullAfterSuccessfulLoad()
+	{
+		// Arrange: first load succeeds, second returns null (post not found)
+		var sender = Substitute.For<ISender>();
+		var firstPostId = Guid.NewGuid();
+		var secondPostId = Guid.NewGuid();
+		const string OwnerSub = "auth0|owner-user";
+
+		var firstPost = new BlogPostDto(firstPostId, "First Post Title", "First Content", OwnerSub, "Owner", string.Empty, [], DateTime.UtcNow, null, false);
+
+		sender.Send(Arg.Is<GetBlogPostByIdQuery>(q => q.Id == firstPostId), Arg.Any<CancellationToken>())
+				.Returns(Task.FromResult(Result.Ok<BlogPostDto?>(firstPost)));
+		sender.Send(Arg.Is<GetBlogPostByIdQuery>(q => q.Id == secondPostId), Arg.Any<CancellationToken>())
+				.Returns(Task.FromResult(Result.Ok<BlogPostDto?>(null)));
+
+		Services.AddSingleton(sender);
+		var navigation = Services.GetRequiredService<NavigationManager>();
+
+		// Act — first render succeeds
+		var cut = RenderWithUser<Edit>(
+				CreatePrincipalWithSub(OwnerSub, ["Author"]),
+				parameters => parameters.Add(p => p.Id, firstPostId));
+
+		cut.Markup.Should().Contain("First Post Title");
+
+		// Act — second render: post not found → should redirect
+		cut.Render(parameters => parameters.Add(p => p.Id, secondPostId));
+
+		// Assert — redirected and no stale form content visible
+		navigation.Uri.Should().EndWith("/blog");
+		cut.Markup.Should().NotContain("First Post Title");
+		cut.Markup.Should().NotContain("Loading...");
+	}
+
 	private IRenderedComponent<TComponent> RenderWithUser<TComponent>(
 			ClaimsPrincipal principal,
 			Action<ComponentParameterCollectionBuilder<TComponent>>? configure = null)


### PR DESCRIPTION
Closes #307\n\nWorking as ralph (Meta).\n\n## Summary\n- reset the Edit page loading flag whenever route parameters change\n- prevent stale previous-post content from persisting across post-ID navigation\n- add bUnit regression coverage for switching IDs in the same component instance