### PR TITLE
[Sprint 19] UX parity hardening for Create/Edit markdown editor (#326)

### DIFF
--- a/src/Web/Features/BlogPosts/Create/Create.razor
+++ b/src/Web/Features/BlogPosts/Create/Create.razor
@@ -30,10 +30,8 @@
 			<InputText class="form-input" @bind-Value="_model.Title" />
 		</div>
 		<div class="form-group">
-			<label class="form-label">Markdown</label>
-			<TextEditor Content="@_model.Content"
-						ContentChanged="@(v => _model.Content = v)"
-						AlignmentOptionsEnabled="false" />
+			<label class="form-label">Content <span class="text-xs text-gray-500 dark:text-gray-400 font-normal">(Markdown)</span></label>
+			<TextEditor @bind-Content="_model.Content" AlignmentOptionsEnabled="false" />
 		</div>
 		<div class="form-group">
 			<label class="form-label flex items-center gap-2">

--- a/tests/Web.Tests.Bunit/Components/RazorSmokeTests.cs
+++ b/tests/Web.Tests.Bunit/Components/RazorSmokeTests.cs
@@ -338,6 +338,20 @@ public class RazorSmokeTests : BunitContext
 	}
 
 	[Fact]
+	public void CreatePostShowsMarkdownContentLabel()
+	{
+		// Arrange
+		Services.AddSingleton(Substitute.For<ISender>());
+
+		// Act
+		var cut = RenderWithUser<Create>(CreatePrincipal("Alice", ["Author"]));
+
+		// Assert — label text and Markdown hint must be present (UX parity with Edit page)
+		cut.Markup.Should().Contain("Content");
+		cut.Markup.Should().Contain("(Markdown)");
+	}
+
+	[Fact]
 	public void CreatePostUsesPrimaryAndSecondaryButtonVariants()
 	{
 		// Arrange
@@ -423,6 +437,27 @@ public class RazorSmokeTests : BunitContext
 		cut.Markup.Should().Contain("Edit Post");
 		cut.Markup.Should().Contain("Existing title");
 		cut.FindComponent<TextEditor>().Instance.Content.Should().Be("Existing content");
+	}
+
+	[Fact]
+	public void EditPostShowsMarkdownContentLabel()
+	{
+		// Arrange
+		var sender = Substitute.For<ISender>();
+		var postId = Guid.NewGuid();
+		var post = new BlogPostDto(postId, "Test Post", "Some content", string.Empty, "Alice", string.Empty, [], DateTime.UtcNow, null, false);
+
+		sender.Send(Arg.Any<GetBlogPostByIdQuery>(), Arg.Any<CancellationToken>())
+				.Returns(Task.FromResult(Result.Ok<BlogPostDto?>(post)));
+
+		Services.AddSingleton(sender);
+
+		// Act
+		var cut = RenderWithUser<Edit>(CreatePrincipal("Alice", ["Author"]), parameters => parameters.Add(p => p.Id, postId));
+
+		// Assert — label text and Markdown hint must be present (UX parity with Create page)
+		cut.Markup.Should().Contain("Content");
+		cut.Markup.Should().Contain("(Markdown)");
 	}
 
 	[Fact]


### PR DESCRIPTION
## Summary

Closes #326

Working as Legolas (Frontend / Blazor)

## Parity Gaps Found and Fixed

| Gap | Create (before) | Edit | Fix Applied |
|-----|----------------|------|-------------|
| **Label text** | `Markdown` (bare) | `Content (Markdown)` with hint | Updated Create label to match Edit pattern |
| **Binding style** | Explicit `Content=` + `ContentChanged=` | `@bind-Content` (idiomatic) | Switched Create to `@bind-Content` |
| **Editor height/border/padding** | ✅ already consistent | ✅ already consistent | No change needed |
| **Blank flash guard** | n/a (no async pre-load) | ✅ `_isLoading` guard already present | No change needed |

## Files Changed

- `src/Web/Features/BlogPosts/Create/Create.razor` — label and binding parity
- `tests/Web.Tests.Bunit/Components/RazorSmokeTests.cs` — two new parity tests

## Test Results

| Suite | Result |
|-------|--------|
| Architecture.Tests | ✅ 16/16 |
| Domain.Tests | ✅ 42/42 |
| Web.Tests | ✅ 158/158 |
| Web.Tests.Bunit | ✅ 94/94 |
| Integration.Tests | ✅ passed |

All 6 pre-push gates green.

## Dependencies
- Builds on top of #323 + #324 + #325 (branch `squad/325-edit-flow-markdown-slice`)