### PR TITLE
fix(apphost): pin MongoDB to mongo:7 with mongo-data-v7 volume

### DIFF
--- a/.squad/agents/boromir/history.md
+++ b/.squad/agents/boromir/history.md
@@ -48,6 +48,34 @@
 
 ## Learnings
 
+### 2026-05-19 — Issue #345: Fix AppHost MongoDB Container Crash (exit code 139 + exit code 62)
+
+**Finding (pass 1):** MongoDB 8.x (the `Aspire.Hosting.MongoDB` 13.3.3 default image `mongo:8.2`) requires AVX CPU instructions on x86-64 hosts. Virtualized environments that do not expose AVX cause MongoDB 8.x to SIGSEGV immediately → container exit code 139, OOMKilled=false, ~30 s after start. Fix: pin to `mongo:7` via `.WithImageTag("7")`.
+
+**Finding (pass 2 — runtime smoke):** After the image tag fix, MongoDB 7 started but then exited with code 62.
+Docker logs: `Wrong mongod version` and `Invalid featureCompatibilityVersion document ... version: "8.2" ... expected ... "7.0"`.
+The persistent `mongo-data` Docker volume had been initialized by `mongo:8.2`; MongoDB 7 refuses to open data
+files written by a newer major version. Fix: rename volume to `mongo-data-v7` for a fresh, compatible volume.
+
+**Secondary finding:** `AppHost.csproj` SDK attribute was `Aspire.AppHost.Sdk/13.3.2` while all Aspire hosting packages in `Directory.Packages.props` were at `13.3.3`. Version mismatch corrected.
+
+**Changed files:**
+
+- `src/AppHost/AppHost.cs` — `.WithImageTag("7")` + `.WithDataVolume("mongo-data-v7")` on the `AddMongoDB` chain.
+- `src/AppHost/AppHost.csproj` — `Aspire.AppHost.Sdk` bumped `13.3.2` → `13.3.3` to match `Directory.Packages.props`.
+
+**Volume naming convention:** version-suffix the volume name (`mongo-data-v{major}`) whenever the MongoDB major version changes on an environment with a pre-existing persistent volume. This avoids featureCompatibilityVersion mismatch crashes without requiring manual `docker volume rm`.
+
+**Validation performed:**
+
+- `dotnet build --configuration Release` (full solution) — **Build succeeded, 0 Warnings, 0 Errors**
+- Architecture.Tests: Passed 16/16; Domain.Tests: Passed 67/67; Web.Tests: Passed 210/210; Web.Tests.Bunit: Passed 104/104 — **397 tests, 0 failures**
+- Integration tests (Docker-backed) not run in this pass — AppHost infra-only change; integration suite is Gimli's gate.
+
+**Worktree:** `squad/345-fix-apphost-mongodb-crash` at `/home/mpaulosky/github/MyBlog-345` (not pushed; coordinator to reconcile fan-out).
+
+---
+
 ### 2026-05-14 — Issue #337: Archive Self-Authored PR Gate Skill
 
 **What was done:** Created `.squad/skills/self-authored-pr-gate/SKILL.md` documenting the workflow pattern discovered during PR #336 (self-authored Aspire/markdown upgrade) and updated `.squad/agents/aragorn/history.md` with Aragorn's gate review findings.

--- a/.squad/agents/gimli/history.md
+++ b/.squad/agents/gimli/history.md
@@ -372,7 +372,11 @@ Completed full xUnit v2 → v3 migration for `tests/Web.Tests/`.
 
 1. **xUnit v3 is backward-compatible for `[Fact]`, `[Theory]`, `[InlineData]`** — no attribute changes needed. The migration is purely a package swap + parallelism configuration.
 
