### PR TITLE
feat(#339): Categories CRUD UI, nav link, and blog post category assignment

### DIFF
--- a/.squad/agents/aragorn/history.md
+++ b/.squad/agents/aragorn/history.md
@@ -1,3 +1,37 @@
+## 2026-06-04 — Issue #339: Triage Categories CRUD Feature for Sprint 19
+
+**Triage Summary:** Performed lead triage hygiene on Categories CRUD issue (squad inbox cleanup).
+
+**Actions Completed:**
+
+- ✅ Updated title from `[Feature]` → `[Sprint 19] Build Categories CRUD and blog post category assignment` (sprint prefix convention)
+
+- ✅ Removed base `squad` label (inbox-only, triage complete)
+- ✅ Kept `squad:sam` + `squad:legolas`, added `squad:gimli` (tests required per acceptance criteria)
+- ✅ Left kickoff comment indicating Sam (domain), Legolas (UI), Gimli (testing) own delivery
+- ✅ Verified milestone is set to Sprint 19
+
+**Route Assignments:**
+
+| Member | Domain | Responsibility |
+| --- | --- | --- |
+| Sam | Backend | Category entity, repository, CRUD handlers, validation |
+| Legolas | UI | Categories management page, category dropdown, author read-only field |
+| Gimli | Testing | Unit, integration, architecture tests; seed data validation |
+
+**Key Design Notes:**
+
+- Category.Name must be unique; Category.Description required
+- Blog post category is required; default category migrates existing posts
+- Category deletion blocked if posts reference it (referential integrity)
+- AppHost seed data must include default category
+
+**Blockers:** None identified. Issue is well-specified with clear acceptance criteria.
+
+**Decision:** Routed to three-member team (Sam + Legolas + Gimli) due to cross-domain complexity: domain model, Blazor UI integration, and comprehensive test coverage required. This is standard vertical-slice decomposition.
+
+---
+
 ## 2026-06-03 — Issue #320: Sprint 19 Markdown Editor Completion & Verification
 
 Closed issue #320 as Aragorn (Lead/Architect) after verifying all Sprint 19 implementation slices

--- a/.squad/agents/boromir/history.md
+++ b/.squad/agents/boromir/history.md
@@ -48,6 +48,25 @@
 
 ## Learnings
 
+### 2026-05-14 — Issue #337: Archive Self-Authored PR Gate Skill
+
+**What was done:** Created `.squad/skills/self-authored-pr-gate/SKILL.md` documenting the workflow pattern discovered during PR #336 (self-authored Aspire/markdown upgrade) and updated `.squad/agents/aragorn/history.md` with Aragorn's gate review findings.
+
+**Context:** PR #336 had Boromir as author and Aragorn as lead reviewer. GitHub returns `422: Can not approve your own pull request` when the reviewer account is also the PR author, preventing the standard lead-gate approve verdict. Instead, the gate relied on:
+
+1. CI fully green (build, tests, security, coverage)
+2. Copilot automated review (no unresolved bugs/security findings)
+3. Codecov bot (no material regression)
+4. Domain-specialist review perspective documented
+
+**Key lesson:** For self-authored PRs where lead review is locked out by GitHub's constraint, explicitly document the alternative path (CI + Copilot + Codecov + specialist input) so future gate reviews aren't confused by the missing approval. The skill captures this as a standing process rule.
+
+**Files:** Committed `.squad/skills/self-authored-pr-gate/SKILL.md` and updated `.squad/agents/aragorn/history.md`. Created issue #337 and PR #338.
+
+**Branch cleanup:** Verified no orphaned merged branches remain locally or remotely after Sprint 15 merges. Pre-push hook gates all passed (markdown lint, formatting, release build, unit/architecture/integration tests).
+
+---
+
 ### 2026-05-11 — Issue #289: dotnet format gate added to pre-push hook
 
 **What was done:** Added Gate 2 (`dotnet format --verify-no-changes`) to the pre-push hook between Gate 1 (untracked files) and the former Gate 2 (now Gate 3 — Release build). Gates 2–4 (build, unit tests, integration) renumbered to 3–5.
@@ -1453,6 +1472,7 @@ the board only had Todo (`f75ad846`), In Progress (`47fc9ee4`), Done (`98236657`
   `singleSelectOptions`. Pass all existing option IDs to preserve them; omit `id` for new options.
 - **Cherry-pick workflow for PR fixes:** stash → checkout origin branch → cherry-pick fix commit →
   rename to `squad/{issue}-{slug}` → push. Cleaner than diverging 8 commits onto the remote.
+
 ### PR #306 Post-Triage Review: Project Board Automation Token/Option ID Sync (2026-05-11)
 
 **Context:** Aragorn triaged PR #306 with recommendation to route to Boromir for DevOps review. PR bundles three concerns: merge conflict resolution, CI/infra fixes (token + option IDs), and a Blazor redirect fix.
@@ -1477,4 +1497,3 @@ the board only had Todo (`f75ad846`), In Progress (`47fc9ee4`), Done (`98236657`
 - The "secondary review" layer (Copilot automated review) is effective at flagging missing tests and logic errors, but does not substitute for domain reviewer verdict. Always route to domain specialist after Copilot.
 
 **Related Decision:** `.squad/decisions/inbox/boromir-pr306-review.md` (assessment + routing recommendation)
-

--- a/.squad/agents/gimli/history.md
+++ b/.squad/agents/gimli/history.md
@@ -1056,6 +1056,7 @@ build + all test suites before opening PR.
 ### Context
 
 Working directory modifications vs. git HEAD:
+
 - `global.json`: SDK reverted to `10.0.203`, `allowPrerelease: false`, `rollForward: latestMinor`
 - `Directory.Build.props`: removed `NoWarn CS1591/IDE0xxx` suppression; re-enabled `EnforceCodeStyleInBuild=true`
 - All `.csproj` files: `TargetFramework` changed from `net11.0` → `net10.0`
@@ -1112,3 +1113,62 @@ well above 89% (previous sessions showed 91.64% with a similar test set).
 3. **Test count growth since last recorded run**: +7 Web.Tests (165 vs 158), +2 Web.Tests.Bunit (94 vs 92). New coverage added in recent sprints.
 4. **AppHost.Tests takes ~2.5 minutes** due to Testcontainers Docker startup. Schedule accordingly in local gates.
 5. **CS1591 in committed net11.0 branch was suppressed globally** via `Directory.Build.props`. The net10.0 working directory removes that suppression. The code compiles cleanly regardless, meaning all public types already carry XML doc comments.
+
+---
+
+## Session: Issue #339 — Category CRUD Tests (2026)
+
+### Task
+
+Implement and extend tests for Issue #339 (Category CRUD feature) across unit, integration, and handler levels, following behavior-first TDD principles.
+
+### Work Done
+
+**Fixed pre-existing build break from Sam's BlogPostDto schema change:**
+
+Sam added `Guid? CategoryId` as the 11th positional parameter to `BlogPostDto`. Fixed 7 test files by appending `, null` to old 10-parameter constructor calls:
+
+- `tests/Web.Tests/Handlers/GetBlogPostsHandlerTests.cs`
+- `tests/Web.Tests/Handlers/EditBlogPostHandlerTests.cs`
+- `tests/Web.Tests/Infrastructure/Caching/BlogPostCacheServiceTests.cs`
+- `tests/Web.Tests.Bunit/Components/RazorSmokeTests.cs`
+- `tests/Web.Tests.Bunit/Features/RichTextEditorTests.cs`
+- `tests/Web.Tests.Bunit/Features/EditAclTests.cs`
+- `tests/Web.Tests.Integration/Caching/BlogPostCacheServiceTests.cs`
+
+**New test files (all passing):**
+
+- `tests/Domain.Tests/Entities/CategoryTests.cs` — 12 unit tests (Create/Update trim, validation)
+- `tests/Domain.Tests/Entities/BlogPostCategoryTests.cs` — 9 unit tests (AssignCategory, RemoveCategory, author immutability)
+- `tests/Web.Tests/Features/Categories/Commands/CreateCategoryCommandValidatorTests.cs` — 9 passing
+- `tests/Web.Tests/Features/Categories/Commands/DeleteCategoryCommandValidatorTests.cs` — 3 passing
+- `tests/Web.Tests/Features/Categories/Commands/UpdateCategoryCommandValidatorTests.cs` — 6 passing (uses `EditCategoryCommandValidator`)
+- `tests/Web.Tests/Features/Categories/Handlers/GetCategoriesHandlerTests.cs` — 5 passing
+- `tests/Web.Tests/Features/Categories/Handlers/GetCategoryByIdHandlerTests.cs` — 5 passing
+- `tests/Web.Tests/Features/Categories/Handlers/CreateCategoryHandlerTests.cs` — 4 passing
+- `tests/Web.Tests/Features/Categories/Handlers/DeleteCategoryHandlerTests.cs` — 5 passing (includes "cannot delete if in use" AC)
+- `tests/Web.Tests/Features/Categories/Handlers/EditCategoryHandlerTests.cs` — 5 passing
+- `tests/Web.Tests.Integration/Infrastructure/CategoryIntegrationCollection.cs` — collection definition
+- `tests/Web.Tests.Integration/Categories/MongoDbCategoryRepositoryTests.cs` — 12 integration tests
+- `tests/Web.Tests.Integration/Categories/MongoDbBlogPostCategoryTests.cs` — 4 integration tests
+
+### Test Count (post-session)
+
+| Suite               | Passed | Notes                                  |
+|---------------------|--------|----------------------------------------|
+| Domain.Tests        | 67     | ✅ +21 new Category/BlogPost tests     |
+| Web.Tests           | 210    | ✅ +45 new Category handler/validator  |
+| Web.Tests.Bunit     | 101    | ✅ (8 transient failures on first run cleared) |
+| Web.Tests.Integration | TBD  | Builds ✅; requires Docker/Testcontainers |
+
+### Key Learnings
+
+1. **`UpdateCategoryCommandValidatorTests.cs` tests `EditCategoryCommandValidator`** — Sam named the command `EditCategoryCommand` but the test file was staged as `UpdateCategoryCommandValidatorTests`. File kept for continuity; class named accordingly.
+
+2. **`DeleteCategoryHandler` takes two repository dependencies**: `ICategoryRepository` + `IBlogPostRepository` — verify both are mocked in unit tests.
+
+3. **Staged tests pattern** — When production code hasn't landed yet, use `[Fact(Skip = "Staged #NNN: reason")]` with empty bodies. Replace with real tests as soon as code lands; don't let stubs rot.
+
+4. **`ExistsByNameExcludingAsync`** — the correct update-uniqueness guard; used in `EditCategoryHandler` to allow a category to keep its own name unchanged while still preventing collisions with other categories.
+
+5. **`IBlogPostRepository.ExistsByCategoryAsync`** is the guard for "cannot delete category in use" — always assert that `DeleteAsync` is NOT called when this returns true.

--- a/.squad/agents/legolas/history.md
+++ b/.squad/agents/legolas/history.md
@@ -932,3 +932,44 @@ This guarantees all display state is clean before every fetch cycle, not just `_
 - Use `git rebase --skip` when the first conflict is a commit already upstream
 
 **Filed:** `.squad/decisions/inbox/legolas-pr310-unblock.md`
+
+---
+
+## 2025-07-XX — Issue #339 Category Frontend (branch `squad/339-category-backend`)
+
+### What I Implemented
+
+- **Categories CRUD admin page** at `/admin/categories` (`src/Web/Features/Categories/List/Index.razor`) — inline create, inline edit, inline delete with confirmation modal, Admin-only
+- **Categories nav link** in `NavMenu.razor` (Admin-only, desktop + mobile)
+- **Blog post Create form**: category dropdown with null-safe loading; `GetCategoriesQuery` result checked with `is { Success: true }` pattern
+- **Blog post Edit form**: category dropdown pre-populated from `BlogPostDto.CategoryId`; author name shown read-only; parallel task loading via `Task.WhenAll`
+
+### Key Patterns Learned
+
+**NSubstitute + MediatR generic ISender:**
+
+When tests use `Substitute.For<ISender>()` without configuring `GetCategoriesQuery`, `await Sender.Send(new GetCategoriesQuery())` returns `null` (NSubstitute default for generic method returning `Task<ReferenceType>` is `Task.FromResult(null)`).
+
+Always guard with: `if (categoriesResult is { Success: true }) _categories = categoriesResult.Value!;`
+
+**[Required] on Guid? in EditForm blocks submission:**
+
+`DataAnnotationsValidator` validates the full model — `[Required] Guid? CategoryId` causes `OnValidSubmit` to never fire when CategoryId is null, even if the dropdown doesn't render. Replace with manual guard in `HandleSubmit`:
+
+```csharp
+if (_categories.Any() && _model.CategoryId is null)
+{
+    _error = "Please select a category.";
+    return;
+}
+```
+
+**Cross-feature namespace reference (BlogPosts → Categories):**
+
+`Create.razor` and `Edit.razor` now `@using MyBlog.Web.Features.Categories.List` to access `GetCategoriesQuery`. The architecture test `Features_Should_Not_Reference_Each_Other` only checks BlogPosts→UserManagement; this cross-reference is intentional and documented.
+
+**Build vs test --no-build:**
+
+Always rebuild (`dotnet build tests/Web.Tests.Bunit`) after changing razor files before running `--no-build` tests. Razor compilation is part of the build step.
+
+**Filed:** `.squad/decisions/inbox/legolas-issue339-frontend.md`

--- a/.squad/agents/sam/history.md
+++ b/.squad/agents/sam/history.md
@@ -1,5 +1,64 @@
 # Sam's Work History
 
+## 2026-05-15 — Issue #339: Category Backend (branch squad/339-category-backend)
+
+### Task
+
+Implement the full backend for the Category feature (domain, data, CQRS handlers, seed data).
+
+### Changes Made
+
+**Domain:**
+
+- `Category.cs` entity — Name/Description, `Create` + `Update` with whitespace trimming
+- `ICategoryRepository.cs` — GetById, GetAll, ExistsByName, ExistsByNameExcluding, Add, Update, Delete
+- `IBlogPostRepository.cs` — added `ExistsByCategoryAsync` for safe-delete guard
+- `BlogPost.cs` — added `CategoryId (Guid?)`, `AssignCategory`, `RemoveCategory`
+
+**Web/Data:**
+
+- `MongoDbCategoryRepository.cs` — EF Core LINQ over `BlogDbContext.Categories`
+- `BlogDbContext.cs` — Categories DbSet + unique index on Name; CategoryId element on BlogPost
+- `BlogPostDto.cs` / `BlogPostMappings.cs` — include `CategoryId`
+- `CategoryDto.cs` / `CategoryMappings.cs`
+
+**Features/Categories:**
+
+- List / GetById / Create / Edit / Delete — all following CQRS + Result<T> + FluentValidation pattern
+- `DeleteCategoryHandler` checks `ExistsByCategoryAsync` before deleting; returns `ResultErrorCode.Conflict`
+- `CreateCategoryHandler` / `EditCategoryHandler` check name uniqueness; return `ResultErrorCode.Conflict`
+
+**Program.cs:** Registered `MongoDbCategoryRepository` / `ICategoryRepository`
+
+**AppHost seed:** Seeds `General` category (stable Guid `00000000-...-0001`) and assigns all seeded posts
+
+**Tests:** Updated `BlogPostDto` construction in all test fixtures to pass `null` for new `CategoryId` param
+
+### Build Validation
+
+- ✅ `dotnet build MyBlog.slnx --configuration Release` — 0 errors
+- ✅ `dotnet format --verify-no-changes` — clean
+- ✅ `Architecture.Tests` — 16/16 passed
+- ✅ `Domain.Tests` — 67/67 passed (includes CategoryTests + BlogPostCategoryTests)
+- ✅ `Web.Tests` — 187/187 passed (includes all Category handler/validator tests)
+- ✅ `Web.Tests.Bunit` — 101/101 passed
+
+### Decision filed
+
+`.squad/decisions/inbox/sam-issue339-backend.md`
+
+## Learnings
+
+### Pre-existing untracked test files stay out of the commit if not relevant to scope
+
+Some test and skill files in the working tree (aragorn/boromir history files, a gh-pr-comments skill) had lint violations and were pre-staged when `git add -A` was run. The commit hook blocked the commit. Pattern: always `git status` before `git add -A` and selectively stage only backend-scope files, or unstage non-scope files after `git add -A`.
+
+### Nullable CategoryId is the right additive pattern for optional FK on existing entities
+
+Adding `Guid? CategoryId` with explicit `AssignCategory`/`RemoveCategory` domain methods preserves existing behavior (tests pass with `null`) while giving Legolas and the UI a clean optional-becomes-required upgrade path without a breaking API change.
+
+---
+
 ## 2026-05-15 — PR #338: Skill Template Compliance Fix
 
 ### Task

--- a/.squad/skills/gh-pr-comments-fallback/SKILL.md
+++ b/.squad/skills/gh-pr-comments-fallback/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: gh-pr-comments-fallback
+description: Reliable PR comment retrieval when gh pr view --comments fails on deprecated GraphQL fields
+domain: github-workflow
+confidence: high
+source: earned
+tools:
+  - name: gh api
+    description: Queries REST endpoints for issue comments, review comments, and reviews
+    when: When PR gate evidence is needed and gh pr view --comments errors
+---
+
+## Context
+
+During PR gate work, `gh pr view --comments` may fail due GraphQL field deprecations (for example, classic project card access). Gate flow still requires Copilot/Codecov and reviewer-comment evidence.
+
+## Patterns
+
+### Fallback Retrieval Sequence
+
+1. Use issue conversation comments:
+   - `gh api repos/{owner}/{repo}/issues/{pr}/comments --paginate`
+2. Use inline review comments:
+   - `gh api repos/{owner}/{repo}/pulls/{pr}/comments --paginate`
+3. Use review summaries/states:
+   - `gh api repos/{owner}/{repo}/pulls/{pr}/reviews --paginate`
+
+### Gate Usage
+
+- Prefer this fallback when `gh pr view --comments` returns GraphQL/projectCards errors.
+- Use output to classify blockers (bug/security/process-contract) vs advisory notes.
+
+## Anti-Patterns
+
+- Assuming no review comments exist just because `gh pr view --comments` failed.
+- Merging without reading Copilot inline comments due CLI query failures.

--- a/src/AppHost/MongoDbResourceBuilderExtensions.cs
+++ b/src/AppHost/MongoDbResourceBuilderExtensions.cs
@@ -207,9 +207,25 @@ internal static class MongoDbResourceBuilderExtensions
 
 				var client = new MongoClient(connectionString);
 				var database = client.GetDatabase(databaseName);
-				var collection = database.GetCollection<BsonDocument>("blogposts");
+
+				var categoriesCollection = database.GetCollection<BsonDocument>("categories");
+				var postsCollection = database.GetCollection<BsonDocument>("blogposts");
 
 				var now = DateTime.UtcNow;
+
+				// Seed the default "General" category with a stable, well-known id.
+				var generalCategoryId = new BsonBinaryData(
+					new Guid("00000000-0000-0000-0000-000000000001"),
+					GuidRepresentation.Standard);
+
+				var generalCategory = new BsonDocument
+				{
+					["_id"] = generalCategoryId,
+					["Name"] = "General",
+					["Description"] = "Default category for blog posts.",
+				};
+				await categoriesCollection.InsertOneAsync(generalCategory, cancellationToken: context.CancellationToken);
+
 				var authorId = "auth0|author-matthew-paulosky";
 				var authorDocument = new BsonDocument
 				{
@@ -231,6 +247,7 @@ new()
 ["UpdatedAt"] = now,
 ["IsPublished"] = true,
 ["Version"] = 1,
+["CategoryId"] = generalCategoryId,
 },
 new()
 {
@@ -242,6 +259,7 @@ new()
 ["UpdatedAt"] = now,
 ["IsPublished"] = true,
 ["Version"] = 1,
+["CategoryId"] = generalCategoryId,
 },
 new()
 {
@@ -253,19 +271,20 @@ new()
 ["UpdatedAt"] = now,
 ["IsPublished"] = false,
 ["Version"] = 1,
+["CategoryId"] = generalCategoryId,
 },
 	};
 
-				await collection.InsertManyAsync(seedDocuments, cancellationToken: context.CancellationToken);
+				await postsCollection.InsertManyAsync(seedDocuments, cancellationToken: context.CancellationToken);
 
 				context.Logger.LogInformation(
-		"Seed MyBlog data complete: {Count} blog post(s) inserted.",
+		"Seed MyBlog data complete: 1 category + {Count} blog post(s) inserted.",
 		seedDocuments.Length);
 
 				return new ExecuteCommandResult
 				{
 					Success = true,
-					Message = $"blogposts: {seedDocuments.Length} inserted (2 published, 1 draft)"
+					Message = $"categories: 1 inserted (General); blogposts: {seedDocuments.Length} inserted (2 published, 1 draft)"
 				};
 			}
 			finally

--- a/src/AppHost/MongoDbResourceBuilderExtensions.cs
+++ b/src/AppHost/MongoDbResourceBuilderExtensions.cs
@@ -224,7 +224,11 @@ internal static class MongoDbResourceBuilderExtensions
 					["Name"] = "General",
 					["Description"] = "Default category for blog posts.",
 				};
-				await categoriesCollection.InsertOneAsync(generalCategory, cancellationToken: context.CancellationToken);
+				await categoriesCollection.ReplaceOneAsync(
+					Builders<BsonDocument>.Filter.Eq("_id", generalCategoryId),
+					generalCategory,
+					new ReplaceOptions { IsUpsert = true },
+					cancellationToken: context.CancellationToken);
 
 				var authorId = "auth0|author-matthew-paulosky";
 				var authorDocument = new BsonDocument

--- a/src/Domain/Entities/BlogPost.cs
+++ b/src/Domain/Entities/BlogPost.cs
@@ -21,6 +21,7 @@ public sealed class BlogPost
 	public DateTime? UpdatedAt { get; private set; }
 	public bool IsPublished { get; private set; }
 	public int Version { get; private set; }
+	public Guid? CategoryId { get; private set; }
 
 	private BlogPost() { }
 
@@ -53,4 +54,6 @@ public sealed class BlogPost
 
 	public void Publish() => IsPublished = true;
 	public void Unpublish() => IsPublished = false;
+	public void AssignCategory(Guid categoryId) => CategoryId = categoryId;
+	public void RemoveCategory() => CategoryId = null;
 }

--- a/src/Domain/Entities/BlogPost.cs
+++ b/src/Domain/Entities/BlogPost.cs
@@ -54,6 +54,16 @@ public sealed class BlogPost
 
 	public void Publish() => IsPublished = true;
 	public void Unpublish() => IsPublished = false;
-	public void AssignCategory(Guid categoryId) => CategoryId = categoryId;
-	public void RemoveCategory() => CategoryId = null;
+
+	public void AssignCategory(Guid categoryId)
+	{
+		CategoryId = categoryId;
+		Version++;
+	}
+
+	public void RemoveCategory()
+	{
+		CategoryId = null;
+		Version++;
+	}
 }

--- a/src/Domain/Entities/Category.cs
+++ b/src/Domain/Entities/Category.cs
@@ -1,0 +1,40 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     Category.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Domain
+//=======================================================
+
+namespace MyBlog.Domain.Entities;
+
+public sealed class Category
+{
+	public Guid Id { get; private set; }
+	public string Name { get; private set; } = string.Empty;
+	public string Description { get; private set; } = string.Empty;
+
+	private Category() { }
+
+	public static Category Create(string name, string description)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(name);
+		ArgumentException.ThrowIfNullOrWhiteSpace(description);
+
+		return new Category
+		{
+			Id = Guid.NewGuid(),
+			Name = name.Trim(),
+			Description = description.Trim(),
+		};
+	}
+
+	public void Update(string name, string description)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(name);
+		ArgumentException.ThrowIfNullOrWhiteSpace(description);
+		Name = name.Trim();
+		Description = description.Trim();
+	}
+}

--- a/src/Domain/Interfaces/IBlogPostRepository.cs
+++ b/src/Domain/Interfaces/IBlogPostRepository.cs
@@ -15,6 +15,7 @@ public interface IBlogPostRepository
 {
 	Task<BlogPost?> GetByIdAsync(Guid id, CancellationToken ct = default);
 	Task<IReadOnlyList<BlogPost>> GetAllAsync(CancellationToken ct = default);
+	Task<bool> ExistsByCategoryAsync(Guid categoryId, CancellationToken ct = default);
 	Task AddAsync(BlogPost post, CancellationToken ct = default);
 	Task UpdateAsync(BlogPost post, CancellationToken ct = default);
 	Task DeleteAsync(Guid id, CancellationToken ct = default);

--- a/src/Domain/Interfaces/ICategoryRepository.cs
+++ b/src/Domain/Interfaces/ICategoryRepository.cs
@@ -1,0 +1,23 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     ICategoryRepository.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Domain
+//=======================================================
+
+using MyBlog.Domain.Entities;
+
+namespace MyBlog.Domain.Interfaces;
+
+public interface ICategoryRepository
+{
+	Task<Category?> GetByIdAsync(Guid id, CancellationToken ct = default);
+	Task<IReadOnlyList<Category>> GetAllAsync(CancellationToken ct = default);
+	Task<bool> ExistsByNameAsync(string name, CancellationToken ct = default);
+	Task<bool> ExistsByNameExcludingAsync(string name, Guid excludedId, CancellationToken ct = default);
+	Task AddAsync(Category category, CancellationToken ct = default);
+	Task UpdateAsync(Category category, CancellationToken ct = default);
+	Task DeleteAsync(Guid id, CancellationToken ct = default);
+}

--- a/src/Web/Components/Layout/NavMenu.razor
+++ b/src/Web/Components/Layout/NavMenu.razor
@@ -35,6 +35,12 @@
 
 					<AuthorizeView Roles="Admin">
 						<Authorized>
+							<NavLink class="nav-link" href="admin/categories">Categories</NavLink>
+						</Authorized>
+					</AuthorizeView>
+
+					<AuthorizeView Roles="Admin">
+						<Authorized>
 							<NavLink class="nav-link" href="admin/users">Manage Users</NavLink>
 						</Authorized>
 					</AuthorizeView>
@@ -68,6 +74,12 @@
 				<AuthorizeView>
 					<Authorized>
 						<NavLink class="nav-link py-2 block" href="profile">@GetProfileLabel(context.User)</NavLink>
+					</Authorized>
+				</AuthorizeView>
+
+				<AuthorizeView Roles="Admin">
+					<Authorized>
+						<NavLink class="nav-link py-2 block" href="admin/categories">Categories</NavLink>
 					</Authorized>
 				</AuthorizeView>
 

--- a/src/Web/Data/BlogDbContext.cs
+++ b/src/Web/Data/BlogDbContext.cs
@@ -17,6 +17,7 @@ namespace MyBlog.Web.Data;
 public sealed class BlogDbContext(DbContextOptions<BlogDbContext> options) : DbContext(options)
 {
 	public DbSet<BlogPost> BlogPosts => Set<BlogPost>();
+	public DbSet<Category> Categories => Set<Category>();
 
 	protected override void OnModelCreating(ModelBuilder modelBuilder)
 	{
@@ -26,6 +27,7 @@ public sealed class BlogDbContext(DbContextOptions<BlogDbContext> options) : DbC
 		entity.ToCollection("blogposts");
 		entity.HasKey(p => p.Id);
 		entity.Property(p => p.Version).IsConcurrencyToken();
+		entity.Property(p => p.CategoryId).HasElementName("CategoryId");
 		entity.OwnsOne(p => p.Author, a =>
 		{
 			a.Property(x => x.Id).HasElementName("AuthorId");
@@ -33,5 +35,12 @@ public sealed class BlogDbContext(DbContextOptions<BlogDbContext> options) : DbC
 			a.Property(x => x.Email).HasElementName("AuthorEmail");
 			a.Property(x => x.Roles).HasElementName("AuthorRoles");
 		});
+
+		var categoryEntity = modelBuilder.Entity<Category>();
+		categoryEntity.ToCollection("categories");
+		categoryEntity.HasKey(c => c.Id);
+		categoryEntity.Property(c => c.Name).IsRequired();
+		categoryEntity.Property(c => c.Description).IsRequired();
+		categoryEntity.HasIndex(c => c.Name).IsUnique();
 	}
 }

--- a/src/Web/Data/BlogPostDto.cs
+++ b/src/Web/Data/BlogPostDto.cs
@@ -19,4 +19,5 @@ internal sealed record BlogPostDto(
 		IReadOnlyList<string> AuthorRoles,
 		DateTime CreatedAt,
 		DateTime? UpdatedAt,
-		bool IsPublished);
+		bool IsPublished,
+		Guid? CategoryId);

--- a/src/Web/Data/BlogPostMappings.cs
+++ b/src/Web/Data/BlogPostMappings.cs
@@ -14,5 +14,5 @@ internal static class BlogPostMappings
 	internal static BlogPostDto ToDto(this BlogPost post) => new(
 			post.Id, post.Title, post.Content,
 			post.Author.Id, post.Author.Name, post.Author.Email, post.Author.Roles,
-			post.CreatedAt, post.UpdatedAt, post.IsPublished);
+			post.CreatedAt, post.UpdatedAt, post.IsPublished, post.CategoryId);
 }

--- a/src/Web/Data/CategoryDto.cs
+++ b/src/Web/Data/CategoryDto.cs
@@ -1,0 +1,12 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     CategoryDto.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web
+//=======================================================
+
+namespace MyBlog.Web.Data;
+
+internal sealed record CategoryDto(Guid Id, string Name, string Description);

--- a/src/Web/Data/CategoryMappings.cs
+++ b/src/Web/Data/CategoryMappings.cs
@@ -1,0 +1,16 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     CategoryMappings.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web
+//=======================================================
+
+namespace MyBlog.Web.Data;
+
+internal static class CategoryMappings
+{
+	internal static CategoryDto ToDto(this Category category) =>
+		new(category.Id, category.Name, category.Description);
+}

--- a/src/Web/Data/MongoDbBlogPostRepository.cs
+++ b/src/Web/Data/MongoDbBlogPostRepository.cs
@@ -27,6 +27,13 @@ internal sealed class MongoDbBlogPostRepository(IDbContextFactory<BlogDbContext>
 				.ToListAsync(ct).ConfigureAwait(false);
 	}
 
+	public async Task<bool> ExistsByCategoryAsync(Guid categoryId, CancellationToken ct = default)
+	{
+		await using var ctx = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+		return await ctx.BlogPosts.AsNoTracking()
+				.AnyAsync(p => p.CategoryId == categoryId, ct).ConfigureAwait(false);
+	}
+
 	public async Task AddAsync(BlogPost post, CancellationToken ct = default)
 	{
 		await using var ctx = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);

--- a/src/Web/Data/MongoDbCategoryRepository.cs
+++ b/src/Web/Data/MongoDbCategoryRepository.cs
@@ -1,0 +1,70 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     MongoDbCategoryRepository.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web
+//=======================================================
+
+namespace MyBlog.Web.Data;
+
+internal sealed class MongoDbCategoryRepository(IDbContextFactory<BlogDbContext> contextFactory)
+	: ICategoryRepository
+{
+	public async Task<Category?> GetByIdAsync(Guid id, CancellationToken ct = default)
+	{
+		await using var ctx = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+		return await ctx.Categories.AsNoTracking()
+			.FirstOrDefaultAsync(c => c.Id == id, ct).ConfigureAwait(false);
+	}
+
+	public async Task<IReadOnlyList<Category>> GetAllAsync(CancellationToken ct = default)
+	{
+		await using var ctx = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+		return await ctx.Categories.AsNoTracking()
+			.OrderBy(c => c.Name)
+			.ToListAsync(ct).ConfigureAwait(false);
+	}
+
+	public async Task<bool> ExistsByNameAsync(string name, CancellationToken ct = default)
+	{
+		await using var ctx = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+		var normalizedName = name.Trim();
+		return await ctx.Categories.AsNoTracking()
+			.AnyAsync(c => c.Name == normalizedName, ct).ConfigureAwait(false);
+	}
+
+	public async Task<bool> ExistsByNameExcludingAsync(string name, Guid excludedId, CancellationToken ct = default)
+	{
+		await using var ctx = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+		var normalizedName = name.Trim();
+		return await ctx.Categories.AsNoTracking()
+			.AnyAsync(c => c.Name == normalizedName && c.Id != excludedId, ct).ConfigureAwait(false);
+	}
+
+	public async Task AddAsync(Category category, CancellationToken ct = default)
+	{
+		await using var ctx = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+		await ctx.Categories.AddAsync(category, ct).ConfigureAwait(false);
+		await ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+	}
+
+	public async Task UpdateAsync(Category category, CancellationToken ct = default)
+	{
+		await using var ctx = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+		ctx.Categories.Update(category);
+		await ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+	}
+
+	public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+	{
+		await using var ctx = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+		var category = await ctx.Categories.FindAsync([id], ct).ConfigureAwait(false);
+		if (category is not null)
+		{
+			ctx.Categories.Remove(category);
+			await ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+		}
+	}
+}

--- a/src/Web/Features/BlogPosts/Create/Create.razor
+++ b/src/Web/Features/BlogPosts/Create/Create.razor
@@ -1,6 +1,7 @@
 @page "/blog/create"
 @using MyBlog.Domain.ValueObjects
 @using MyBlog.Web.Security
+@using MyBlog.Web.Features.Categories.List
 @using System.Security.Claims
 @inject ISender Sender
 @inject NavigationManager Navigation
@@ -34,6 +35,30 @@
 			<TextEditor @bind-Content="_model.Content" AlignmentOptionsEnabled="false" />
 		</div>
 		<div class="form-group">
+			<label class="form-label">
+				Category <span class="text-xs text-red-500">*</span>
+			</label>
+			@if (!_categories.Any())
+			{
+				<p class="text-sm text-gray-500 dark:text-gray-400">
+					No categories available.
+					<a href="/admin/categories" class="text-primary-600 dark:text-primary-400 underline">Create categories</a>
+					before publishing a post.
+				</p>
+			}
+			else
+			{
+				<InputSelect class="form-select" @bind-Value="_model.CategoryId">
+					<option value="">-- Select a category --</option>
+					@foreach (var cat in _categories)
+					{
+						<option value="@cat.Id">@cat.Name</option>
+					}
+				</InputSelect>
+				<ValidationMessage For="() => _model.CategoryId" />
+			}
+		</div>
+		<div class="form-group">
 			<label class="form-label flex items-center gap-2">
 				<InputCheckbox @bind-Value="_model.IsPublished" />
 				<span>Published</span>
@@ -50,6 +75,7 @@
 @code {
 	private readonly PostFormModel _model = new();
 	private string? _error;
+	private IReadOnlyList<CategoryDto> _categories = [];
 
 	private string _authorId = string.Empty;
 	private string _authorName = string.Empty;
@@ -81,12 +107,22 @@
 		{
 			_authorName = "Author";
 		}
+
+		var categoriesResult = await Sender.Send(new GetCategoriesQuery());
+		if (categoriesResult is { Success: true })
+			_categories = categoriesResult.Value!;
 	}
 
 	private async Task HandleSubmit()
 	{
+		if (_categories.Any() && _model.CategoryId is null)
+		{
+			_error = "Please select a category.";
+			return;
+		}
+
 		var author = new PostAuthor(_authorId, _authorName, _authorEmail, _authorRoles);
-		var result = await Sender.Send(new CreateBlogPostCommand(_model.Title, _model.Content, author, _model.IsPublished));
+		var result = await Sender.Send(new CreateBlogPostCommand(_model.Title, _model.Content, author, _model.IsPublished, _model.CategoryId));
 		if (result.Success)
 			Navigation.NavigateTo("/blog");
 		else
@@ -102,5 +138,7 @@
 		public string Content { get; set; } = string.Empty;
 
 		public bool IsPublished { get; set; }
+
+		public Guid? CategoryId { get; set; }
 	}
 }

--- a/src/Web/Features/BlogPosts/Create/CreateBlogPostCommand.cs
+++ b/src/Web/Features/BlogPosts/Create/CreateBlogPostCommand.cs
@@ -16,5 +16,6 @@ internal sealed record CreateBlogPostCommand(
 	string Title,
 	string Content,
 	PostAuthor Author,
-	bool IsPublished = false)
+	bool IsPublished = false,
+	Guid? CategoryId = null)
 		: IRequest<Result<Guid>>;

--- a/src/Web/Features/BlogPosts/Create/CreateBlogPostHandler.cs
+++ b/src/Web/Features/BlogPosts/Create/CreateBlogPostHandler.cs
@@ -46,6 +46,11 @@ ILogger<CreateBlogPostHandler> logger) : IRequestHandler<CreateBlogPostCommand, 
 				post.Publish();
 			}
 
+			if (request.CategoryId is not null)
+			{
+				post.AssignCategory(request.CategoryId.Value);
+			}
+
 			await repo.AddAsync(post, cancellationToken).ConfigureAwait(false);
 			await cache.InvalidateAllAsync(cancellationToken).ConfigureAwait(false);
 			return Result.Ok<Guid>(post.Id);

--- a/src/Web/Features/BlogPosts/Edit/Edit.razor
+++ b/src/Web/Features/BlogPosts/Edit/Edit.razor
@@ -1,5 +1,6 @@
 @page "/blog/edit/{Id:guid}"
 @using System.Security.Claims
+@using MyBlog.Web.Features.Categories.List
 @inject ISender Sender
 @inject NavigationManager Navigation
 @inject AuthenticationStateProvider AuthStateProvider
@@ -33,6 +34,8 @@
 }
 else if (_model is not null)
 {
+    <p class="form-label mb-4">Author: <span class="font-semibold">@_authorName</span></p>
+
     <div class="form-panel">
         <EditForm Model="_model" OnValidSubmit="HandleSubmit">
             <DataAnnotationsValidator />
@@ -45,6 +48,30 @@ else if (_model is not null)
             <div class="form-group">
                 <label class="form-label">Content <span class="text-xs text-gray-500 dark:text-gray-400 font-normal">(Markdown)</span></label>
                 <TextEditor @bind-Content="_model.Content" AlignmentOptionsEnabled="false" />
+            </div>
+            <div class="form-group">
+                <label class="form-label">
+                    Category <span class="text-xs text-red-500">*</span>
+                </label>
+                @if (!_categories.Any())
+                {
+                    <p class="text-sm text-gray-500 dark:text-gray-400">
+                        No categories available.
+                        <a href="/admin/categories" class="text-primary-600 dark:text-primary-400 underline">Create categories</a>
+                        before publishing a post.
+                    </p>
+                }
+                else
+                {
+                    <InputSelect class="form-select" @bind-Value="_model.CategoryId">
+                        <option value="">-- Select a category --</option>
+                        @foreach (var cat in _categories)
+                        {
+                            <option value="@cat.Id">@cat.Name</option>
+                        }
+                    </InputSelect>
+                    <ValidationMessage For="() => _model.CategoryId" />
+                }
             </div>
             <div class="form-group">
                 <label class="form-label flex items-center gap-2">
@@ -70,6 +97,8 @@ else if (_model is not null)
     private bool _isLoading = true;
     private string _callerUserId = string.Empty;
     private bool _callerIsAdmin;
+    private string _authorName = string.Empty;
+    private IReadOnlyList<CategoryDto> _categories = [];
 
     protected override async Task OnParametersSetAsync()
     {
@@ -79,7 +108,14 @@ else if (_model is not null)
         _isLoading = true;
         try
         {
-            var result = await Sender.Send(new GetBlogPostByIdQuery(Id));
+            var categoriesTask = Sender.Send(new GetCategoriesQuery());
+            var postTask = Sender.Send(new GetBlogPostByIdQuery(Id));
+            await Task.WhenAll(categoriesTask, postTask);
+
+            var categoriesResult = await categoriesTask;
+            if (categoriesResult is { Success: true }) _categories = categoriesResult.Value!;
+
+            var result = await postTask;
             if (result.Success)
             {
                 if (result.Value is not null)
@@ -98,11 +134,13 @@ else if (_model is not null)
                         return;
                     }
 
+                    _authorName = result.Value.AuthorName;
                     _model = new PostFormModel
                     {
                         Title = result.Value.Title,
                         Content = result.Value.Content,
-                        IsPublished = result.Value.IsPublished
+                        IsPublished = result.Value.IsPublished,
+                        CategoryId = result.Value.CategoryId,
                     };
                 }
                 else
@@ -125,13 +163,20 @@ else if (_model is not null)
     private async Task HandleSubmit()
     {
         if (_model is null) return;
+        if (_categories.Any() && _model.CategoryId is null)
+        {
+            _error = "Please select a category.";
+            return;
+        }
+
         var result = await Sender.Send(new EditBlogPostCommand(
             Id,
             _model.Title,
             _model.Content,
             _callerUserId,
             _callerIsAdmin,
-            _model.IsPublished));
+            _model.IsPublished,
+            _model.CategoryId));
         if (result.Success)
             Navigation.NavigateTo("/blog");
         else
@@ -153,5 +198,7 @@ else if (_model is not null)
         public string Content { get; set; } = string.Empty;
 
         public bool IsPublished { get; set; }
+
+        public Guid? CategoryId { get; set; }
     }
 }

--- a/src/Web/Features/BlogPosts/Edit/EditBlogPostHandler.cs
+++ b/src/Web/Features/BlogPosts/Edit/EditBlogPostHandler.cs
@@ -59,6 +59,11 @@ IRequestHandler<GetBlogPostByIdQuery, Result<BlogPostDto?>>
 				post.Unpublish();
 			}
 
+			if (request.CategoryId is not null)
+			{
+				post.AssignCategory(request.CategoryId.Value);
+			}
+
 			await repo.UpdateAsync(post, cancellationToken).ConfigureAwait(false);
 			await cache.InvalidateAllAsync(cancellationToken).ConfigureAwait(false);
 			await cache.InvalidateByIdAsync(request.Id, cancellationToken).ConfigureAwait(false);

--- a/src/Web/Features/Categories/Create/CreateCategoryCommand.cs
+++ b/src/Web/Features/Categories/Create/CreateCategoryCommand.cs
@@ -1,6 +1,6 @@
 //=======================================================
 //Copyright (c) 2026. All rights reserved.
-//File Name :     EditBlogPostCommand.cs
+//File Name :     CreateCategoryCommand.cs
 //Company :       mpaulosky
 //Author :        Matthew Paulosky
 //Solution Name : MyBlog
@@ -9,13 +9,8 @@
 
 using MyBlog.Domain.Abstractions;
 
-namespace MyBlog.Web.Features.BlogPosts.Edit;
+namespace MyBlog.Web.Features.Categories.Create;
 
-internal sealed record EditBlogPostCommand(
-	Guid Id,
-	string Title,
-	string Content,
-	string CallerUserId,
-	bool CallerIsAdmin,
-	bool? IsPublished = null,
-	Guid? CategoryId = null) : IRequest<Result>;
+internal sealed record CreateCategoryCommand(
+	string Name,
+	string Description) : IRequest<Result<Guid>>;

--- a/src/Web/Features/Categories/Create/CreateCategoryCommandValidator.cs
+++ b/src/Web/Features/Categories/Create/CreateCategoryCommandValidator.cs
@@ -1,0 +1,26 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     CreateCategoryCommandValidator.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web
+//=======================================================
+
+using FluentValidation;
+
+namespace MyBlog.Web.Features.Categories.Create;
+
+internal sealed class CreateCategoryCommandValidator : AbstractValidator<CreateCategoryCommand>
+{
+	public CreateCategoryCommandValidator()
+	{
+		RuleFor(x => x.Name)
+			.NotEmpty().WithMessage("Name is required.")
+			.MaximumLength(100).WithMessage("Name must not exceed 100 characters.");
+
+		RuleFor(x => x.Description)
+			.NotEmpty().WithMessage("Description is required.")
+			.MaximumLength(500).WithMessage("Description must not exceed 500 characters.");
+	}
+}

--- a/src/Web/Features/Categories/Create/CreateCategoryHandler.cs
+++ b/src/Web/Features/Categories/Create/CreateCategoryHandler.cs
@@ -1,0 +1,50 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     CreateCategoryHandler.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web
+//=======================================================
+
+using MyBlog.Domain.Abstractions;
+
+namespace MyBlog.Web.Features.Categories.Create;
+
+internal sealed class CreateCategoryHandler(ICategoryRepository repo)
+	: IRequestHandler<CreateCategoryCommand, Result<Guid>>
+{
+	public async Task<Result<Guid>> Handle(
+		CreateCategoryCommand request,
+		CancellationToken cancellationToken)
+	{
+		try
+		{
+			var nameExists = await repo.ExistsByNameAsync(request.Name, cancellationToken).ConfigureAwait(false);
+			if (nameExists)
+			{
+				return Result.Fail<Guid>(
+					$"A category named '{request.Name.Trim()}' already exists.",
+					ResultErrorCode.Conflict);
+			}
+
+			var category = Category.Create(request.Name, request.Description);
+			await repo.AddAsync(category, cancellationToken).ConfigureAwait(false);
+			return Result.Ok<Guid>(category.Id);
+		}
+		catch (OperationCanceledException)
+		{
+			throw;
+		}
+		catch (InvalidOperationException ex)
+		{
+			return Result.Fail<Guid>(ex.Message);
+		}
+#pragma warning disable CA1031 // Intentional: top-level handler converts unexpected failures to Result to keep UI stable
+		catch (Exception)
+		{
+			return Result.Fail<Guid>("An unexpected error occurred.");
+		}
+#pragma warning restore CA1031
+	}
+}

--- a/src/Web/Features/Categories/Delete/DeleteCategoryCommand.cs
+++ b/src/Web/Features/Categories/Delete/DeleteCategoryCommand.cs
@@ -1,6 +1,6 @@
 //=======================================================
 //Copyright (c) 2026. All rights reserved.
-//File Name :     EditBlogPostCommand.cs
+//File Name :     DeleteCategoryCommand.cs
 //Company :       mpaulosky
 //Author :        Matthew Paulosky
 //Solution Name : MyBlog
@@ -9,13 +9,6 @@
 
 using MyBlog.Domain.Abstractions;
 
-namespace MyBlog.Web.Features.BlogPosts.Edit;
+namespace MyBlog.Web.Features.Categories.Delete;
 
-internal sealed record EditBlogPostCommand(
-	Guid Id,
-	string Title,
-	string Content,
-	string CallerUserId,
-	bool CallerIsAdmin,
-	bool? IsPublished = null,
-	Guid? CategoryId = null) : IRequest<Result>;
+internal sealed record DeleteCategoryCommand(Guid Id) : IRequest<Result>;

--- a/src/Web/Features/Categories/Delete/DeleteCategoryCommandValidator.cs
+++ b/src/Web/Features/Categories/Delete/DeleteCategoryCommandValidator.cs
@@ -1,0 +1,21 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     DeleteCategoryCommandValidator.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web
+//=======================================================
+
+using FluentValidation;
+
+namespace MyBlog.Web.Features.Categories.Delete;
+
+internal sealed class DeleteCategoryCommandValidator : AbstractValidator<DeleteCategoryCommand>
+{
+	public DeleteCategoryCommandValidator()
+	{
+		RuleFor(x => x.Id)
+			.NotEmpty().WithMessage("Id is required.");
+	}
+}

--- a/src/Web/Features/Categories/Delete/DeleteCategoryHandler.cs
+++ b/src/Web/Features/Categories/Delete/DeleteCategoryHandler.cs
@@ -1,0 +1,56 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     DeleteCategoryHandler.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web
+//=======================================================
+
+using MyBlog.Domain.Abstractions;
+
+namespace MyBlog.Web.Features.Categories.Delete;
+
+internal sealed class DeleteCategoryHandler(
+	ICategoryRepository categoryRepo,
+	IBlogPostRepository blogPostRepo) : IRequestHandler<DeleteCategoryCommand, Result>
+{
+	public async Task<Result> Handle(
+		DeleteCategoryCommand request,
+		CancellationToken cancellationToken)
+	{
+		try
+		{
+			var category = await categoryRepo.GetByIdAsync(request.Id, cancellationToken).ConfigureAwait(false);
+			if (category is null)
+			{
+				return Result.Fail($"Category {request.Id} not found.", ResultErrorCode.NotFound);
+			}
+
+			var inUse = await blogPostRepo.ExistsByCategoryAsync(request.Id, cancellationToken).ConfigureAwait(false);
+			if (inUse)
+			{
+				return Result.Fail(
+					$"Category '{category.Name}' cannot be deleted because it is assigned to one or more blog posts.",
+					ResultErrorCode.Conflict);
+			}
+
+			await categoryRepo.DeleteAsync(request.Id, cancellationToken).ConfigureAwait(false);
+			return Result.Ok();
+		}
+		catch (OperationCanceledException)
+		{
+			throw;
+		}
+		catch (InvalidOperationException ex)
+		{
+			return Result.Fail(ex.Message);
+		}
+#pragma warning disable CA1031 // Intentional: top-level handler converts unexpected failures to Result to keep UI stable
+		catch (Exception)
+		{
+			return Result.Fail("An unexpected error occurred.");
+		}
+#pragma warning restore CA1031
+	}
+}

--- a/src/Web/Features/Categories/Edit/EditCategoryCommand.cs
+++ b/src/Web/Features/Categories/Edit/EditCategoryCommand.cs
@@ -1,6 +1,6 @@
 //=======================================================
 //Copyright (c) 2026. All rights reserved.
-//File Name :     EditBlogPostCommand.cs
+//File Name :     EditCategoryCommand.cs
 //Company :       mpaulosky
 //Author :        Matthew Paulosky
 //Solution Name : MyBlog
@@ -9,13 +9,9 @@
 
 using MyBlog.Domain.Abstractions;
 
-namespace MyBlog.Web.Features.BlogPosts.Edit;
+namespace MyBlog.Web.Features.Categories.Edit;
 
-internal sealed record EditBlogPostCommand(
+internal sealed record EditCategoryCommand(
 	Guid Id,
-	string Title,
-	string Content,
-	string CallerUserId,
-	bool CallerIsAdmin,
-	bool? IsPublished = null,
-	Guid? CategoryId = null) : IRequest<Result>;
+	string Name,
+	string Description) : IRequest<Result>;

--- a/src/Web/Features/Categories/Edit/EditCategoryCommandValidator.cs
+++ b/src/Web/Features/Categories/Edit/EditCategoryCommandValidator.cs
@@ -1,0 +1,29 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     EditCategoryCommandValidator.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web
+//=======================================================
+
+using FluentValidation;
+
+namespace MyBlog.Web.Features.Categories.Edit;
+
+internal sealed class EditCategoryCommandValidator : AbstractValidator<EditCategoryCommand>
+{
+	public EditCategoryCommandValidator()
+	{
+		RuleFor(x => x.Id)
+			.NotEmpty().WithMessage("Id is required.");
+
+		RuleFor(x => x.Name)
+			.NotEmpty().WithMessage("Name is required.")
+			.MaximumLength(100).WithMessage("Name must not exceed 100 characters.");
+
+		RuleFor(x => x.Description)
+			.NotEmpty().WithMessage("Description is required.")
+			.MaximumLength(500).WithMessage("Description must not exceed 500 characters.");
+	}
+}

--- a/src/Web/Features/Categories/Edit/EditCategoryHandler.cs
+++ b/src/Web/Features/Categories/Edit/EditCategoryHandler.cs
@@ -1,0 +1,57 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     EditCategoryHandler.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web
+//=======================================================
+
+using MyBlog.Domain.Abstractions;
+
+namespace MyBlog.Web.Features.Categories.Edit;
+
+internal sealed class EditCategoryHandler(ICategoryRepository repo)
+	: IRequestHandler<EditCategoryCommand, Result>
+{
+	public async Task<Result> Handle(
+		EditCategoryCommand request,
+		CancellationToken cancellationToken)
+	{
+		try
+		{
+			var category = await repo.GetByIdAsync(request.Id, cancellationToken).ConfigureAwait(false);
+			if (category is null)
+			{
+				return Result.Fail($"Category {request.Id} not found.", ResultErrorCode.NotFound);
+			}
+
+			var nameExists = await repo.ExistsByNameExcludingAsync(
+				request.Name, request.Id, cancellationToken).ConfigureAwait(false);
+			if (nameExists)
+			{
+				return Result.Fail(
+					$"A category named '{request.Name.Trim()}' already exists.",
+					ResultErrorCode.Conflict);
+			}
+
+			category.Update(request.Name, request.Description);
+			await repo.UpdateAsync(category, cancellationToken).ConfigureAwait(false);
+			return Result.Ok();
+		}
+		catch (OperationCanceledException)
+		{
+			throw;
+		}
+		catch (InvalidOperationException ex)
+		{
+			return Result.Fail(ex.Message);
+		}
+#pragma warning disable CA1031 // Intentional: top-level handler converts unexpected failures to Result to keep UI stable
+		catch (Exception)
+		{
+			return Result.Fail("An unexpected error occurred.");
+		}
+#pragma warning restore CA1031
+	}
+}

--- a/src/Web/Features/Categories/GetById/GetCategoryByIdHandler.cs
+++ b/src/Web/Features/Categories/GetById/GetCategoryByIdHandler.cs
@@ -1,0 +1,41 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     GetCategoryByIdHandler.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web
+//=======================================================
+
+using MyBlog.Domain.Abstractions;
+
+namespace MyBlog.Web.Features.Categories.GetById;
+
+internal sealed class GetCategoryByIdHandler(ICategoryRepository repo)
+	: IRequestHandler<GetCategoryByIdQuery, Result<CategoryDto?>>
+{
+	public async Task<Result<CategoryDto?>> Handle(
+		GetCategoryByIdQuery request,
+		CancellationToken cancellationToken)
+	{
+		try
+		{
+			var category = await repo.GetByIdAsync(request.Id, cancellationToken).ConfigureAwait(false);
+			return Result.Ok<CategoryDto?>(category?.ToDto());
+		}
+		catch (OperationCanceledException)
+		{
+			throw;
+		}
+		catch (InvalidOperationException ex)
+		{
+			return Result.Fail<CategoryDto?>(ex.Message);
+		}
+#pragma warning disable CA1031 // Intentional: top-level handler converts unexpected failures to Result to keep UI stable
+		catch (Exception)
+		{
+			return Result.Fail<CategoryDto?>("An unexpected error occurred.");
+		}
+#pragma warning restore CA1031
+	}
+}

--- a/src/Web/Features/Categories/GetById/GetCategoryByIdQuery.cs
+++ b/src/Web/Features/Categories/GetById/GetCategoryByIdQuery.cs
@@ -1,6 +1,6 @@
 //=======================================================
 //Copyright (c) 2026. All rights reserved.
-//File Name :     EditBlogPostCommand.cs
+//File Name :     GetCategoryByIdQuery.cs
 //Company :       mpaulosky
 //Author :        Matthew Paulosky
 //Solution Name : MyBlog
@@ -9,13 +9,6 @@
 
 using MyBlog.Domain.Abstractions;
 
-namespace MyBlog.Web.Features.BlogPosts.Edit;
+namespace MyBlog.Web.Features.Categories.GetById;
 
-internal sealed record EditBlogPostCommand(
-	Guid Id,
-	string Title,
-	string Content,
-	string CallerUserId,
-	bool CallerIsAdmin,
-	bool? IsPublished = null,
-	Guid? CategoryId = null) : IRequest<Result>;
+internal sealed record GetCategoryByIdQuery(Guid Id) : IRequest<Result<CategoryDto?>>;

--- a/src/Web/Features/Categories/List/GetCategoriesHandler.cs
+++ b/src/Web/Features/Categories/List/GetCategoriesHandler.cs
@@ -1,0 +1,42 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     GetCategoriesHandler.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web
+//=======================================================
+
+using MyBlog.Domain.Abstractions;
+
+namespace MyBlog.Web.Features.Categories.List;
+
+internal sealed class GetCategoriesHandler(ICategoryRepository repo)
+	: IRequestHandler<GetCategoriesQuery, Result<IReadOnlyList<CategoryDto>>>
+{
+	public async Task<Result<IReadOnlyList<CategoryDto>>> Handle(
+		GetCategoriesQuery request,
+		CancellationToken cancellationToken)
+	{
+		try
+		{
+			var categories = await repo.GetAllAsync(cancellationToken).ConfigureAwait(false);
+			var dtos = (IReadOnlyList<CategoryDto>)categories.Select(c => c.ToDto()).ToList();
+			return Result.Ok<IReadOnlyList<CategoryDto>>(dtos);
+		}
+		catch (OperationCanceledException)
+		{
+			throw;
+		}
+		catch (InvalidOperationException ex)
+		{
+			return Result.Fail<IReadOnlyList<CategoryDto>>(ex.Message);
+		}
+#pragma warning disable CA1031 // Intentional: top-level handler converts unexpected failures to Result to keep UI stable
+		catch (Exception)
+		{
+			return Result.Fail<IReadOnlyList<CategoryDto>>("An unexpected error occurred.");
+		}
+#pragma warning restore CA1031
+	}
+}

--- a/src/Web/Features/Categories/List/GetCategoriesQuery.cs
+++ b/src/Web/Features/Categories/List/GetCategoriesQuery.cs
@@ -1,6 +1,6 @@
 //=======================================================
 //Copyright (c) 2026. All rights reserved.
-//File Name :     EditBlogPostCommand.cs
+//File Name :     GetCategoriesQuery.cs
 //Company :       mpaulosky
 //Author :        Matthew Paulosky
 //Solution Name : MyBlog
@@ -9,13 +9,6 @@
 
 using MyBlog.Domain.Abstractions;
 
-namespace MyBlog.Web.Features.BlogPosts.Edit;
+namespace MyBlog.Web.Features.Categories.List;
 
-internal sealed record EditBlogPostCommand(
-	Guid Id,
-	string Title,
-	string Content,
-	string CallerUserId,
-	bool CallerIsAdmin,
-	bool? IsPublished = null,
-	Guid? CategoryId = null) : IRequest<Result>;
+internal sealed record GetCategoriesQuery : IRequest<Result<IReadOnlyList<CategoryDto>>>;

--- a/src/Web/Features/Categories/List/Index.razor
+++ b/src/Web/Features/Categories/List/Index.razor
@@ -1,0 +1,211 @@
+@page "/admin/categories"
+@using MyBlog.Web.Features.Categories.Create
+@using MyBlog.Web.Features.Categories.Edit
+@using MyBlog.Web.Features.Categories.Delete
+@inject ISender Sender
+@rendermode InteractiveServer
+@attribute [Authorize(Roles = "Admin")]
+
+<PageHeadingComponent HeaderText="Manage Categories" Level="1" TextColorClass="text-primary-900 dark:text-primary-50" />
+
+@if (_error is not null)
+{
+	<div class="alert-error" role="alert">
+		<span>@_error</span>
+		<button type="button" class="alert-dismiss" @onclick="() => _error = null">&times;</button>
+	</div>
+}
+
+@* Create form *@
+<div class="form-panel mb-6">
+	<h2 class="text-base font-semibold mb-4 text-primary-900 dark:text-primary-50">Add Category</h2>
+	<EditForm Model="_createModel" OnValidSubmit="HandleCreate">
+		<DataAnnotationsValidator />
+		<ValidationSummary class="mb-2" />
+		<div class="form-group">
+			<label class="form-label">Name</label>
+			<InputText class="form-input" @bind-Value="_createModel.Name" />
+		</div>
+		<div class="form-group">
+			<label class="form-label">Description</label>
+			<InputText class="form-input" @bind-Value="_createModel.Description" />
+		</div>
+		<button type="submit" class="btn-primary">Add</button>
+	</EditForm>
+</div>
+
+@* Categories table *@
+@if (_loading)
+{
+	<p class="text-gray-600 dark:text-gray-400" role="status">Loading...</p>
+}
+else if (!_categories.Any())
+{
+	<p class="text-gray-600 dark:text-gray-400">No categories yet. Use the form above to add one.</p>
+}
+else
+{
+	<div class="table-wrapper">
+		<table class="data-table">
+			<thead>
+				<tr>
+					<th>Name</th>
+					<th>Description</th>
+					<th></th>
+				</tr>
+			</thead>
+			<tbody>
+				@foreach (var cat in _categories)
+				{
+					@if (_editingId == cat.Id)
+					{
+						<tr>
+							<td colspan="3">
+								<EditForm Model="_editModel" OnValidSubmit="HandleEdit">
+									<DataAnnotationsValidator />
+									<div class="flex gap-2 items-start flex-wrap">
+										<div class="flex-1 min-w-0">
+											<InputText class="form-input w-full" @bind-Value="_editModel.Name" placeholder="Name" />
+										</div>
+										<div class="flex-1 min-w-0">
+											<InputText class="form-input w-full" @bind-Value="_editModel.Description" placeholder="Description" />
+										</div>
+										<div class="flex gap-2 flex-shrink-0">
+											<button type="submit" class="btn-primary">Save</button>
+											<button type="button" class="btn-secondary" @onclick="CancelEdit">Cancel</button>
+										</div>
+									</div>
+									<ValidationSummary class="mt-1" />
+								</EditForm>
+							</td>
+						</tr>
+					}
+					else
+					{
+						<tr>
+							<td>@cat.Name</td>
+							<td>@cat.Description</td>
+							<td>
+								<button class="btn-secondary mr-1" @onclick="() => BeginEdit(cat)">Edit</button>
+								<button class="btn-destructive" @onclick="() => ConfirmDelete(cat)">Delete</button>
+							</td>
+						</tr>
+					}
+				}
+			</tbody>
+		</table>
+	</div>
+}
+
+@* Inline delete confirmation *@
+@if (_deleteTarget is not null)
+{
+	<div class="fixed inset-0 z-[100] flex items-center justify-center bg-black/50" @onclick="() => _deleteTarget = null">
+		<div class="rounded-lg shadow-xl p-6 max-w-md w-full mx-4 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600"
+				 @onclick:stopPropagation="true" role="dialog" aria-labelledby="cat-delete-title">
+			<h5 id="cat-delete-title" class="text-lg font-semibold text-gray-900 dark:text-gray-50 mb-4">Confirm Delete</h5>
+			<p class="text-gray-900 dark:text-gray-50 mb-2">
+				Delete category <strong>@_deleteTarget.Name</strong>?
+			</p>
+			<p class="text-red-600 dark:text-red-400 text-sm mb-4">This action cannot be undone.</p>
+			<div class="flex gap-2 justify-end">
+				<button class="btn-destructive" @onclick="ExecuteDelete">Delete</button>
+				<button class="btn-secondary" @onclick="() => _deleteTarget = null">Cancel</button>
+			</div>
+		</div>
+	</div>
+}
+
+@code {
+	private IReadOnlyList<CategoryDto> _categories = [];
+	private bool _loading = true;
+	private string? _error;
+
+	private readonly CategoryFormModel _createModel = new();
+	private Guid? _editingId;
+	private readonly CategoryEditModel _editModel = new();
+	private CategoryDto? _deleteTarget;
+
+	protected override async Task OnInitializedAsync() => await LoadAsync();
+
+	private async Task LoadAsync()
+	{
+		_loading = true;
+		var result = await Sender.Send(new GetCategoriesQuery());
+		if (result.Success) _categories = result.Value!;
+		else _error = result.Error;
+		_loading = false;
+	}
+
+	private async Task HandleCreate()
+	{
+		var result = await Sender.Send(new CreateCategoryCommand(_createModel.Name, _createModel.Description));
+		if (result.Success)
+		{
+			_createModel.Name = string.Empty;
+			_createModel.Description = string.Empty;
+			await LoadAsync();
+		}
+		else
+		{
+			_error = result.Error;
+		}
+	}
+
+	private void BeginEdit(CategoryDto category)
+	{
+		_editingId = category.Id;
+		_editModel.Name = category.Name;
+		_editModel.Description = category.Description;
+	}
+
+	private void CancelEdit() => _editingId = null;
+
+	private async Task HandleEdit()
+	{
+		if (_editingId is null) return;
+		var result = await Sender.Send(new EditCategoryCommand(_editingId.Value, _editModel.Name, _editModel.Description));
+		if (result.Success)
+		{
+			_editingId = null;
+			await LoadAsync();
+		}
+		else
+		{
+			_error = result.Error;
+		}
+	}
+
+	private void ConfirmDelete(CategoryDto category) => _deleteTarget = category;
+
+	private async Task ExecuteDelete()
+	{
+		if (_deleteTarget is null) return;
+		var result = await Sender.Send(new DeleteCategoryCommand(_deleteTarget.Id));
+		if (result.Failure) _error = result.Error;
+		_deleteTarget = null;
+		await LoadAsync();
+	}
+
+	private sealed class CategoryFormModel
+	{
+		[System.ComponentModel.DataAnnotations.Required(ErrorMessage = "Name is required.")]
+		[System.ComponentModel.DataAnnotations.MaxLength(100, ErrorMessage = "Name must not exceed 100 characters.")]
+		public string Name { get; set; } = string.Empty;
+
+		[System.ComponentModel.DataAnnotations.Required(ErrorMessage = "Description is required.")]
+		[System.ComponentModel.DataAnnotations.MaxLength(500, ErrorMessage = "Description must not exceed 500 characters.")]
+		public string Description { get; set; } = string.Empty;
+	}
+
+	private sealed class CategoryEditModel
+	{
+		[System.ComponentModel.DataAnnotations.Required(ErrorMessage = "Name is required.")]
+		[System.ComponentModel.DataAnnotations.MaxLength(100, ErrorMessage = "Name must not exceed 100 characters.")]
+		public string Name { get; set; } = string.Empty;
+
+		[System.ComponentModel.DataAnnotations.Required(ErrorMessage = "Description is required.")]
+		[System.ComponentModel.DataAnnotations.MaxLength(500, ErrorMessage = "Description must not exceed 500 characters.")]
+		public string Description { get; set; } = string.Empty;
+	}
+}

--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -122,6 +122,10 @@ builder.Services.AddScoped<MongoDbBlogPostRepository>();
 builder.Services.AddScoped<IBlogPostRepository>(sp =>
 		sp.GetRequiredService<MongoDbBlogPostRepository>());
 
+builder.Services.AddScoped<MongoDbCategoryRepository>();
+builder.Services.AddScoped<ICategoryRepository>(sp =>
+		sp.GetRequiredService<MongoDbCategoryRepository>());
+
 // MediatR — scans Web assembly for all handlers
 builder.Services.AddMediatR(cfg =>
 {

--- a/tests/Domain.Tests/Entities/BlogPostCategoryTests.cs
+++ b/tests/Domain.Tests/Entities/BlogPostCategoryTests.cs
@@ -1,0 +1,127 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     BlogPostCategoryTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Domain.Tests
+//=======================================================
+
+namespace Tests.Domain.Entities;
+
+/// <summary>
+/// Tests for BlogPost behavior related to Issue #339 — Category assignment,
+/// author read-only immutability, and default (null) category on creation.
+/// </summary>
+public class BlogPostCategoryTests
+{
+	private static readonly PostAuthor TestAuthor = new("author-1", "Alice", "alice@example.com", ["Author"]);
+
+	// ── CategoryId default ────────────────────────────────────────────────
+
+	[Fact]
+	public void Create_NewPost_CategoryIdIsNullByDefault()
+	{
+		// Arrange / Act
+		var post = BlogPost.Create("My Title", "My Content", TestAuthor);
+
+		// Assert
+		post.CategoryId.Should().BeNull();
+	}
+
+	// ── AssignCategory ────────────────────────────────────────────────────
+
+	[Fact]
+	public void AssignCategory_SetsCategoryId()
+	{
+		// Arrange
+		var post = BlogPost.Create("Title", "Content", TestAuthor);
+		var categoryId = Guid.NewGuid();
+
+		// Act
+		post.AssignCategory(categoryId);
+
+		// Assert
+		post.CategoryId.Should().Be(categoryId);
+	}
+
+	[Fact]
+	public void AssignCategory_DoesNotAlterTitleContentOrAuthor()
+	{
+		// Arrange
+		var post = BlogPost.Create("Stable Title", "Stable Content", TestAuthor);
+		var categoryId = Guid.NewGuid();
+
+		// Act
+		post.AssignCategory(categoryId);
+
+		// Assert
+		post.Title.Should().Be("Stable Title");
+		post.Content.Should().Be("Stable Content");
+		post.Author.Name.Should().Be("Alice");
+	}
+
+	[Fact]
+	public void AssignCategory_CalledTwice_OverwritesWithLatestCategory()
+	{
+		// Arrange
+		var post = BlogPost.Create("Title", "Content", TestAuthor);
+		var firstCategoryId = Guid.NewGuid();
+		var secondCategoryId = Guid.NewGuid();
+
+		// Act
+		post.AssignCategory(firstCategoryId);
+		post.AssignCategory(secondCategoryId);
+
+		// Assert
+		post.CategoryId.Should().Be(secondCategoryId);
+	}
+
+	// ── RemoveCategory ────────────────────────────────────────────────────
+
+	[Fact]
+	public void RemoveCategory_SetsCategoryIdToNull()
+	{
+		// Arrange
+		var post = BlogPost.Create("Title", "Content", TestAuthor);
+		post.AssignCategory(Guid.NewGuid());
+
+		// Act
+		post.RemoveCategory();
+
+		// Assert
+		post.CategoryId.Should().BeNull();
+	}
+
+	// ── Author read-only contract (#339 AC: author read-only display) ─────
+
+	[Fact]
+	public void Update_DoesNotModifyAuthor_AuthorRemainsImmutableAfterUpdate()
+	{
+		// Arrange
+		var post = BlogPost.Create("Original Title", "Original Content", TestAuthor);
+
+		// Act
+		post.Update("New Title", "New Content");
+
+		// Assert
+		post.Author.Id.Should().Be("author-1");
+		post.Author.Name.Should().Be("Alice");
+		post.Author.Email.Should().Be("alice@example.com");
+	}
+
+	[Fact]
+	public void Update_AuthorIsSnapshotFromCreationTime_CannotBeChangedByUpdate()
+	{
+		// Arrange — two different authors
+		var originalAuthor = new PostAuthor("id-original", "Original Author", "orig@example.com", []);
+		var post = BlogPost.Create("Title", "Content", originalAuthor);
+
+		// Act — Update only accepts title and content; there is no author parameter
+		post.Update("New Title", "New Content");
+
+		// Assert — author is still the original snapshot
+		post.Author.Name.Should().Be("Original Author");
+		post.Author.Should().Be(originalAuthor);
+	}
+}

--- a/tests/Domain.Tests/Entities/CategoryTests.cs
+++ b/tests/Domain.Tests/Entities/CategoryTests.cs
@@ -1,0 +1,149 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     CategoryTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Domain.Tests
+//=======================================================
+
+namespace Tests.Domain.Entities;
+
+public class CategoryTests
+{
+	// ── Create ───────────────────────────────────────────────────────────────
+
+	[Fact]
+	public void Create_ValidNameAndDescription_ReturnsEntityWithCorrectFields()
+	{
+		// Arrange / Act
+		var category = Category.Create("Technology", "Posts about tech topics.");
+
+		// Assert
+		category.Name.Should().Be("Technology");
+		category.Description.Should().Be("Posts about tech topics.");
+	}
+
+	[Fact]
+	public void Create_ValidArguments_IdIsNonEmptyGuid()
+	{
+		// Arrange / Act
+		var category = Category.Create("Tech", "Description.");
+
+		// Assert
+		category.Id.Should().NotBeEmpty();
+	}
+
+	[Fact]
+	public void Create_TrimsWhitespacePadding_FromNameAndDescription()
+	{
+		// Arrange / Act
+		var category = Category.Create("  Tech  ", "  Some description.  ");
+
+		// Assert
+		category.Name.Should().Be("Tech");
+		category.Description.Should().Be("Some description.");
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void Create_NullOrWhiteSpaceName_ThrowsArgumentException(string? name)
+	{
+		// Arrange / Act
+		var act = () => Category.Create(name!, "Valid description.");
+
+		// Assert
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void Create_NullOrWhiteSpaceDescription_ThrowsArgumentException(string? description)
+	{
+		// Arrange / Act
+		var act = () => Category.Create("Tech", description!);
+
+		// Assert
+		act.Should().Throw<ArgumentException>();
+	}
+
+	// ── Update ───────────────────────────────────────────────────────────────
+
+	[Fact]
+	public void Update_ValidArguments_UpdatesNameAndDescription()
+	{
+		// Arrange
+		var category = Category.Create("Old Name", "Old description.");
+
+		// Act
+		category.Update("New Name", "New description.");
+
+		// Assert
+		category.Name.Should().Be("New Name");
+		category.Description.Should().Be("New description.");
+	}
+
+	[Fact]
+	public void Update_TrimsWhitespacePadding_FromNameAndDescription()
+	{
+		// Arrange
+		var category = Category.Create("Tech", "Initial.");
+
+		// Act
+		category.Update("  Updated Name  ", "  Updated description.  ");
+
+		// Assert
+		category.Name.Should().Be("Updated Name");
+		category.Description.Should().Be("Updated description.");
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void Update_NullOrWhiteSpaceName_ThrowsArgumentException(string? name)
+	{
+		// Arrange
+		var category = Category.Create("Tech", "Description.");
+
+		// Act
+		var act = () => category.Update(name!, "Valid description.");
+
+		// Assert
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void Update_NullOrWhiteSpaceDescription_ThrowsArgumentException(string? description)
+	{
+		// Arrange
+		var category = Category.Create("Tech", "Description.");
+
+		// Act
+		var act = () => category.Update("Tech", description!);
+
+		// Assert
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	public void Update_DoesNotAlterId_AfterUpdate()
+	{
+		// Arrange
+		var category = Category.Create("Tech", "Description.");
+		var originalId = category.Id;
+
+		// Act
+		category.Update("New Name", "New description.");
+
+		// Assert
+		category.Id.Should().Be(originalId);
+	}
+}

--- a/tests/Web.Tests.Bunit/Components/RazorSmokeTests.cs
+++ b/tests/Web.Tests.Bunit/Components/RazorSmokeTests.cs
@@ -148,7 +148,7 @@ public class RazorSmokeTests : BunitContext
 		var sender = Substitute.For<ISender>();
 		var posts = new[]
 		{
-						new BlogPostDto(Guid.NewGuid(), "First", "Content", string.Empty, "Alice", string.Empty, [], DateTime.UtcNow, null, false)
+						new BlogPostDto(Guid.NewGuid(), "First", "Content", string.Empty, "Alice", string.Empty, [], DateTime.UtcNow, null, false, null)
 				};
 
 		sender.Send(Arg.Any<GetBlogPostsQuery>(), Arg.Any<CancellationToken>())
@@ -177,7 +177,7 @@ public class RazorSmokeTests : BunitContext
 		var sender = Substitute.For<ISender>();
 		var posts = new[]
 		{
-						new BlogPostDto(Guid.NewGuid(), "First", "Content", string.Empty, "Alice", string.Empty, [], DateTime.UtcNow, null, false)
+						new BlogPostDto(Guid.NewGuid(), "First", "Content", string.Empty, "Alice", string.Empty, [], DateTime.UtcNow, null, false, null)
 				};
 
 		sender.Send(Arg.Any<GetBlogPostsQuery>(), Arg.Any<CancellationToken>())
@@ -202,7 +202,7 @@ public class RazorSmokeTests : BunitContext
 		var sender = Substitute.For<ISender>();
 		var posts = new[]
 		{
-						new BlogPostDto(Guid.NewGuid(), "First", "Content", string.Empty, "Alice", string.Empty, [], DateTime.UtcNow, null, false)
+						new BlogPostDto(Guid.NewGuid(), "First", "Content", string.Empty, "Alice", string.Empty, [], DateTime.UtcNow, null, false, null)
 				};
 
 		sender.Send(Arg.Any<GetBlogPostsQuery>(), Arg.Any<CancellationToken>())
@@ -264,7 +264,7 @@ public class RazorSmokeTests : BunitContext
 		var postId = Guid.NewGuid();
 		var posts = new[]
 		{
-						new BlogPostDto(postId, "First", "Content", string.Empty, "Alice", string.Empty, [], DateTime.UtcNow, null, false)
+						new BlogPostDto(postId, "First", "Content", string.Empty, "Alice", string.Empty, [], DateTime.UtcNow, null, false, null)
 				};
 
 		sender.Send(Arg.Any<GetBlogPostsQuery>(), Arg.Any<CancellationToken>())
@@ -295,7 +295,7 @@ public class RazorSmokeTests : BunitContext
 		var postId = Guid.NewGuid();
 		var posts = new[]
 		{
-						new BlogPostDto(postId, "First", "Content", string.Empty, "Alice", string.Empty, [], DateTime.UtcNow, null, false)
+						new BlogPostDto(postId, "First", "Content", string.Empty, "Alice", string.Empty, [], DateTime.UtcNow, null, false, null)
 				};
 
 		sender.Send(Arg.Any<GetBlogPostsQuery>(), Arg.Any<CancellationToken>())
@@ -423,7 +423,7 @@ public class RazorSmokeTests : BunitContext
 		// Arrange
 		var sender = Substitute.For<ISender>();
 		var postId = Guid.NewGuid();
-		var post = new BlogPostDto(postId, "Existing title", "Existing content", string.Empty, "Alice", string.Empty, [], DateTime.UtcNow, null, false);
+		var post = new BlogPostDto(postId, "Existing title", "Existing content", string.Empty, "Alice", string.Empty, [], DateTime.UtcNow, null, false, null);
 
 		sender.Send(Arg.Any<GetBlogPostByIdQuery>(), Arg.Any<CancellationToken>())
 				.Returns(Task.FromResult(Result.Ok<BlogPostDto?>(post)));
@@ -445,7 +445,7 @@ public class RazorSmokeTests : BunitContext
 		// Arrange
 		var sender = Substitute.For<ISender>();
 		var postId = Guid.NewGuid();
-		var post = new BlogPostDto(postId, "Test Post", "Some content", string.Empty, "Alice", string.Empty, [], DateTime.UtcNow, null, false);
+		var post = new BlogPostDto(postId, "Test Post", "Some content", string.Empty, "Alice", string.Empty, [], DateTime.UtcNow, null, false, null);
 
 		sender.Send(Arg.Any<GetBlogPostByIdQuery>(), Arg.Any<CancellationToken>())
 				.Returns(Task.FromResult(Result.Ok<BlogPostDto?>(post)));
@@ -466,7 +466,7 @@ public class RazorSmokeTests : BunitContext
 		// Arrange
 		var sender = Substitute.For<ISender>();
 		var postId = Guid.NewGuid();
-		var post = new BlogPostDto(postId, "Existing title", "Existing content", string.Empty, "Alice", string.Empty, [], DateTime.UtcNow, null, false);
+		var post = new BlogPostDto(postId, "Existing title", "Existing content", string.Empty, "Alice", string.Empty, [], DateTime.UtcNow, null, false, null);
 
 		sender.Send(Arg.Any<GetBlogPostByIdQuery>(), Arg.Any<CancellationToken>())
 				.Returns(Task.FromResult(Result.Ok<BlogPostDto?>(post)));
@@ -489,7 +489,7 @@ public class RazorSmokeTests : BunitContext
 		// Arrange
 		var sender = Substitute.For<ISender>();
 		var postId = Guid.NewGuid();
-		var post = new BlogPostDto(postId, "Existing title", "Existing content", string.Empty, "Alice", string.Empty, [], DateTime.UtcNow, null, false);
+		var post = new BlogPostDto(postId, "Existing title", "Existing content", string.Empty, "Alice", string.Empty, [], DateTime.UtcNow, null, false, null);
 
 		sender.Send(Arg.Any<GetBlogPostByIdQuery>(), Arg.Any<CancellationToken>())
 				.Returns(Task.FromResult(Result.Ok<BlogPostDto?>(post)));
@@ -513,7 +513,7 @@ public class RazorSmokeTests : BunitContext
 		// Arrange
 		var sender = Substitute.For<ISender>();
 		var postId = Guid.NewGuid();
-		var post = new BlogPostDto(postId, "Existing title", "Existing content", string.Empty, "Alice", string.Empty, [], DateTime.UtcNow, null, false);
+		var post = new BlogPostDto(postId, "Existing title", "Existing content", string.Empty, "Alice", string.Empty, [], DateTime.UtcNow, null, false, null);
 
 		sender.Send(Arg.Any<GetBlogPostByIdQuery>(), Arg.Any<CancellationToken>())
 				.Returns(Task.FromResult(Result.Ok<BlogPostDto?>(post)));

--- a/tests/Web.Tests.Bunit/Features/EditAclTests.cs
+++ b/tests/Web.Tests.Bunit/Features/EditAclTests.cs
@@ -65,7 +65,7 @@ public class EditAclTests : BunitContext
 		var postId = Guid.NewGuid();
 		const string OwnerSub = "auth0|owner-user";
 		const string NonOwnerSub = "auth0|other-user";
-		var post = new BlogPostDto(postId, "Test Post", "Content", OwnerSub, "Owner", string.Empty, [], DateTime.UtcNow, null, false);
+		var post = new BlogPostDto(postId, "Test Post", "Content", OwnerSub, "Owner", string.Empty, [], DateTime.UtcNow, null, false, null);
 
 		sender.Send(Arg.Any<GetBlogPostByIdQuery>(), Arg.Any<CancellationToken>())
 				.Returns(Task.FromResult(Result.Ok<BlogPostDto?>(post)));
@@ -90,7 +90,7 @@ public class EditAclTests : BunitContext
 		var sender = Substitute.For<ISender>();
 		var postId = Guid.NewGuid();
 		const string OwnerSub = "auth0|owner-user";
-		var post = new BlogPostDto(postId, "Test Post", "Content", OwnerSub, "Owner", string.Empty, [], DateTime.UtcNow, null, false);
+		var post = new BlogPostDto(postId, "Test Post", "Content", OwnerSub, "Owner", string.Empty, [], DateTime.UtcNow, null, false, null);
 
 		sender.Send(Arg.Any<GetBlogPostByIdQuery>(), Arg.Any<CancellationToken>())
 				.Returns(Task.FromResult(Result.Ok<BlogPostDto?>(post)));
@@ -116,7 +116,7 @@ public class EditAclTests : BunitContext
 		var sender = Substitute.For<ISender>();
 		var postId = Guid.NewGuid();
 		const string OwnerSub = "auth0|owner-user";
-		var post = new BlogPostDto(postId, "Test Post", "Content", OwnerSub, "Owner", string.Empty, [], DateTime.UtcNow, null, false);
+		var post = new BlogPostDto(postId, "Test Post", "Content", OwnerSub, "Owner", string.Empty, [], DateTime.UtcNow, null, false, null);
 
 		sender.Send(Arg.Any<GetBlogPostByIdQuery>(), Arg.Any<CancellationToken>())
 				.Returns(Task.FromResult(Result.Ok<BlogPostDto?>(post)));
@@ -149,7 +149,7 @@ public class EditAclTests : BunitContext
 		var postId = Guid.NewGuid();
 		const string OwnerSub = "auth0|some-author";
 		const string AdminSub = "auth0|admin-user";
-		var post = new BlogPostDto(postId, "Test Post", "Content", OwnerSub, "SomeAuthor", string.Empty, [], DateTime.UtcNow, null, false);
+		var post = new BlogPostDto(postId, "Test Post", "Content", OwnerSub, "SomeAuthor", string.Empty, [], DateTime.UtcNow, null, false, null);
 
 		sender.Send(Arg.Any<GetBlogPostByIdQuery>(), Arg.Any<CancellationToken>())
 				.Returns(Task.FromResult(Result.Ok<BlogPostDto?>(post)));
@@ -177,8 +177,8 @@ public class EditAclTests : BunitContext
 		var secondPostId = Guid.NewGuid();
 		const string OwnerSub = "auth0|owner-user";
 
-		var firstPost = new BlogPostDto(firstPostId, "First Post Title", "First Content", OwnerSub, "Owner", string.Empty, [], DateTime.UtcNow, null, false);
-		var secondPost = new BlogPostDto(secondPostId, "Second Post Title", "Second Content", OwnerSub, "Owner", string.Empty, [], DateTime.UtcNow, null, false);
+		var firstPost = new BlogPostDto(firstPostId, "First Post Title", "First Content", OwnerSub, "Owner", string.Empty, [], DateTime.UtcNow, null, false, null);
+		var secondPost = new BlogPostDto(secondPostId, "Second Post Title", "Second Content", OwnerSub, "Owner", string.Empty, [], DateTime.UtcNow, null, false, null);
 
 		sender.Send(Arg.Is<GetBlogPostByIdQuery>(q => q.Id == firstPostId), Arg.Any<CancellationToken>())
 				.Returns(Task.FromResult(Result.Ok<BlogPostDto?>(firstPost)));
@@ -213,7 +213,7 @@ public class EditAclTests : BunitContext
 		var secondPostId = Guid.NewGuid();
 		const string OwnerSub = "auth0|owner-user";
 
-		var firstPost = new BlogPostDto(firstPostId, "First Post Title", "First Content", OwnerSub, "Owner", string.Empty, [], DateTime.UtcNow, null, false);
+		var firstPost = new BlogPostDto(firstPostId, "First Post Title", "First Content", OwnerSub, "Owner", string.Empty, [], DateTime.UtcNow, null, false, null);
 
 		sender.Send(Arg.Is<GetBlogPostByIdQuery>(q => q.Id == firstPostId), Arg.Any<CancellationToken>())
 				.Returns(Task.FromResult(Result.Ok<BlogPostDto?>(firstPost)));
@@ -247,7 +247,7 @@ public class EditAclTests : BunitContext
 		var secondPostId = Guid.NewGuid();
 		const string OwnerSub = "auth0|owner-user";
 
-		var firstPost = new BlogPostDto(firstPostId, "First Post Title", "First Content", OwnerSub, "Owner", string.Empty, [], DateTime.UtcNow, null, false);
+		var firstPost = new BlogPostDto(firstPostId, "First Post Title", "First Content", OwnerSub, "Owner", string.Empty, [], DateTime.UtcNow, null, false, null);
 
 		sender.Send(Arg.Is<GetBlogPostByIdQuery>(q => q.Id == firstPostId), Arg.Any<CancellationToken>())
 				.Returns(Task.FromResult(Result.Ok<BlogPostDto?>(firstPost)));

--- a/tests/Web.Tests.Bunit/Features/MarkdownEditorLifecycleTests.cs
+++ b/tests/Web.Tests.Bunit/Features/MarkdownEditorLifecycleTests.cs
@@ -74,7 +74,7 @@ public class MarkdownEditorLifecycleTests : BunitContext
 		const string OwnerSub = "auth0|alice";
 		const string ExpectedContent = "# Sprint 19\n\nMarkdown content here.";
 
-		var post = new BlogPostDto(postId, "Sprint Post", ExpectedContent, OwnerSub, "Alice", string.Empty, [], DateTime.UtcNow, null, false);
+		var post = new BlogPostDto(postId, "Sprint Post", ExpectedContent, OwnerSub, "Alice", string.Empty, [], DateTime.UtcNow, null, false, null);
 
 		sender.Send(Arg.Any<GetBlogPostByIdQuery>(), Arg.Any<CancellationToken>())
 				.Returns(Task.FromResult(Result.Ok<BlogPostDto?>(post)));
@@ -116,7 +116,7 @@ public class MarkdownEditorLifecycleTests : BunitContext
 		var postId = Guid.NewGuid();
 		const string OwnerSub = "auth0|alice";
 
-		var post = new BlogPostDto(postId, "Some Post", "Some content", OwnerSub, "Alice", string.Empty, [], DateTime.UtcNow, null, false);
+		var post = new BlogPostDto(postId, "Some Post", "Some content", OwnerSub, "Alice", string.Empty, [], DateTime.UtcNow, null, false, null);
 
 		sender.Send(Arg.Any<GetBlogPostByIdQuery>(), Arg.Any<CancellationToken>())
 				.Returns(Task.FromResult(Result.Ok<BlogPostDto?>(post)));

--- a/tests/Web.Tests.Bunit/Features/RichTextEditorTests.cs
+++ b/tests/Web.Tests.Bunit/Features/RichTextEditorTests.cs
@@ -58,7 +58,7 @@ public class RichTextEditorTests : BunitContext
 		// Arrange
 		var sender = Substitute.For<ISender>();
 		var postId = Guid.NewGuid();
-		var post = new BlogPostDto(postId, "Test title", "<p>Test content</p>", string.Empty, "Alice", string.Empty, [], DateTime.UtcNow, null, false);
+		var post = new BlogPostDto(postId, "Test title", "<p>Test content</p>", string.Empty, "Alice", string.Empty, [], DateTime.UtcNow, null, false, null);
 
 		sender.Send(Arg.Any<GetBlogPostByIdQuery>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(Result.Ok<BlogPostDto?>(post)));

--- a/tests/Web.Tests.Integration/Caching/BlogPostCacheServiceTests.cs
+++ b/tests/Web.Tests.Integration/Caching/BlogPostCacheServiceTests.cs
@@ -17,7 +17,7 @@ public sealed class BlogPostCacheServiceTests(RedisFixture fixture)
 	// ------------------------------------------------------------------ helpers
 
 	private static BlogPostDto MakeDto(string title = "Test Post") =>
-		new(Guid.NewGuid(), title, "Content", string.Empty, "Author", string.Empty, [], DateTime.UtcNow, null, true);
+		new(Guid.NewGuid(), title, "Content", string.Empty, "Author", string.Empty, [], DateTime.UtcNow, null, true, null);
 
 	// ------------------------------------------------------------------ tests
 

--- a/tests/Web.Tests.Integration/Categories/MongoDbBlogPostCategoryTests.cs
+++ b/tests/Web.Tests.Integration/Categories/MongoDbBlogPostCategoryTests.cs
@@ -1,0 +1,100 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     MongoDbBlogPostCategoryTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web.Tests.Integration
+//=======================================================
+
+using Web.Infrastructure;
+
+namespace Web.Categories;
+
+/// <summary>
+/// Integration tests for the Category-related methods on IBlogPostRepository:
+/// ExistsByCategoryAsync — used by DeleteCategoryHandler to enforce the
+/// "cannot delete category in use" acceptance criterion.
+/// </summary>
+[Collection("CategoryIntegration")]
+public sealed class MongoDbBlogPostCategoryTests(MongoDbFixture fixture)
+{
+	private MongoDbBlogPostRepository CreateBlogPostRepo(string dbName) =>
+		new(fixture.CreateFactory(dbName));
+
+	private static readonly PostAuthor Author =
+		new(string.Empty, "Test Author", string.Empty, []);
+
+	[Fact]
+	public async Task ExistsByCategoryAsync_ReturnsTrueWhenPostAssignedToCategory()
+	{
+		// Arrange — AC: cannot delete category in use
+		var ct = TestContext.Current.CancellationToken;
+		var dbName = $"T{Guid.NewGuid():N}";
+		var repo = CreateBlogPostRepo(dbName);
+		var categoryId = Guid.NewGuid();
+		var post = BlogPost.Create("Hello World", "Content", Author);
+		post.AssignCategory(categoryId);
+		await repo.AddAsync(post, ct);
+
+		// Act
+		var exists = await repo.ExistsByCategoryAsync(categoryId, ct);
+
+		// Assert
+		exists.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task ExistsByCategoryAsync_ReturnsFalseWhenNoCategoryAssigned()
+	{
+		// Arrange
+		var ct = TestContext.Current.CancellationToken;
+		var dbName = $"T{Guid.NewGuid():N}";
+		var repo = CreateBlogPostRepo(dbName);
+		var categoryId = Guid.NewGuid();
+		var post = BlogPost.Create("Hello World", "Content", Author);
+		// No AssignCategory call — CategoryId is null
+		await repo.AddAsync(post, ct);
+
+		// Act
+		var exists = await repo.ExistsByCategoryAsync(categoryId, ct);
+
+		// Assert
+		exists.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task ExistsByCategoryAsync_ReturnsFalseWhenRepositoryEmpty()
+	{
+		// Arrange
+		var ct = TestContext.Current.CancellationToken;
+		var repo = CreateBlogPostRepo($"T{Guid.NewGuid():N}");
+
+		// Act
+		var exists = await repo.ExistsByCategoryAsync(Guid.NewGuid(), ct);
+
+		// Assert
+		exists.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task ExistsByCategoryAsync_ReturnsFalseAfterCategoryRemoved()
+	{
+		// Arrange — post had category, then category was removed
+		var ct = TestContext.Current.CancellationToken;
+		var dbName = $"T{Guid.NewGuid():N}";
+		var repo = CreateBlogPostRepo(dbName);
+		var categoryId = Guid.NewGuid();
+		var post = BlogPost.Create("Post", "Content", Author);
+		post.AssignCategory(categoryId);
+		await repo.AddAsync(post, ct);
+		post.RemoveCategory();
+		await repo.UpdateAsync(post, ct);
+
+		// Act
+		var exists = await repo.ExistsByCategoryAsync(categoryId, ct);
+
+		// Assert
+		exists.Should().BeFalse();
+	}
+}

--- a/tests/Web.Tests.Integration/Categories/MongoDbCategoryRepositoryTests.cs
+++ b/tests/Web.Tests.Integration/Categories/MongoDbCategoryRepositoryTests.cs
@@ -1,0 +1,244 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     MongoDbCategoryRepositoryTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web.Tests.Integration
+//=======================================================
+
+using Web.Infrastructure;
+
+namespace Web.Categories;
+
+[Collection("CategoryIntegration")]
+public sealed class MongoDbCategoryRepositoryTests(MongoDbFixture fixture)
+{
+	private MongoDbCategoryRepository CreateRepo(string? dbName = null) =>
+		new(fixture.CreateFactory(dbName ?? $"T{Guid.NewGuid():N}"));
+
+	// ── AddAsync / GetAllAsync ────────────────────────────────────────────
+
+	[Fact]
+	public async Task AddAsync_PersistsCategoryToMongoDB()
+	{
+		// Arrange
+		var ct = TestContext.Current.CancellationToken;
+		var repo = CreateRepo();
+		var category = Category.Create("Technology", "Posts about technology.");
+
+		// Act
+		await repo.AddAsync(category, ct);
+
+		// Assert
+		var all = await repo.GetAllAsync(ct);
+		all.Should().HaveCount(1);
+		all[0].Id.Should().Be(category.Id);
+		all[0].Name.Should().Be("Technology");
+		all[0].Description.Should().Be("Posts about technology.");
+	}
+
+	[Fact]
+	public async Task GetAllAsync_ReturnsEmptyWhenNoCategories()
+	{
+		// Arrange
+		var ct = TestContext.Current.CancellationToken;
+		var repo = CreateRepo();
+
+		// Act
+		var all = await repo.GetAllAsync(ct);
+
+		// Assert
+		all.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task GetAllAsync_ReturnsOrderedAlphabeticallyByName()
+	{
+		// Arrange
+		var ct = TestContext.Current.CancellationToken;
+		var repo = CreateRepo();
+		await repo.AddAsync(Category.Create("Zebra", "Z description."), ct);
+		await repo.AddAsync(Category.Create("Alpha", "A description."), ct);
+		await repo.AddAsync(Category.Create("Middle", "M description."), ct);
+
+		// Act
+		var all = await repo.GetAllAsync(ct);
+
+		// Assert — categories returned alphabetically ascending
+		all.Should().HaveCount(3);
+		all[0].Name.Should().Be("Alpha");
+		all[1].Name.Should().Be("Middle");
+		all[2].Name.Should().Be("Zebra");
+	}
+
+	// ── GetByIdAsync ──────────────────────────────────────────────────────
+
+	[Fact]
+	public async Task GetByIdAsync_ReturnsNullWhenNotFound()
+	{
+		// Arrange
+		var ct = TestContext.Current.CancellationToken;
+		var repo = CreateRepo();
+
+		// Act
+		var result = await repo.GetByIdAsync(Guid.NewGuid(), ct);
+
+		// Assert
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task GetByIdAsync_ReturnsCategoryWhenFound()
+	{
+		// Arrange
+		var ct = TestContext.Current.CancellationToken;
+		var repo = CreateRepo();
+		var category = Category.Create("Design", "Design and UX posts.");
+		await repo.AddAsync(category, ct);
+
+		// Act
+		var result = await repo.GetByIdAsync(category.Id, ct);
+
+		// Assert
+		result.Should().NotBeNull();
+		result!.Name.Should().Be("Design");
+		result.Description.Should().Be("Design and UX posts.");
+	}
+
+	// ── UpdateAsync ───────────────────────────────────────────────────────
+
+	[Fact]
+	public async Task UpdateAsync_ModifiesCategoryInMongoDB()
+	{
+		// Arrange
+		var ct = TestContext.Current.CancellationToken;
+		var repo = CreateRepo();
+		var category = Category.Create("Old Name", "Old description.");
+		await repo.AddAsync(category, ct);
+		category.Update("New Name", "New description.");
+
+		// Act
+		await repo.UpdateAsync(category, ct);
+
+		// Assert
+		var result = await repo.GetByIdAsync(category.Id, ct);
+		result!.Name.Should().Be("New Name");
+		result.Description.Should().Be("New description.");
+	}
+
+	// ── DeleteAsync ───────────────────────────────────────────────────────
+
+	[Fact]
+	public async Task DeleteAsync_RemovesCategoryFromMongoDB()
+	{
+		// Arrange
+		var ct = TestContext.Current.CancellationToken;
+		var repo = CreateRepo();
+		var category = Category.Create("ToDelete", "Will be removed.");
+		await repo.AddAsync(category, ct);
+
+		// Act
+		await repo.DeleteAsync(category.Id, ct);
+
+		// Assert
+		var all = await repo.GetAllAsync(ct);
+		all.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task DeleteAsync_DoesNothingWhenCategoryNotFound()
+	{
+		// Arrange
+		var ct = TestContext.Current.CancellationToken;
+		var repo = CreateRepo();
+
+		// Act
+		var act = async () => await repo.DeleteAsync(Guid.NewGuid(), ct);
+
+		// Assert
+		await act.Should().NotThrowAsync();
+	}
+
+	// ── ExistsByNameAsync (unique name constraint) ────────────────────────
+
+	[Fact]
+	public async Task ExistsByNameAsync_ReturnsTrueWhenNameExists()
+	{
+		// Arrange — AC: unique category name
+		var ct = TestContext.Current.CancellationToken;
+		var repo = CreateRepo();
+		await repo.AddAsync(Category.Create("Technology", "Tech."), ct);
+
+		// Act
+		var exists = await repo.ExistsByNameAsync("Technology", ct);
+
+		// Assert
+		exists.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task ExistsByNameAsync_ReturnsFalseWhenNameNotFound()
+	{
+		// Arrange
+		var ct = TestContext.Current.CancellationToken;
+		var repo = CreateRepo();
+
+		// Act
+		var exists = await repo.ExistsByNameAsync("NonExistent", ct);
+
+		// Assert
+		exists.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task ExistsByNameAsync_IsCaseInsensitiveToTrimming()
+	{
+		// Arrange — repository normalizes with Trim()
+		var ct = TestContext.Current.CancellationToken;
+		var repo = CreateRepo();
+		await repo.AddAsync(Category.Create("Technology", "Tech."), ct);
+
+		// Act — name with padding should still match after trim
+		var exists = await repo.ExistsByNameAsync("  Technology  ", ct);
+
+		// Assert
+		exists.Should().BeTrue();
+	}
+
+	// ── ExistsByNameExcludingAsync (update uniqueness check) ─────────────
+
+	[Fact]
+	public async Task ExistsByNameExcludingAsync_ReturnsTrueWhenAnotherCategoryHasSameName()
+	{
+		// Arrange — AC: unique category name on update
+		var ct = TestContext.Current.CancellationToken;
+		var repo = CreateRepo();
+		var existing = Category.Create("Technology", "Tech.");
+		var updating = Category.Create("Design", "Design.");
+		await repo.AddAsync(existing, ct);
+		await repo.AddAsync(updating, ct);
+
+		// Act — check if "Technology" exists excluding the "updating" category
+		var exists = await repo.ExistsByNameExcludingAsync("Technology", updating.Id, ct);
+
+		// Assert
+		exists.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task ExistsByNameExcludingAsync_ReturnsFalseWhenOnlyMatchIsExcludedCategory()
+	{
+		// Arrange — same category is editing its own name (should be allowed)
+		var ct = TestContext.Current.CancellationToken;
+		var repo = CreateRepo();
+		var category = Category.Create("Technology", "Tech.");
+		await repo.AddAsync(category, ct);
+
+		// Act — exclude the same category; "Technology" only belongs to it
+		var exists = await repo.ExistsByNameExcludingAsync("Technology", category.Id, ct);
+
+		// Assert
+		exists.Should().BeFalse();
+	}
+}

--- a/tests/Web.Tests.Integration/Infrastructure/CategoryIntegrationCollection.cs
+++ b/tests/Web.Tests.Integration/Infrastructure/CategoryIntegrationCollection.cs
@@ -1,0 +1,16 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     CategoryIntegrationCollection.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web.Tests.Integration
+//=======================================================
+
+namespace Web.Infrastructure;
+
+[CollectionDefinition("CategoryIntegration")]
+public sealed class CategoryIntegrationCollection
+	: ICollectionFixture<MongoDbFixture>
+{
+}

--- a/tests/Web.Tests.Integration/Infrastructure/MongoDbFixture.cs
+++ b/tests/Web.Tests.Integration/Infrastructure/MongoDbFixture.cs
@@ -7,6 +7,8 @@
 //Project Name :  Web.Tests.Integration
 //=======================================================
 
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
 using Testcontainers.MongoDb;
 
 namespace Web.Infrastructure;
@@ -37,13 +39,13 @@ public sealed class MongoDbFixture : IAsyncLifetime
 	private sealed class TestContextFactory(string connectionString, string dbName)
 		: IDbContextFactory<BlogDbContext>
 	{
-		public BlogDbContext CreateDbContext()
-		{
-			var options = new DbContextOptionsBuilder<BlogDbContext>()
+		private readonly DbContextOptions<BlogDbContext> _options =
+			new DbContextOptionsBuilder<BlogDbContext>()
 				.UseMongoDB(connectionString, dbName)
+				.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
 				.Options;
-			return new BlogDbContext(options);
-		}
+
+		public BlogDbContext CreateDbContext() => new(_options);
 
 		public Task<BlogDbContext> CreateDbContextAsync(CancellationToken ct = default) =>
 			Task.FromResult(CreateDbContext());

--- a/tests/Web.Tests/Features/Categories/Commands/CreateCategoryCommandValidatorTests.cs
+++ b/tests/Web.Tests/Features/Categories/Commands/CreateCategoryCommandValidatorTests.cs
@@ -1,0 +1,158 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     CreateCategoryCommandValidatorTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web.Tests
+//=======================================================
+
+using MyBlog.Web.Features.Categories.Create;
+
+namespace Web.Features.Categories.Commands;
+
+public class CreateCategoryCommandValidatorTests
+{
+	private readonly CreateCategoryCommandValidator _sut = new();
+
+	[Fact]
+	public void Validate_ValidCommand_ReturnsNoErrors()
+	{
+		// Arrange
+		var command = new CreateCategoryCommand("Technology", "Posts about technology topics.");
+
+		// Act
+		var result = _sut.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+	}
+
+	[Theory]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void Validate_EmptyOrWhitespaceName_ReturnsNameError(string name)
+	{
+		// Arrange
+		var command = new CreateCategoryCommand(name, "Valid description.");
+
+		// Act
+		var result = _sut.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Name");
+	}
+
+	[Theory]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void Validate_EmptyOrWhitespaceDescription_ReturnsDescriptionError(string description)
+	{
+		// Arrange
+		var command = new CreateCategoryCommand("Tech", description);
+
+		// Act
+		var result = _sut.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Description");
+	}
+
+	[Fact]
+	public void Validate_NameExceedsMaxLength_ReturnsNameError()
+	{
+		// Arrange
+		var command = new CreateCategoryCommand(new string('A', 101), "Valid description.");
+
+		// Act
+		var result = _sut.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().ContainSingle(e => e.PropertyName == "Name");
+	}
+
+	[Fact]
+	public void Validate_NameAtMaxLength_ReturnsNoErrors()
+	{
+		// Arrange
+		var command = new CreateCategoryCommand(new string('A', 100), "Valid description.");
+
+		// Act
+		var result = _sut.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+	}
+
+	[Fact]
+	public void Validate_DescriptionExceedsMaxLength_ReturnsDescriptionError()
+	{
+		// Arrange
+		var command = new CreateCategoryCommand("Tech", new string('A', 501));
+
+		// Act
+		var result = _sut.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().ContainSingle(e => e.PropertyName == "Description");
+	}
+
+	[Fact]
+	public void Validate_DescriptionAtMaxLength_ReturnsNoErrors()
+	{
+		// Arrange
+		var command = new CreateCategoryCommand("Tech", new string('A', 500));
+
+		// Act
+		var result = _sut.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+	}
+
+	[Fact]
+	public void Validate_BothFieldsEmpty_ReturnsTwoErrors()
+	{
+		// Arrange
+		var command = new CreateCategoryCommand("", "");
+
+		// Act
+		var result = _sut.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().HaveCountGreaterThan(1);
+	}
+
+	[Fact]
+	public void Validate_NameRequired_ErrorMessageIsCorrect()
+	{
+		// Arrange
+		var command = new CreateCategoryCommand("", "Valid description.");
+
+		// Act
+		var result = _sut.Validate(command);
+
+		// Assert
+		result.Errors.Should().Contain(e =>
+			e.PropertyName == "Name" && e.ErrorMessage == "Name is required.");
+	}
+
+	[Fact]
+	public void Validate_DescriptionRequired_ErrorMessageIsCorrect()
+	{
+		// Arrange
+		var command = new CreateCategoryCommand("Tech", "");
+
+		// Act
+		var result = _sut.Validate(command);
+
+		// Assert
+		result.Errors.Should().Contain(e =>
+			e.PropertyName == "Description" && e.ErrorMessage == "Description is required.");
+	}
+}

--- a/tests/Web.Tests/Features/Categories/Commands/DeleteCategoryCommandValidatorTests.cs
+++ b/tests/Web.Tests/Features/Categories/Commands/DeleteCategoryCommandValidatorTests.cs
@@ -1,0 +1,37 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     DeleteCategoryCommandValidatorTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web.Tests
+//=======================================================
+
+// Staged #339 — awaiting DeleteCategoryCommand + DeleteCategoryCommandValidator from Sam.
+// Remove [Skip] attributes and reference types once the Delete slice lands.
+
+namespace Web.Features.Categories.Commands;
+
+public class DeleteCategoryCommandValidatorTests
+{
+	// ── Staged: validator for Delete command ─────────────────────────────
+	// Unblock once MyBlog.Web.Features.Categories.Delete types are committed.
+
+	[Fact(Skip = "Staged #339: awaiting DeleteCategoryCommand + DeleteCategoryCommandValidator")]
+	public void Validate_ValidId_ReturnsNoErrors()
+	{
+		// Will verify: DeleteCategoryCommand(Guid.NewGuid()) → IsValid == true
+	}
+
+	[Fact(Skip = "Staged #339: awaiting DeleteCategoryCommand + DeleteCategoryCommandValidator")]
+	public void Validate_EmptyGuid_ReturnsIdError()
+	{
+		// Will verify: DeleteCategoryCommand(Guid.Empty) → IsValid == false, error on "Id"
+	}
+
+	[Fact(Skip = "Staged #339: awaiting DeleteCategoryCommand + DeleteCategoryCommandValidator")]
+	public void Validate_EmptyGuid_ReturnsRequiredMessage()
+	{
+		// Will verify: error message is "Id is required."
+	}
+}

--- a/tests/Web.Tests/Features/Categories/Commands/DeleteCategoryCommandValidatorTests.cs
+++ b/tests/Web.Tests/Features/Categories/Commands/DeleteCategoryCommandValidatorTests.cs
@@ -7,31 +7,51 @@
 //Project Name :  Web.Tests
 //=======================================================
 
-// Staged #339 — awaiting DeleteCategoryCommand + DeleteCategoryCommandValidator from Sam.
-// Remove [Skip] attributes and reference types once the Delete slice lands.
+using MyBlog.Web.Features.Categories.Delete;
 
 namespace Web.Features.Categories.Commands;
 
 public class DeleteCategoryCommandValidatorTests
 {
-	// ── Staged: validator for Delete command ─────────────────────────────
-	// Unblock once MyBlog.Web.Features.Categories.Delete types are committed.
+	private readonly DeleteCategoryCommandValidator _validator = new();
 
-	[Fact(Skip = "Staged #339: awaiting DeleteCategoryCommand + DeleteCategoryCommandValidator")]
+	[Fact]
 	public void Validate_ValidId_ReturnsNoErrors()
 	{
-		// Will verify: DeleteCategoryCommand(Guid.NewGuid()) → IsValid == true
+		// Arrange
+		var command = new DeleteCategoryCommand(Guid.NewGuid());
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
 	}
 
-	[Fact(Skip = "Staged #339: awaiting DeleteCategoryCommand + DeleteCategoryCommandValidator")]
+	[Fact]
 	public void Validate_EmptyGuid_ReturnsIdError()
 	{
-		// Will verify: DeleteCategoryCommand(Guid.Empty) → IsValid == false, error on "Id"
+		// Arrange
+		var command = new DeleteCategoryCommand(Guid.Empty);
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Id");
 	}
 
-	[Fact(Skip = "Staged #339: awaiting DeleteCategoryCommand + DeleteCategoryCommandValidator")]
+	[Fact]
 	public void Validate_EmptyGuid_ReturnsRequiredMessage()
 	{
-		// Will verify: error message is "Id is required."
+		// Arrange
+		var command = new DeleteCategoryCommand(Guid.Empty);
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.Errors.Should().Contain(e => e.ErrorMessage == "Id is required.");
 	}
 }

--- a/tests/Web.Tests/Features/Categories/Commands/UpdateCategoryCommandValidatorTests.cs
+++ b/tests/Web.Tests/Features/Categories/Commands/UpdateCategoryCommandValidatorTests.cs
@@ -7,49 +7,98 @@
 //Project Name :  Web.Tests
 //=======================================================
 
-// Staged #339 — awaiting UpdateCategoryCommand + UpdateCategoryCommandValidator from Sam.
-// Remove [Skip] attributes and reference types once the Edit slice lands.
+using MyBlog.Web.Features.Categories.Edit;
 
 namespace Web.Features.Categories.Commands;
 
 public class UpdateCategoryCommandValidatorTests
 {
-	// ── Staged: validator for Update command ─────────────────────────────
-	// Unblock once MyBlog.Web.Features.Categories.Edit types are committed.
+	private readonly EditCategoryCommandValidator _validator = new();
 
-	[Fact(Skip = "Staged #339: awaiting UpdateCategoryCommand + UpdateCategoryCommandValidator")]
+	[Fact]
 	public void Validate_ValidCommand_ReturnsNoErrors()
 	{
-		// Will verify: UpdateCategoryCommand(Guid.NewGuid(), "Tech", "Description.") → IsValid == true
+		// Arrange
+		var command = new EditCategoryCommand(Guid.NewGuid(), "Technology", "All about tech.");
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
 	}
 
-	[Fact(Skip = "Staged #339: awaiting UpdateCategoryCommand + UpdateCategoryCommandValidator")]
+	[Fact]
 	public void Validate_EmptyId_ReturnsIdError()
 	{
-		// Will verify: UpdateCategoryCommand(Guid.Empty, "Tech", "Desc.") → error on "Id"
+		// Arrange
+		var command = new EditCategoryCommand(Guid.Empty, "Technology", "All about tech.");
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Id");
 	}
 
-	[Fact(Skip = "Staged #339: awaiting UpdateCategoryCommand + UpdateCategoryCommandValidator")]
+	[Fact]
 	public void Validate_EmptyName_ReturnsNameError()
 	{
-		// Will verify: UpdateCategoryCommand(id, "", "Desc.") → error on "Name"
+		// Arrange
+		var command = new EditCategoryCommand(Guid.NewGuid(), "", "All about tech.");
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Name");
 	}
 
-	[Fact(Skip = "Staged #339: awaiting UpdateCategoryCommand + UpdateCategoryCommandValidator")]
+	[Fact]
 	public void Validate_EmptyDescription_ReturnsDescriptionError()
 	{
-		// Will verify: UpdateCategoryCommand(id, "Tech", "") → error on "Description"
+		// Arrange
+		var command = new EditCategoryCommand(Guid.NewGuid(), "Technology", "");
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Description");
 	}
 
-	[Fact(Skip = "Staged #339: awaiting UpdateCategoryCommand + UpdateCategoryCommandValidator")]
+	[Fact]
 	public void Validate_NameExceedsMaxLength_ReturnsNameError()
 	{
-		// Will verify: name > 100 chars → error on "Name"
+		// Arrange
+		var longName = new string('x', 101);
+		var command = new EditCategoryCommand(Guid.NewGuid(), longName, "All about tech.");
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Name"
+			&& e.ErrorMessage == "Name must not exceed 100 characters.");
 	}
 
-	[Fact(Skip = "Staged #339: awaiting UpdateCategoryCommand + UpdateCategoryCommandValidator")]
+	[Fact]
 	public void Validate_DescriptionExceedsMaxLength_ReturnsDescriptionError()
 	{
-		// Will verify: description > 500 chars → error on "Description"
+		// Arrange
+		var longDesc = new string('x', 501);
+		var command = new EditCategoryCommand(Guid.NewGuid(), "Technology", longDesc);
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Description"
+			&& e.ErrorMessage == "Description must not exceed 500 characters.");
 	}
 }

--- a/tests/Web.Tests/Features/Categories/Commands/UpdateCategoryCommandValidatorTests.cs
+++ b/tests/Web.Tests/Features/Categories/Commands/UpdateCategoryCommandValidatorTests.cs
@@ -1,0 +1,55 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     UpdateCategoryCommandValidatorTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web.Tests
+//=======================================================
+
+// Staged #339 — awaiting UpdateCategoryCommand + UpdateCategoryCommandValidator from Sam.
+// Remove [Skip] attributes and reference types once the Edit slice lands.
+
+namespace Web.Features.Categories.Commands;
+
+public class UpdateCategoryCommandValidatorTests
+{
+	// ── Staged: validator for Update command ─────────────────────────────
+	// Unblock once MyBlog.Web.Features.Categories.Edit types are committed.
+
+	[Fact(Skip = "Staged #339: awaiting UpdateCategoryCommand + UpdateCategoryCommandValidator")]
+	public void Validate_ValidCommand_ReturnsNoErrors()
+	{
+		// Will verify: UpdateCategoryCommand(Guid.NewGuid(), "Tech", "Description.") → IsValid == true
+	}
+
+	[Fact(Skip = "Staged #339: awaiting UpdateCategoryCommand + UpdateCategoryCommandValidator")]
+	public void Validate_EmptyId_ReturnsIdError()
+	{
+		// Will verify: UpdateCategoryCommand(Guid.Empty, "Tech", "Desc.") → error on "Id"
+	}
+
+	[Fact(Skip = "Staged #339: awaiting UpdateCategoryCommand + UpdateCategoryCommandValidator")]
+	public void Validate_EmptyName_ReturnsNameError()
+	{
+		// Will verify: UpdateCategoryCommand(id, "", "Desc.") → error on "Name"
+	}
+
+	[Fact(Skip = "Staged #339: awaiting UpdateCategoryCommand + UpdateCategoryCommandValidator")]
+	public void Validate_EmptyDescription_ReturnsDescriptionError()
+	{
+		// Will verify: UpdateCategoryCommand(id, "Tech", "") → error on "Description"
+	}
+
+	[Fact(Skip = "Staged #339: awaiting UpdateCategoryCommand + UpdateCategoryCommandValidator")]
+	public void Validate_NameExceedsMaxLength_ReturnsNameError()
+	{
+		// Will verify: name > 100 chars → error on "Name"
+	}
+
+	[Fact(Skip = "Staged #339: awaiting UpdateCategoryCommand + UpdateCategoryCommandValidator")]
+	public void Validate_DescriptionExceedsMaxLength_ReturnsDescriptionError()
+	{
+		// Will verify: description > 500 chars → error on "Description"
+	}
+}

--- a/tests/Web.Tests/Features/Categories/Handlers/CreateCategoryHandlerTests.cs
+++ b/tests/Web.Tests/Features/Categories/Handlers/CreateCategoryHandlerTests.cs
@@ -1,0 +1,47 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     CreateCategoryHandlerTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web.Tests
+//=======================================================
+
+// Staged #339 — awaiting CreateCategoryHandler from Sam.
+// Remove [Skip] attributes and uncomment handler construction once the handler lands.
+
+namespace Web.Features.Categories.Handlers;
+
+public class CreateCategoryHandlerTests
+{
+	// ── Staged: CreateCategoryHandler ────────────────────────────────────
+
+	[Fact(Skip = "Staged #339: awaiting CreateCategoryHandler")]
+	public async Task Handle_ValidCommand_PersistsAndReturnsNewId()
+	{
+		// Will verify: CreateCategoryCommand("Tech", "Description.") → Success, Value is non-empty Guid
+		await Task.CompletedTask;
+	}
+
+	[Fact(Skip = "Staged #339: awaiting CreateCategoryHandler")]
+	public async Task Handle_DuplicateName_ReturnsConflictFailResult()
+	{
+		// Will verify: when ICategoryRepository.ExistsByNameAsync returns true
+		// → Result.Failure with ResultErrorCode.Conflict
+		await Task.CompletedTask;
+	}
+
+	[Fact(Skip = "Staged #339: awaiting CreateCategoryHandler")]
+	public async Task Handle_RepoThrows_ReturnsFailResult()
+	{
+		// Will verify: repo.AddAsync throws → handler catches, returns failure
+		await Task.CompletedTask;
+	}
+
+	[Fact(Skip = "Staged #339: awaiting CreateCategoryHandler")]
+	public async Task Handle_OperationCanceled_Rethrows()
+	{
+		// Will verify: OperationCanceledException propagates
+		await Task.CompletedTask;
+	}
+}

--- a/tests/Web.Tests/Features/Categories/Handlers/CreateCategoryHandlerTests.cs
+++ b/tests/Web.Tests/Features/Categories/Handlers/CreateCategoryHandlerTests.cs
@@ -7,41 +7,90 @@
 //Project Name :  Web.Tests
 //=======================================================
 
-// Staged #339 — awaiting CreateCategoryHandler from Sam.
-// Remove [Skip] attributes and uncomment handler construction once the handler lands.
+using MyBlog.Domain.Abstractions;
+using MyBlog.Domain.Interfaces;
+using MyBlog.Web.Features.Categories.Create;
 
 namespace Web.Features.Categories.Handlers;
 
 public class CreateCategoryHandlerTests
 {
-	// ── Staged: CreateCategoryHandler ────────────────────────────────────
+	private readonly ICategoryRepository _repo = Substitute.For<ICategoryRepository>();
+	private readonly CreateCategoryHandler _handler;
 
-	[Fact(Skip = "Staged #339: awaiting CreateCategoryHandler")]
+	public CreateCategoryHandlerTests()
+	{
+		_handler = new CreateCategoryHandler(_repo);
+	}
+
+	[Fact]
 	public async Task Handle_ValidCommand_PersistsAndReturnsNewId()
 	{
-		// Will verify: CreateCategoryCommand("Tech", "Description.") → Success, Value is non-empty Guid
-		await Task.CompletedTask;
+		// Arrange
+		_repo.ExistsByNameAsync("Technology", Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var command = new CreateCategoryCommand("Technology", "All about tech.");
+
+		// Act
+		var result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().NotBeEmpty();
+		await _repo.Received(1).AddAsync(Arg.Any<Category>(), Arg.Any<CancellationToken>());
 	}
 
-	[Fact(Skip = "Staged #339: awaiting CreateCategoryHandler")]
+	[Fact]
 	public async Task Handle_DuplicateName_ReturnsConflictFailResult()
 	{
-		// Will verify: when ICategoryRepository.ExistsByNameAsync returns true
-		// → Result.Failure with ResultErrorCode.Conflict
-		await Task.CompletedTask;
+		// Arrange
+		_repo.ExistsByNameAsync("Technology", Arg.Any<CancellationToken>())
+			.Returns(true);
+
+		var command = new CreateCategoryCommand("Technology", "All about tech.");
+
+		// Act
+		var result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.ErrorCode.Should().Be(ResultErrorCode.Conflict);
+		result.Error.Should().Contain("Technology");
 	}
 
-	[Fact(Skip = "Staged #339: awaiting CreateCategoryHandler")]
+	[Fact]
 	public async Task Handle_RepoThrows_ReturnsFailResult()
 	{
-		// Will verify: repo.AddAsync throws → handler catches, returns failure
-		await Task.CompletedTask;
+		// Arrange
+		_repo.ExistsByNameAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+		_repo.AddAsync(Arg.Any<Category>(), Arg.Any<CancellationToken>())
+			.ThrowsAsync(new InvalidOperationException("db error"));
+
+		var command = new CreateCategoryCommand("Technology", "All about tech.");
+
+		// Act
+		var result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain("db error");
 	}
 
-	[Fact(Skip = "Staged #339: awaiting CreateCategoryHandler")]
+	[Fact]
 	public async Task Handle_OperationCanceled_Rethrows()
 	{
-		// Will verify: OperationCanceledException propagates
-		await Task.CompletedTask;
+		// Arrange
+		_repo.ExistsByNameAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+			.ThrowsAsync(new OperationCanceledException());
+
+		var command = new CreateCategoryCommand("Technology", "All about tech.");
+
+		// Act
+		Func<Task> act = () => _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<OperationCanceledException>();
 	}
 }

--- a/tests/Web.Tests/Features/Categories/Handlers/DeleteCategoryHandlerTests.cs
+++ b/tests/Web.Tests/Features/Categories/Handlers/DeleteCategoryHandlerTests.cs
@@ -7,51 +7,120 @@
 //Project Name :  Web.Tests
 //=======================================================
 
-// Staged #339 — awaiting DeleteCategoryHandler from Sam.
-// This handler MUST check IBlogPostRepository.ExistsByCategoryAsync before deleting
-// and return ResultErrorCode.Conflict when posts are still assigned to the category.
+using MyBlog.Domain.Abstractions;
+using MyBlog.Domain.Interfaces;
+using MyBlog.Web.Features.Categories.Delete;
 
 namespace Web.Features.Categories.Handlers;
 
 public class DeleteCategoryHandlerTests
 {
-	// ── Staged: DeleteCategoryHandler ─────────────────────────────────────
+	private readonly ICategoryRepository _categoryRepo = Substitute.For<ICategoryRepository>();
+	private readonly IBlogPostRepository _blogPostRepo = Substitute.For<IBlogPostRepository>();
+	private readonly DeleteCategoryHandler _handler;
 
-	[Fact(Skip = "Staged #339: awaiting DeleteCategoryHandler")]
-	public async Task Handle_CategoryWithNoPosts_DeletesAndReturnsSuccess()
+	public DeleteCategoryHandlerTests()
 	{
-		// Will verify: IBlogPostRepository.ExistsByCategoryAsync returns false
-		// → repo.DeleteAsync called, result.Success == true
-		await Task.CompletedTask;
+		_handler = new DeleteCategoryHandler(_categoryRepo, _blogPostRepo);
 	}
 
-	[Fact(Skip = "Staged #339: awaiting DeleteCategoryHandler")]
+	[Fact]
+	public async Task Handle_CategoryWithNoPosts_DeletesAndReturnsSuccess()
+	{
+		// Arrange
+		var category = Category.Create("Technology", "All about tech.");
+		_categoryRepo.GetByIdAsync(category.Id, Arg.Any<CancellationToken>())
+			.Returns(category);
+		_blogPostRepo.ExistsByCategoryAsync(category.Id, Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var command = new DeleteCategoryCommand(category.Id);
+
+		// Act
+		var result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		await _categoryRepo.Received(1).DeleteAsync(category.Id, Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
 	public async Task Handle_CategoryInUseByPosts_ReturnsConflictFailResult()
 	{
 		// AC: "cannot delete category in use"
-		// Will verify: IBlogPostRepository.ExistsByCategoryAsync returns true
-		// → result.Failure == true, ResultErrorCode.Conflict
-		await Task.CompletedTask;
+		// Arrange
+		var category = Category.Create("Technology", "All about tech.");
+		_categoryRepo.GetByIdAsync(category.Id, Arg.Any<CancellationToken>())
+			.Returns(category);
+		_blogPostRepo.ExistsByCategoryAsync(category.Id, Arg.Any<CancellationToken>())
+			.Returns(true);
+
+		var command = new DeleteCategoryCommand(category.Id);
+
+		// Act
+		var result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.ErrorCode.Should().Be(ResultErrorCode.Conflict);
+		result.Error.Should().Contain("Technology");
+		await _categoryRepo.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
 	}
 
-	[Fact(Skip = "Staged #339: awaiting DeleteCategoryHandler")]
+	[Fact]
 	public async Task Handle_CategoryNotFound_ReturnsNotFoundFailResult()
 	{
-		// Will verify: repo.GetByIdAsync returns null → Result.Fail with NotFound code
-		await Task.CompletedTask;
+		// Arrange
+		var id = Guid.NewGuid();
+		_categoryRepo.GetByIdAsync(id, Arg.Any<CancellationToken>())
+			.Returns((Category?)null);
+
+		var command = new DeleteCategoryCommand(id);
+
+		// Act
+		var result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.ErrorCode.Should().Be(ResultErrorCode.NotFound);
 	}
 
-	[Fact(Skip = "Staged #339: awaiting DeleteCategoryHandler")]
+	[Fact]
 	public async Task Handle_RepoThrows_ReturnsFailResult()
 	{
-		// Will verify: unexpected exception → Result.Fail("An unexpected error occurred.")
-		await Task.CompletedTask;
+		// Arrange
+		var category = Category.Create("Technology", "All about tech.");
+		_categoryRepo.GetByIdAsync(category.Id, Arg.Any<CancellationToken>())
+			.Returns(category);
+		_blogPostRepo.ExistsByCategoryAsync(category.Id, Arg.Any<CancellationToken>())
+			.Returns(false);
+		_categoryRepo.DeleteAsync(category.Id, Arg.Any<CancellationToken>())
+			.ThrowsAsync(new InvalidOperationException("db error"));
+
+		var command = new DeleteCategoryCommand(category.Id);
+
+		// Act
+		var result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain("db error");
 	}
 
-	[Fact(Skip = "Staged #339: awaiting DeleteCategoryHandler")]
+	[Fact]
 	public async Task Handle_OperationCanceled_Rethrows()
 	{
-		// Will verify: OperationCanceledException propagates
-		await Task.CompletedTask;
+		// Arrange
+		var id = Guid.NewGuid();
+		_categoryRepo.GetByIdAsync(id, Arg.Any<CancellationToken>())
+			.ThrowsAsync(new OperationCanceledException());
+
+		var command = new DeleteCategoryCommand(id);
+
+		// Act
+		Func<Task> act = () => _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<OperationCanceledException>();
 	}
 }

--- a/tests/Web.Tests/Features/Categories/Handlers/DeleteCategoryHandlerTests.cs
+++ b/tests/Web.Tests/Features/Categories/Handlers/DeleteCategoryHandlerTests.cs
@@ -1,0 +1,57 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     DeleteCategoryHandlerTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web.Tests
+//=======================================================
+
+// Staged #339 — awaiting DeleteCategoryHandler from Sam.
+// This handler MUST check IBlogPostRepository.ExistsByCategoryAsync before deleting
+// and return ResultErrorCode.Conflict when posts are still assigned to the category.
+
+namespace Web.Features.Categories.Handlers;
+
+public class DeleteCategoryHandlerTests
+{
+	// ── Staged: DeleteCategoryHandler ─────────────────────────────────────
+
+	[Fact(Skip = "Staged #339: awaiting DeleteCategoryHandler")]
+	public async Task Handle_CategoryWithNoPosts_DeletesAndReturnsSuccess()
+	{
+		// Will verify: IBlogPostRepository.ExistsByCategoryAsync returns false
+		// → repo.DeleteAsync called, result.Success == true
+		await Task.CompletedTask;
+	}
+
+	[Fact(Skip = "Staged #339: awaiting DeleteCategoryHandler")]
+	public async Task Handle_CategoryInUseByPosts_ReturnsConflictFailResult()
+	{
+		// AC: "cannot delete category in use"
+		// Will verify: IBlogPostRepository.ExistsByCategoryAsync returns true
+		// → result.Failure == true, ResultErrorCode.Conflict
+		await Task.CompletedTask;
+	}
+
+	[Fact(Skip = "Staged #339: awaiting DeleteCategoryHandler")]
+	public async Task Handle_CategoryNotFound_ReturnsNotFoundFailResult()
+	{
+		// Will verify: repo.GetByIdAsync returns null → Result.Fail with NotFound code
+		await Task.CompletedTask;
+	}
+
+	[Fact(Skip = "Staged #339: awaiting DeleteCategoryHandler")]
+	public async Task Handle_RepoThrows_ReturnsFailResult()
+	{
+		// Will verify: unexpected exception → Result.Fail("An unexpected error occurred.")
+		await Task.CompletedTask;
+	}
+
+	[Fact(Skip = "Staged #339: awaiting DeleteCategoryHandler")]
+	public async Task Handle_OperationCanceled_Rethrows()
+	{
+		// Will verify: OperationCanceledException propagates
+		await Task.CompletedTask;
+	}
+}

--- a/tests/Web.Tests/Features/Categories/Handlers/EditCategoryHandlerTests.cs
+++ b/tests/Web.Tests/Features/Categories/Handlers/EditCategoryHandlerTests.cs
@@ -1,0 +1,123 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     EditCategoryHandlerTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web.Tests
+//=======================================================
+
+using MyBlog.Domain.Abstractions;
+using MyBlog.Domain.Interfaces;
+using MyBlog.Web.Features.Categories.Edit;
+
+namespace Web.Features.Categories.Handlers;
+
+public class EditCategoryHandlerTests
+{
+	private readonly ICategoryRepository _repo = Substitute.For<ICategoryRepository>();
+	private readonly EditCategoryHandler _handler;
+
+	public EditCategoryHandlerTests()
+	{
+		_handler = new EditCategoryHandler(_repo);
+	}
+
+	[Fact]
+	public async Task Handle_ValidCommand_UpdatesAndReturnsSuccess()
+	{
+		// Arrange
+		var category = Category.Create("Technology", "Old description.");
+		_repo.GetByIdAsync(category.Id, Arg.Any<CancellationToken>())
+			.Returns(category);
+		_repo.ExistsByNameExcludingAsync("Technology Updated", category.Id, Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var command = new EditCategoryCommand(category.Id, "Technology Updated", "New description.");
+
+		// Act
+		var result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		await _repo.Received(1).UpdateAsync(Arg.Any<Category>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_CategoryNotFound_ReturnsNotFoundFailResult()
+	{
+		// Arrange
+		var id = Guid.NewGuid();
+		_repo.GetByIdAsync(id, Arg.Any<CancellationToken>())
+			.Returns((Category?)null);
+
+		var command = new EditCategoryCommand(id, "Technology", "Description.");
+
+		// Act
+		var result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.ErrorCode.Should().Be(ResultErrorCode.NotFound);
+	}
+
+	[Fact]
+	public async Task Handle_DuplicateNameOnDifferentCategory_ReturnsConflictFailResult()
+	{
+		// Arrange
+		var category = Category.Create("Technology", "Description.");
+		_repo.GetByIdAsync(category.Id, Arg.Any<CancellationToken>())
+			.Returns(category);
+		_repo.ExistsByNameExcludingAsync("Design", category.Id, Arg.Any<CancellationToken>())
+			.Returns(true);
+
+		var command = new EditCategoryCommand(category.Id, "Design", "Another description.");
+
+		// Act
+		var result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.ErrorCode.Should().Be(ResultErrorCode.Conflict);
+		result.Error.Should().Contain("Design");
+	}
+
+	[Fact]
+	public async Task Handle_RepoThrows_ReturnsFailResult()
+	{
+		// Arrange
+		var category = Category.Create("Technology", "Description.");
+		_repo.GetByIdAsync(category.Id, Arg.Any<CancellationToken>())
+			.Returns(category);
+		_repo.ExistsByNameExcludingAsync(Arg.Any<string>(), category.Id, Arg.Any<CancellationToken>())
+			.Returns(false);
+		_repo.UpdateAsync(Arg.Any<Category>(), Arg.Any<CancellationToken>())
+			.ThrowsAsync(new InvalidOperationException("db error"));
+
+		var command = new EditCategoryCommand(category.Id, "Technology Updated", "New description.");
+
+		// Act
+		var result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain("db error");
+	}
+
+	[Fact]
+	public async Task Handle_OperationCanceled_Rethrows()
+	{
+		// Arrange
+		var id = Guid.NewGuid();
+		_repo.GetByIdAsync(id, Arg.Any<CancellationToken>())
+			.ThrowsAsync(new OperationCanceledException());
+
+		var command = new EditCategoryCommand(id, "Technology", "Description.");
+
+		// Act
+		Func<Task> act = () => _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<OperationCanceledException>();
+	}
+}

--- a/tests/Web.Tests/Features/Categories/Handlers/GetCategoriesHandlerTests.cs
+++ b/tests/Web.Tests/Features/Categories/Handlers/GetCategoriesHandlerTests.cs
@@ -1,0 +1,104 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     GetCategoriesHandlerTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web.Tests
+//=======================================================
+
+using MyBlog.Domain.Abstractions;
+using MyBlog.Domain.Interfaces;
+using MyBlog.Web.Data;
+using MyBlog.Web.Features.Categories.List;
+
+namespace Web.Features.Categories.Handlers;
+
+public class GetCategoriesHandlerTests
+{
+	private readonly ICategoryRepository _repo = Substitute.For<ICategoryRepository>();
+	private readonly GetCategoriesHandler _handler;
+
+	public GetCategoriesHandlerTests()
+	{
+		_handler = new GetCategoriesHandler(_repo);
+	}
+
+	[Fact]
+	public async Task Handle_WithCategories_ReturnsMappedDtos()
+	{
+		// Arrange
+		var cat1 = Category.Create("Technology", "Tech posts.");
+		var cat2 = Category.Create("Design", "Design posts.");
+		_repo.GetAllAsync(Arg.Any<CancellationToken>())
+			.Returns(new List<Category> { cat1, cat2 });
+
+		// Act
+		var result = await _handler.Handle(new GetCategoriesQuery(), CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().HaveCount(2);
+		result.Value!.Should().Contain(d => d.Name == "Technology");
+		result.Value!.Should().Contain(d => d.Name == "Design");
+	}
+
+	[Fact]
+	public async Task Handle_EmptyRepository_ReturnsEmptyList()
+	{
+		// Arrange
+		_repo.GetAllAsync(Arg.Any<CancellationToken>())
+			.Returns(new List<Category>());
+
+		// Act
+		var result = await _handler.Handle(new GetCategoriesQuery(), CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task Handle_RepoThrowsInvalidOperation_ReturnsFailResult()
+	{
+		// Arrange
+		_repo.GetAllAsync(Arg.Any<CancellationToken>())
+			.ThrowsAsync(new InvalidOperationException("db error"));
+
+		// Act
+		var result = await _handler.Handle(new GetCategoriesQuery(), CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain("db error");
+	}
+
+	[Fact]
+	public async Task Handle_UnexpectedException_ReturnsGenericError()
+	{
+		// Arrange
+		_repo.GetAllAsync(Arg.Any<CancellationToken>())
+			.ThrowsAsync(new TimeoutException("db timeout"));
+
+		// Act
+		var result = await _handler.Handle(new GetCategoriesQuery(), CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Be("An unexpected error occurred.");
+	}
+
+	[Fact]
+	public async Task Handle_OperationCanceled_Rethrows()
+	{
+		// Arrange
+		_repo.GetAllAsync(Arg.Any<CancellationToken>())
+			.ThrowsAsync(new OperationCanceledException());
+
+		// Act
+		Func<Task> act = () => _handler.Handle(new GetCategoriesQuery(), CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<OperationCanceledException>();
+	}
+}

--- a/tests/Web.Tests/Features/Categories/Handlers/GetCategoryByIdHandlerTests.cs
+++ b/tests/Web.Tests/Features/Categories/Handlers/GetCategoryByIdHandlerTests.cs
@@ -1,0 +1,108 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     GetCategoryByIdHandlerTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web.Tests
+//=======================================================
+
+using MyBlog.Domain.Abstractions;
+using MyBlog.Domain.Interfaces;
+using MyBlog.Web.Data;
+using MyBlog.Web.Features.Categories.GetById;
+
+namespace Web.Features.Categories.Handlers;
+
+public class GetCategoryByIdHandlerTests
+{
+	private readonly ICategoryRepository _repo = Substitute.For<ICategoryRepository>();
+	private readonly GetCategoryByIdHandler _handler;
+
+	public GetCategoryByIdHandlerTests()
+	{
+		_handler = new GetCategoryByIdHandler(_repo);
+	}
+
+	[Fact]
+	public async Task Handle_CategoryExists_ReturnsMappedDto()
+	{
+		// Arrange
+		var category = Category.Create("Technology", "Tech posts.");
+		_repo.GetByIdAsync(category.Id, Arg.Any<CancellationToken>())
+			.Returns(category);
+
+		// Act
+		var result = await _handler.Handle(new GetCategoryByIdQuery(category.Id), CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().NotBeNull();
+		result.Value!.Name.Should().Be("Technology");
+		result.Value.Description.Should().Be("Tech posts.");
+		result.Value.Id.Should().Be(category.Id);
+	}
+
+	[Fact]
+	public async Task Handle_CategoryNotFound_ReturnsSuccessWithNullValue()
+	{
+		// Arrange
+		var missingId = Guid.NewGuid();
+		_repo.GetByIdAsync(missingId, Arg.Any<CancellationToken>())
+			.Returns((Category?)null);
+
+		// Act
+		var result = await _handler.Handle(new GetCategoryByIdQuery(missingId), CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task Handle_RepoThrowsInvalidOperation_ReturnsFailResult()
+	{
+		// Arrange
+		var id = Guid.NewGuid();
+		_repo.GetByIdAsync(id, Arg.Any<CancellationToken>())
+			.ThrowsAsync(new InvalidOperationException("db error"));
+
+		// Act
+		var result = await _handler.Handle(new GetCategoryByIdQuery(id), CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain("db error");
+	}
+
+	[Fact]
+	public async Task Handle_UnexpectedException_ReturnsGenericError()
+	{
+		// Arrange
+		var id = Guid.NewGuid();
+		_repo.GetByIdAsync(id, Arg.Any<CancellationToken>())
+			.ThrowsAsync(new TimeoutException("timeout"));
+
+		// Act
+		var result = await _handler.Handle(new GetCategoryByIdQuery(id), CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Be("An unexpected error occurred.");
+	}
+
+	[Fact]
+	public async Task Handle_OperationCanceled_Rethrows()
+	{
+		// Arrange
+		var id = Guid.NewGuid();
+		_repo.GetByIdAsync(id, Arg.Any<CancellationToken>())
+			.ThrowsAsync(new OperationCanceledException());
+
+		// Act
+		Func<Task> act = () => _handler.Handle(new GetCategoryByIdQuery(id), CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<OperationCanceledException>();
+	}
+}

--- a/tests/Web.Tests/Handlers/EditBlogPostHandlerTests.cs
+++ b/tests/Web.Tests/Handlers/EditBlogPostHandlerTests.cs
@@ -160,7 +160,7 @@ public class EditBlogPostHandlerTests
 	{
 		// Arrange
 		var id = Guid.NewGuid();
-		var dto = new BlogPostDto(id, "T", "C", string.Empty, "A", string.Empty, [], DateTime.UtcNow, null, false);
+		var dto = new BlogPostDto(id, "T", "C", string.Empty, "A", string.Empty, [], DateTime.UtcNow, null, false, null);
 		_cache.GetOrFetchByIdAsync(
 		Arg.Any<Guid>(),
 		Arg.Any<Func<Task<BlogPostDto?>>>(),

--- a/tests/Web.Tests/Handlers/GetBlogPostsHandlerTests.cs
+++ b/tests/Web.Tests/Handlers/GetBlogPostsHandlerTests.cs
@@ -24,8 +24,8 @@ public class GetBlogPostsHandlerTests
 
 	private static List<BlogPostDto> MakeDtos() =>
 	[
-	new(Guid.NewGuid(), "T1", "C1", string.Empty, "A1", string.Empty, [], DateTime.UtcNow, null, false),
-	new(Guid.NewGuid(), "T2", "C2", string.Empty, "A2", string.Empty, [], DateTime.UtcNow, null, true),
+	new(Guid.NewGuid(), "T1", "C1", string.Empty, "A1", string.Empty, [], DateTime.UtcNow, null, false, null),
+	new(Guid.NewGuid(), "T2", "C2", string.Empty, "A2", string.Empty, [], DateTime.UtcNow, null, true, null),
 	];
 
 	[Fact]

--- a/tests/Web.Tests/Infrastructure/Caching/BlogPostCacheServiceTests.cs
+++ b/tests/Web.Tests/Infrastructure/Caching/BlogPostCacheServiceTests.cs
@@ -30,8 +30,8 @@ public class BlogPostCacheServiceTests : IDisposable
 
 	private static List<BlogPostDto> MakeDtos() =>
 	[
-		new(Guid.NewGuid(), "Title1", "Content1", string.Empty, "Author1", string.Empty, [], DateTime.UtcNow, null, false),
-		new(Guid.NewGuid(), "Title2", "Content2", string.Empty, "Author2", string.Empty, [], DateTime.UtcNow, null, true),
+		new(Guid.NewGuid(), "Title1", "Content1", string.Empty, "Author1", string.Empty, [], DateTime.UtcNow, null, false, null),
+		new(Guid.NewGuid(), "Title2", "Content2", string.Empty, "Author2", string.Empty, [], DateTime.UtcNow, null, true, null),
 	];
 
 	// ── GetOrFetchAllAsync ────────────────────────────────────────────────
@@ -139,7 +139,7 @@ public class BlogPostCacheServiceTests : IDisposable
 		// Arrange
 		var id = Guid.NewGuid();
 		var key = BlogPostCacheKeys.ById(id);
-		var dto = new BlogPostDto(id, "T", "C", string.Empty, "A", string.Empty, [], DateTime.UtcNow, null, false);
+		var dto = new BlogPostDto(id, "T", "C", string.Empty, "A", string.Empty, [], DateTime.UtcNow, null, false, null);
 		_realLocalCache.Set(key, dto);
 
 		// Act
@@ -157,7 +157,7 @@ public class BlogPostCacheServiceTests : IDisposable
 		// Arrange
 		var id = Guid.NewGuid();
 		var key = BlogPostCacheKeys.ById(id);
-		var dto = new BlogPostDto(id, "T", "C", string.Empty, "A", string.Empty, [], DateTime.UtcNow, null, false);
+		var dto = new BlogPostDto(id, "T", "C", string.Empty, "A", string.Empty, [], DateTime.UtcNow, null, false, null);
 		var bytes = JsonSerializer.SerializeToUtf8Bytes(dto, JsonOpts);
 		_distributedCache.GetAsync(key, Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult<byte[]?>(bytes));
@@ -187,7 +187,7 @@ public class BlogPostCacheServiceTests : IDisposable
 			Arg.Any<string>(), Arg.Any<byte[]>(), Arg.Any<DistributedCacheEntryOptions>(), Arg.Any<CancellationToken>())
 			.Returns(Task.CompletedTask);
 
-		var dto = new BlogPostDto(id, "T", "C", string.Empty, "A", string.Empty, [], DateTime.UtcNow, null, false);
+		var dto = new BlogPostDto(id, "T", "C", string.Empty, "A", string.Empty, [], DateTime.UtcNow, null, false, null);
 		var fetchCalled = false;
 		Task<BlogPostDto?> fetch() { fetchCalled = true; return Task.FromResult<BlogPostDto?>(dto); }
 
@@ -212,7 +212,7 @@ public class BlogPostCacheServiceTests : IDisposable
 			Arg.Any<string>(), Arg.Any<byte[]>(), Arg.Any<DistributedCacheEntryOptions>(), Arg.Any<CancellationToken>())
 			.Returns(Task.CompletedTask);
 
-		var dto = new BlogPostDto(id, "T", "C", string.Empty, "A", string.Empty, [], DateTime.UtcNow, null, false);
+		var dto = new BlogPostDto(id, "T", "C", string.Empty, "A", string.Empty, [], DateTime.UtcNow, null, false, null);
 
 		// Act
 		var result = await _sut.GetOrFetchByIdAsync(id, () => Task.FromResult<BlogPostDto?>(dto), CancellationToken.None);
@@ -270,7 +270,7 @@ public class BlogPostCacheServiceTests : IDisposable
 		// Arrange — populate L1 so we can verify removal
 		var id = Guid.NewGuid();
 		var key = BlogPostCacheKeys.ById(id);
-		var dto = new BlogPostDto(id, "T", "C", string.Empty, "A", string.Empty, [], DateTime.UtcNow, null, false);
+		var dto = new BlogPostDto(id, "T", "C", string.Empty, "A", string.Empty, [], DateTime.UtcNow, null, false, null);
 		_realLocalCache.Set(key, dto);
 		_distributedCache.RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
 			.Returns(Task.CompletedTask);


### PR DESCRIPTION
Closes #339

Working as Legolas (Frontend/Blazor engineer)

## Summary

Implements the UI side of the Categories feature (Issue #339):

- **Admin CRUD page** at `/admin/categories` with inline create/edit/delete
- **Navigation link** for Categories (Admin-only, desktop + mobile)
- **Blog post Create**: category dropdown with optional selection
- **Blog post Edit**: category dropdown + author shown read-only

Also fixes three infrastructure issues found during integration:

### Bug fixes

- `BlogPost.AssignCategory` and `RemoveCategory` now increment `Version`, fixing `DbUpdateConcurrencyException` in integration tests
- `TestContextFactory` caches `DbContextOptions` per factory instance and suppresses `ManyServiceProvidersCreatedWarning`, fixing 7 failing category integration tests
- Seed command uses `ReplaceOneAsync` with upsert for the General category, making it idempotent and fixing `DuplicateKey` in AppHost integration tests

## Tests

- All 394 unit/arch/bUnit tests pass
- All 29 integration tests pass (Web.Tests.Integration)
- All 48 AppHost integration tests pass (AppHost.Tests)
