### PR TITLE
fix: pre-push hook tag passthrough

### DIFF
--- a/.github/hooks/pre-push
+++ b/.github/hooks/pre-push
@@ -13,6 +13,17 @@ RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; RE
 
 echo -e "${CYAN}━━━ Pre-Push Gate ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
 
+# ── Tag passthrough: allow version tags without branch gates ───────────────
+# git passes refspecs on stdin: "<local-ref> <local-sha1> <remote-ref> <remote-sha1>"
+# Save stdin and check if ALL refs being pushed are tags.
+PUSH_REFS=$(cat)
+if [[ -n "$PUSH_REFS" ]] && echo "$PUSH_REFS" | grep -q "^refs/tags/"; then
+  if ! echo "$PUSH_REFS" | grep -qv "^refs/tags/"; then
+    echo -e "${GREEN}✅  Tag push — skipping branch gates.${RESET}"
+    exit 0
+  fi
+fi
+
 # ── Gate 0: Enforce branch naming conventions ──────────────────────────────
 # Merge hierarchy: squad/{issue}-{slug} → sprint/{N}-{slug} → dev → main (release only)
 CURRENT_BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null || echo "")"


### PR DESCRIPTION
## Summary

Fixes #387

Tag pushes (`git push origin refs/tags/v1.7.0`) were being blocked by Gate 0 in the pre-push hook because it reads `git symbolic-ref HEAD` (which was `dev`) and rejects pushes from protected branches — without considering that the refspec being pushed is a tag, not a branch.

## Fix

Added a tag passthrough block **before** Gate 0 that reads stdin refspecs. If all pushed refs are `refs/tags/*`, the hook exits immediately with success.

## Test

```bash
git push origin refs/tags/v1.7.0
# Pre-Push Gate
# ✅  Tag push — skipping branch gates.
```

Discovered when tagging Sprint 20 release as `v1.7.0`.