-2. **Indentation fix via brace-counter: leading `}` handling is the hard part.** When a line starts with `}`, the depth must be decremented BEFORE printing (so the `}` itself is one level less indented), and the net brace change for the rest of the line must exclude that leading close. The bug to avoid: counting the leading `}` twice — once when adjusting depth and again in the opens-minus-closes calculation.
+2. **Indentation fix via brace-counter: leading `}` handling is the hard part.**
+   When a line starts with `}`, the depth must be decremented BEFORE printing (so the `}` itself is one
+   level less indented), and the net brace change for the rest of the line must exclude that leading close.
+   The bug to avoid: counting the leading `}` twice — once when adjusting depth and again in the
+   opens-minus-closes calculation.
 
 3. **`edit` tool replaces a matched substring, not just the header.** When using `edit` to replace a header pattern, if the new content includes the full file body, the result is the new full content prepended to the surviving old body — producing a duplicate class. Always verify line count post-edit when replacing large blocks.
 
@@ -1244,3 +1248,41 @@ FluentAssertions instead.
 
 `cut.Render(p => p.Add(...))` cannot include `AddCascadingValue` — throws `InvalidOperationException`.
 Set cascading values only in the initial `Render<T>()` call.
+
+## Session: AppHost MongoDB Image Regression Coverage — Issue #345 (2026-05-17)
+
+### Task
+
+Add regression coverage for the AppHost MongoDB crash under Aspire without editing production
+code. Prefer configuration-focused tests that guard the intended MongoDB image/tag wiring.
+
+### Work Done
+
+- Added `tests/AppHost.Tests/MongoDbContainerConfigurationTests.cs`.
+- Covered the AppHost MongoDB resource at two levels:
+  - runtime model annotation resolves to `docker.io/library/mongo:7`
+  - source wiring keeps an explicit `.WithImageTag("7")` pin in `src/AppHost/AppHost.cs`
+- Extended the same regression file to guard the MongoDB data volume rename:
+  - runtime model mount resolves to named volume `mongo-data-v7` at `/data/db`
+  - source wiring keeps `.WithDataVolume("mongo-data-v7")`
+  - tests explicitly reject legacy volume name `mongo-data`
+- Confirmed Boromir's AppHost repair already exists in the worktree filesystem even though the
+  earlier file-view overlay did not show it.
+
+### Validation
+
+- `npm ci --no-audit --no-fund`
+- `dotnet test tests/AppHost.Tests -c Release --no-restore --filter "FullyQualifiedName~MongoDbContainerConfigurationTests|FullyQualifiedName~EnvVarTests"`
+  - Result: 6 passed, 0 failed, 0 skipped
+
+### Learnings
+
+1. AppHost MongoDB image pinning is worth testing twice: model-level `ContainerImageAnnotation`
+   coverage proves the built application resolves `docker.io/library/mongo:7`, while a
+   source-structure guard proves the explicit `.WithImageTag("7")` call remains in AppHost code.
+2. For this worktree, filesystem reads via `bash` reflected the latest `AppHost.cs` contents more
+   reliably than the file-view overlay; verify the on-disk source before assuming a config change
+   is missing.
+3. When downgrading a local MongoDB container image, volume names matter too: reusing a volume
+   created by MongoDB 8.2 can preserve FCV metadata that makes MongoDB 7 fail at startup. Guard
+   the named volume in AppHost tests, not just the container image tag.

--- a/.squad/agents/sam/history.md
+++ b/.squad/agents/sam/history.md
@@ -526,3 +526,50 @@ AppHost.Tests: 48/48 passed. Scope: log wording only; no logic changes.
 ### Learning: Log wording must match the actual DB operation semantics
 
 When upsert (`ReplaceOneAsync + IsUpsert=true`) is the behavior, log strings must say "upserted" or "inserted/updated" — not "inserted". Future seed operations: always audit log strings against the actual driver call used.
