### PR TITLE
Upgrade Aspire and markdown package versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,11 +5,11 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Aspire Packages -->
-    <PackageVersion Include="Aspire.Hosting.MongoDB" Version="13.3.1" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.3.1" />
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.3.1" />
-    <PackageVersion Include="Aspire.MongoDB.Driver" Version="13.3.1" />
-    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.3.1" />
+    <PackageVersion Include="Aspire.Hosting.MongoDB" Version="13.3.2" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.3.2" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.3.2" />
+    <PackageVersion Include="Aspire.MongoDB.Driver" Version="13.3.2" />
+    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.3.2" />
     <!-- Auth0 Packages -->
     <PackageVersion Include="Auth0.AspNetCore.Authentication" Version="1.7.0" />
     <PackageVersion Include="Auth0.ManagementApi" Version="8.3.0" />
@@ -22,8 +22,8 @@
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <!-- Markdown editor -->
-    <PackageVersion Include="Markdig" Version="0.44.0" />
-    <PackageVersion Include="PSC.Blazor.Components.MarkdownEditor" Version="10.0.7" />
+    <PackageVersion Include="Markdig" Version="1.2.0" />
+    <PackageVersion Include="PSC.Blazor.Components.MarkdownEditor" Version="10.0.8" />
     <!-- CQRS/Mediator -->
     <PackageVersion Include="MediatR" Version="14.1.0" />
     <!-- Database -->

--- a/src/AppHost/AppHost.cs
+++ b/src/AppHost/AppHost.cs
@@ -11,7 +11,9 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 var mongo = builder.AddMongoDB("mongodb")
 	.WithDataVolume("mongo-data").WithMongoExpress();
+
 var mongoDb = mongo.AddDatabase("myblog");
+
 var redis = builder.AddRedis("redis");
 
 mongo.WithMongoDbDevCommands("myblog");

--- a/src/AppHost/AppHost.csproj
+++ b/src/AppHost/AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.3.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.3.2">
 
   <ItemGroup>
     <ProjectReference Include="..\ServiceDefaults\ServiceDefaults.csproj" IsAspireProjectResource="false" />


### PR DESCRIPTION
Refs #335

## Summary

Upgrade Aspire hosting/testing/driver/cache packages to 13.3.2, align `Aspire.AppHost.Sdk` to 13.3.2, and bump markdown editor stack package versions.

Closes #335

## Type of Change

- [x] ⚙️ Infra/CI (GitHub Actions, Aspire, NuGet, deployment)
- [x] ♻️ Refactor (no behavior change, code cleanup/restructure)

## Domain Affected

- [x] 🏗️ Architecture / domain logic / CQRS → **Aragorn required**
- [x] ⚙️ CI/CD / GitHub Actions / NuGet / Aspire AppHost → **Boromir required**

## Self-Review Checklist

### Code Quality

- [x] I ran `dotnet build MyBlog.slnx --configuration Release` — 0 errors, 0 warnings
- [x] I ran `dotnet test MyBlog.slnx --configuration Release --no-build` — all pass
- [x] No TODO/FIXME left unless tracked in a follow-up issue (link it)
- [x] No secrets, API keys, or credentials committed

### Merge Readiness

- [x] Branch is up to date with `main` (no merge conflicts)
- [x] CI checks are green (do not request review while checks are pending/failing)
- [x] PR description is complete — reviewers should not have to ask what this does