+
+---
+
+## 🔴 CORRECTION: Issue #345 MongoDB Container Crash Fix (2026-05-17)
+
+**By:** Scribe (correction appended)  
+**Referenced:** Lines 44–45 (recommendation code snippet) and Line 110 (learning item) contained incomplete/incorrect guidance.
+
+### What Was Wrong
+
+Sam's original investigation correctly identified the root cause (MongoDB 8.x SIGSEGV) but the **recommendation and learning item were incomplete:**
+
+- **Line 44–45:** Recommended pinning to `mongo:8.0` and keeping `mongo-data` volume
+- **Line 110:** Stated the fix is `.WithImageTag("8.0")`
+
+### What Actually Happened (Implementation)
+
+Boromir's infrastructure fix (issue #345) pinned to **`mongo:7`** (not `8.0`) **and renamed the volume to `mongo-data-v7`** (not keeping `mongo-data`).
+
+**Why this was necessary:**
+
+1. **Image tag:** MongoDB 8.x (including 8.0) still requires AVX CPU instructions. Pinning to `mongo:7` LTS (which does NOT require AVX) is the stable solution.
+2. **Volume rename:** When the first attempt used `mongo:7` but the old `mongo-data` volume remained, MongoDB 7 exited with code 62: `Wrong mongod version — featureCompatibilityVersion "8.2"`. MongoDB refuses to open data files from a newer major version. Renaming to `mongo-data-v7` gave MongoDB 7 a fresh, compatible volume.
+
+### Accepted Final Fix
+
+```csharp
+var mongo = builder.AddMongoDB("mongodb")
+    .WithImageTag("7")              // pin to LTS with no AVX requirement
+    .WithDataVolume("mongo-data-v7") // version-suffixed volume to avoid featureCompatibilityVersion mismatch
+    .WithMongoExpress();
+```
+
+### Validation Results
+
+- ✅ Build: `dotnet build MyBlog.slnx -c Release --no-restore` passed
+- ✅ Format: `dotnet format MyBlog.slnx --verify-no-changes --no-restore` passed
+- ✅ Regression tests: `dotnet test tests/AppHost.Tests -c Release --no-restore --filter 'FullyQualifiedName~MongoDbContainerConfigurationTests'` — 4/4 passed
+- ✅ Smoke test: `aspire start --isolated --apphost src/AppHost/AppHost.csproj` — MongoDB healthy on `docker.io/library/mongo:7` with volume `mongo-data-v7`; all services running
+
+### Standing Rule (From Decision)
+
+When MongoDB major version changes on an Aspire dev environment with a pre-existing persistent volume, suffix the volume name with `v{major}` (e.g., `mongo-data-v7`, `mongo-data-v8`). This prevents featureCompatibilityVersion mismatch crashes transparently.
+
+### Why Scribe Is Appending This
+
+Reviewer lockout: Sam authored the incorrect guidance, so Sam cannot revise their own history artifact. Scribe appends this correction to preserve accuracy and allow the PR to proceed.

--- a/.squad/agents/sam/history.md
+++ b/.squad/agents/sam/history.md
@@ -1,5 +1,53 @@
 # Sam's Work History
 
+## 2026-05-19 — Issue #345: AppHost MongoDB Container Crash Investigation (branch squad/345-fix-apphost-mongodb-crash)
+
+### Task
+
+Review whether Web/MongoDB application wiring contributes to the `mongo:8.2` container crash (exit 139 / SIGSEGV) observed in the Aspire runtime.
+
+### Finding
+
+**Root cause is purely AppHost/container — no Web wiring defect found.**
+
+- `docker.io/library/mongo:8.2` (default for `Aspire.Hosting.MongoDB` 13.3.3) exits with code 139 (SIGSEGV). This is a container image crash — architecture incompatibility or a bug in the `8.2` tag. This is Boromir's domain.
+- Web's MongoDB.Driver heartbeat timeouts and operation cancellations are **downstream symptoms** of the container crash, not a contributing cause.
+
+**Web wiring verified clean:**
+
+| Check | Result |
+| --- | --- |
+| `AddMongoDBClient("myblog")` matches AppHost database resource name | ✅ Correct |
+| `AddDbContextFactory<BlogDbContext>` consumes IMongoClient correctly | ✅ Correct |
+| `MongoDbBlogPostRepository` uses short-lived contexts from factory | ✅ Correct |
+| `MongoDbCategoryRepository` uses short-lived contexts from factory | ✅ Correct |
+| `BlogDbContext` — blogposts collection, Version concurrency token, categories unique index | ✅ Correct |
+| AppHost `.WaitFor(mongo)` prevents Web serving before MongoDB is ready | ✅ Correct |
+
+### Changed Files
+
+None. No Web production code changes required.
+
+### Validation Performed
+
+- ✅ `dotnet build MyBlog.slnx -c Release` — 0 errors
+- ✅ `Architecture.Tests` — 16/16 passed
+- ✅ `Web.Tests` — 210/210 passed
+- ✅ `Domain.Tests` — 67/67 passed
+
+### Recommendation for Boromir
+
+Pin the MongoDB container image to a stable tag in AppHost.cs:
+
+```csharp
+var mongo = builder.AddMongoDB("mongodb")
+    .WithImageTag("8.0")   // pin away from 8.2 which SIGSEGVs
+    .WithDataVolume("mongo-data")
+    .WithMongoExpress();
+```
+
+---
+
 ## 2026-05-15 — Issue #339: Category Backend (branch squad/339-category-backend)
 
 ### Task
@@ -56,6 +104,10 @@ Some test and skill files in the working tree (aragorn/boromir history files, a 
 ### Nullable CategoryId is the right additive pattern for optional FK on existing entities
 
 Adding `Guid? CategoryId` with explicit `AssignCategory`/`RemoveCategory` domain methods preserves existing behavior (tests pass with `null`) while giving Legolas and the UI a clean optional-becomes-required upgrade path without a breaking API change.
+
+### mongo:8.2 (Aspire.Hosting.MongoDB 13.3.3 default) causes exit 139 (SIGSEGV)
+
+When diagnosing MongoDB container crashes under Aspire, check the image tag first. Exit code 139 is SIGSEGV — an image-level crash, not an application wiring defect. The fix is to pin the container image with `.WithImageTag("8.0")` in AppHost. Web timeout logs are downstream symptoms of the container crash and should not be mistaken for wiring bugs.
 
 ---
 

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2905,3 +2905,58 @@ is required only "before publishing a post."
 - Future PRs that introduce a "required at publish only" form constraint should either bind the asterisk + validator to the publish flag, or make the copy unconditional. Document the chosen pattern when #341 is implemented.
 - For all future PR gates, treat the `Coverage Analysis` job as the authoritative coverage signal when Codecov bot output is absent.
 - `gh pr merge --delete-branch` should be invoked from `dev` (or with `.squad/agents/` stashed) to avoid the post-merge local-checkout failure observed during this gate.
+
+---
+
+## Issue #345: AppHost MongoDB Container Crash (Sprint 19)
+
+### Decision: Pin AppHost MongoDB Image to `mongo:7` (LTS) and Use Version-Suffixed Volume
+
+**Status:** ✅ Implemented  
+**Date:** 2026-05-19  
+**Author:** Sam (investigation), Boromir (infrastructure change), Gimli (regression tests)  
+**Related Issue:** #345 — [Sprint 19] Fix AppHost MongoDB container crash under Aspire
+
+#### Problem
+
+Aspire AppHost health checks failing; MongoDB container (`docker.io/library/mongo:8.2`, default from `Aspire.Hosting.MongoDB` SDK 13.3.3) exits immediately with code 139 (SIGSEGV). Web logs show MongoDB heartbeat and connection timeouts.
+
+#### Root Cause
+
+MongoDB 8.x requires AVX CPU instruction set. Virtualized hosts and CI runners do not expose AVX; container crashes on startup.
+
+#### Decision
+
+1. **Image Pin:** `src/AppHost/AppHost.cs` pins MongoDB Aspire resource to `mongo:7` via `.WithImageTag("7")`
+2. **Volume Naming:** Data volume renamed from `mongo-data` to `mongo-data-v7` via `.WithDataVolume("mongo-data-v7")`
+3. **SDK Alignment:** `src/AppHost/AppHost.csproj` bumped `Aspire.AppHost.Sdk` from `13.3.2` to `13.3.3`
+
+#### Why
+
+**SIGSEGV Crash (Exit 139):**  
+MongoDB 8.x requires AVX. Pinning to `mongo:7` (LTS, no AVX requirement) eliminates the crash.
+
+**featureCompatibilityVersion Mismatch (Exit 62):**  
+After pinning image to `mongo:7`, MongoDB 7 still failed because the existing `mongo-data` volume contained `featureCompatibilityVersion: "8.2"` metadata from the previous `mongo:8.2` run. MongoDB refuses to open data files written by a newer major version. Renaming the volume to `mongo-data-v7` gives MongoDB 7 a fresh, compatible volume without requiring manual cleanup on developer machines.
+
+#### Standing Rule: Volume Naming Convention
+
+When MongoDB major version changes on an Aspire dev environment with a pre-existing persistent volume, suffix the volume name with `v{major}` (e.g., `mongo-data-v7`, `mongo-data-v8`). This prevents featureCompatibilityVersion mismatch crashes transparently.
+
+#### Validation
+
+- Build: ✅ `dotnet build MyBlog.slnx -c Release --no-restore` passed
+- Format: ✅ `dotnet format MyBlog.slnx --verify-no-changes --no-restore` passed
+- Regression tests: ✅ `dotnet test tests/AppHost.Tests -c Release --no-restore --filter 'FullyQualifiedName~MongoDbContainerConfigurationTests'` — 4/4 passed
+- Smoke test: ✅ `aspire start --isolated --apphost src/AppHost/AppHost.csproj` — MongoDB healthy on `mongo:7` with volume `mongo-data-v7`; all services running and healthy
+
+#### Impact
+
+- `src/AppHost/AppHost.cs` — `.WithImageTag("7")` + `.WithDataVolume("mongo-data-v7")`
+- `src/AppHost/AppHost.csproj` — `Aspire.AppHost.Sdk` bumped `13.3.2` → `13.3.3`
+- `tests/AppHost.Tests/MongoDbContainerConfigurationTests.cs` — new regression test suite asserting pinned image tag and version-suffixed volume
+- No application code changes; Web/MongoDB wiring confirmed correct
+
+#### Future Consideration
+
+When the team's standard dev/CI runner is confirmed to expose AVX (or when MongoDB 8.x AVX requirement is lifted), the image pin can be removed to resume tracking the hosting default. At that point rename the volume to `mongo-data-v8` (or remove the suffix if the pin is gone and volumes will be freshly created).

--- a/src/AppHost/AppHost.cs
+++ b/src/AppHost/AppHost.cs
@@ -10,7 +10,8 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
 var mongo = builder.AddMongoDB("mongodb")
-	.WithDataVolume("mongo-data").WithMongoExpress();
+	.WithImageTag("7")
+	.WithDataVolume("mongo-data-v7").WithMongoExpress();
 
 var mongoDb = mongo.AddDatabase("myblog");
 

--- a/src/AppHost/AppHost.csproj
+++ b/src/AppHost/AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.3.2">
+<Project Sdk="Aspire.AppHost.Sdk/13.3.3">
 
   <ItemGroup>
     <ProjectReference Include="..\ServiceDefaults\ServiceDefaults.csproj" IsAspireProjectResource="false" />

--- a/tests/AppHost.Tests/MongoDbContainerConfigurationTests.cs
+++ b/tests/AppHost.Tests/MongoDbContainerConfigurationTests.cs
@@ -1,0 +1,125 @@
+// ============================================
+// Copyright (c) 2026. All rights reserved.
+// File Name :     MongoDbContainerConfigurationTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : MyBlog
+// Project Name :  AppHost.Tests
+// =============================================
+
+using System.Text.RegularExpressions;
+
+using Aspire.Hosting;
+
+using FluentAssertions;
+
+namespace AppHost.Tests;
+
+/// <summary>
+/// Regression coverage for MongoDB AppHost container configuration.
+/// </summary>
+public sealed class MongoDbContainerConfigurationTests
+{
+	private const string AspireMongoRegistry = "docker.io";
+	private const string AspireMongoImage = "library/mongo";
+	private const string PinnedStableMongoTag = "7";
+	private const string KnownCrashingAspireMongoTag = "8.2";
+	private const string LegacyMongoDataVolume = "mongo-data";
+	private const string PinnedMongoDataVolume = "mongo-data-v7";
+	private const string MongoDataTargetPath = "/data/db";
+	private static readonly string RepoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../"));
+
+	private static Task<IDistributedApplicationTestingBuilder> CreateBuilderAsync() =>
+		DistributedApplicationTestingBuilder.CreateAsync<Projects.AppHost>(
+			args: [],
+			configureBuilder: static (options, _) => { options.DisableDashboard = true; },
+			cancellationToken: TestContext.Current.CancellationToken);
+
+	[Fact]
+	public async Task MongoDb_Resource_Overrides_Known_Crashing_Aspire_Default_Image_Tag()
+	{
+		// Arrange
+		var builder = await CreateBuilderAsync();
+		var mongoResource = builder.Resources.Single(static resource => resource.Name == "mongodb");
+
+		// Act
+		var image = mongoResource.Annotations
+			.OfType<ContainerImageAnnotation>()
+			.Single();
+
+		// Assert
+		image.Registry.Should().Be(AspireMongoRegistry);
+		image.Image.Should().Be(AspireMongoImage);
+		image.Tag.Should().Be(PinnedStableMongoTag,
+			$"issue #345 observed Aspire's default '{KnownCrashingAspireMongoTag}' MongoDB image exiting with code 139, so AppHost should stay pinned to the stable '{PinnedStableMongoTag}' tag");
+	}
+
+	[Fact]
+	public void AppHost_Source_Pins_MongoDb_Image_Away_From_The_Known_Crashing_Default()
+	{
+		// Arrange
+		var appHostSource = ReadRepoFile("src/AppHost/AppHost.cs");
+
+		// Act
+		var overridesMongoImageTag =
+			Regex.IsMatch(
+				appHostSource,
+				$@"AddMongoDB\(""mongodb""\)[\s\S]*?\.WithImageTag\s*\(\s*""{Regex.Escape(PinnedStableMongoTag)}""\s*\)",
+				RegexOptions.CultureInvariant)
+			|| Regex.IsMatch(
+				appHostSource,
+				@"AddMongoDB\(""mongodb""\)[\s\S]*?\.WithImage\s*\(",
+				RegexOptions.CultureInvariant);
+
+		// Assert
+		overridesMongoImageTag.Should().BeTrue(
+			$"issue #345 observed the default mongo:{KnownCrashingAspireMongoTag} Aspire image crashing with exit code 139, so AppHost must explicitly pin MongoDB to the stable '{PinnedStableMongoTag}' tag");
+	}
+
+	[Fact]
+	public async Task MongoDb_Resource_Uses_A_New_Data_Volume_For_The_Pinned_MongoDb_7_Image()
+	{
+		// Arrange
+		var builder = await CreateBuilderAsync();
+		var mongoResource = builder.Resources.Single(static resource => resource.Name == "mongodb");
+
+		// Act
+		var foundMounts = mongoResource.TryGetContainerMounts(out var mounts);
+		var dataMount = mounts?
+			.SingleOrDefault(static mount => mount.Target == MongoDataTargetPath);
+
+		// Assert
+		foundMounts.Should().BeTrue("the MongoDB resource should expose its data volume mount");
+		dataMount.Should().NotBeNull("MongoDB should mount a named volume at /data/db");
+		dataMount!.Type.Should().Be(ContainerMountType.Volume,
+			"the AppHost should continue using a named Docker volume for MongoDB data");
+		dataMount.Source.Should().Be(PinnedMongoDataVolume,
+			$"the pinned MongoDB {PinnedStableMongoTag} container must not reuse the legacy '{LegacyMongoDataVolume}' volume that carries MongoDB {KnownCrashingAspireMongoTag} feature compatibility metadata");
+		dataMount.Source.Should().NotBe(LegacyMongoDataVolume,
+			$"reusing '{LegacyMongoDataVolume}' lets MongoDB {KnownCrashingAspireMongoTag} feature compatibility metadata crash the pinned MongoDB {PinnedStableMongoTag} container with code 62");
+	}
+
+	[Fact]
+	public void AppHost_Source_Pins_MongoDb_7_To_Its_Own_Data_Volume_Name()
+	{
+		// Arrange
+		var appHostSource = ReadRepoFile("src/AppHost/AppHost.cs");
+
+		// Act
+		var usesPinnedVolumeName = Regex.IsMatch(
+			appHostSource,
+			$@"AddMongoDB\(""mongodb""\)[\s\S]*?\.WithImageTag\s*\(\s*""{Regex.Escape(PinnedStableMongoTag)}""\s*\)[\s\S]*?\.WithDataVolume\s*\(\s*""{Regex.Escape(PinnedMongoDataVolume)}""\s*\)",
+			RegexOptions.CultureInvariant);
+
+		// Assert
+		usesPinnedVolumeName.Should().BeTrue(
+			$"the pinned MongoDB {PinnedStableMongoTag} AppHost configuration must use '{PinnedMongoDataVolume}' instead of reusing the legacy '{LegacyMongoDataVolume}' volume");
+		appHostSource.Should().NotContain($".WithDataVolume(\"{LegacyMongoDataVolume}\")",
+			$"reusing the legacy '{LegacyMongoDataVolume}' volume allows MongoDB {KnownCrashingAspireMongoTag} feature compatibility metadata to break the pinned MongoDB {PinnedStableMongoTag} container");
+	}
+
+	private static string ReadRepoFile(string relativePath)
+	{
+		return File.ReadAllText(Path.Combine(RepoRoot, relativePath));
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two cascading AppHost/MongoDB container crashes introduced when `Aspire.Hosting.MongoDB` 13.3.3 defaulted to `mongo:8.2`.

### Root causes

| # | Symptom | Exit code | Cause | Fix |
|---|---------|-----------|-------|-----|
| 1 | MongoDB container crashes ~30 s after start | 139 (SIGSEGV) | `mongo:8.2` requires AVX CPU instructions; virtualized hosts that don't expose AVX segfault immediately | Pin image to `mongo:7` via `.WithImageTag("7")` |
| 2 | MongoDB 7 container refuses to start after image fix | 62 | `mongo-data` volume was initialised by `mongo:8.2` (featureCompatibilityVersion `8.2`); MongoDB 7 rejects data files from a newer major version | Rename volume to `mongo-data-v7` |

### Changes

- `src/AppHost/AppHost.cs` — `.WithImageTag("7")` + `.WithDataVolume("mongo-data-v7")` on the `AddMongoDB` chain
- `src/AppHost/AppHost.csproj` — `Aspire.AppHost.Sdk` bumped `13.3.2` → `13.3.3` to align with `Directory.Packages.props`
- `tests/AppHost.Tests/MongoDbContainerConfigurationTests.cs` — new regression suite (4 tests) asserting image tag, volume name, and source-level guards

No application business logic was changed. No secrets or connection strings are included.

### Testing

| Suite | Result |
|-------|--------|
| AppHost.Tests (full, no filter) | ✅ 52 passed, 1 skipped (pre-existing Playwright flake), 0 failed |
| Architecture.Tests | ✅ 16/16 |
| Domain.Tests | ✅ 67/67 |
| Web.Tests | ✅ 210/210 |
| Web.Tests.Bunit | ✅ 104/104 |
| Pre-push gate (markdown lint, dotnet format, release build, unit + integration) | ✅ All passed |

### Review gate

Aragorn: CONDITIONALLY APPROVED — no code changes required, gate clears on AppHost.Tests 0 failures. ✅ Condition satisfied.

Closes #345