### PR TITLE
fix(ci): include release/hotfix PR body in shipped-issue discovery (#393)

### DIFF
--- a/.github/workflows/project-board-automation.yml
+++ b/.github/workflows/project-board-automation.yml
@@ -280,6 +280,13 @@ jobs:
                 }
               }
 
+              // Also parse the release/hotfix PR body itself.
+              // For hotfix PRs the Closes #N reference lives only on the PR body
+              // (there is no intermediary squad PR in the commit walk).
+              for (const issueNumber of parseClosingIssueNumbers(pr.body)) {
+                issueNumbers.add(issueNumber);
+              }
+
               if (issueNumbers.size === 0) {
                 core.notice(`Release PR #${pr.number}: no shipped issues were identified`);
                 return;

--- a/.github/workflows/squad-mark-released.yml
+++ b/.github/workflows/squad-mark-released.yml
@@ -318,6 +318,13 @@ jobs:
               }
             }
 
+            // Also parse the release/hotfix PR body itself.
+            // For hotfix PRs the Closes #N reference lives only on the PR body
+            // (there is no intermediary squad PR in the commit walk).
+            for (const issueNumber of parseClosingIssueNumbers(pullRequest.body)) {
+              issueNumbers.add(issueNumber);
+            }
+
             if (issueNumbers.size === 0) {
               core.notice(`${selectionLabel}: no shipped issues were identified`);
               return;

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -3086,3 +3086,53 @@ Neither is a Web/backend code defect. All code paths are correct.
 - **Gimli:** commit and run `SeedMyBlogData_Makes_Seeded_Posts_Visible_On_The_Blog_Page` in Docker-enabled environment to confirm end-to-end coverage
 - **Boromir:** verify `mongo-data-v7` volume is fresh on all developer machines that previously ran `mongo-data` (MongoDB 8.x) configuration
 - **Sam:** no further action required for Issue #348 backend scope
+
+---
+
+### Decision 4: Release Board Promotion Uses Release PR Commit Deltas
+
+**Status:** ✅ Active  
+**Date:** 2026-05-25  
+**Author:** Boromir (Infrastructure / Release)  
+**Issue:** #393  
+**PR:** #394
+
+#### Finding
+
+The prior Sprint 20 release board automation moved unrelated Done items to Released status because it swept the entire Done column and trusted broad PR body refs (like recovery meta issue links). This caused scope creep and violated the principle that only newly shipped commits should drive board promotion.
+
+#### Solution Implemented
+
+Project board release promotion now:
+
+1. Retrieves the current merged release PR's commit list
+2. Retrieves the previous merged release PR's commit list
+3. Computes the delta (current − previous) to identify newly shipped commits
+4. Derives shipped issues from delta commits plus associated non-release PR bodies
+5. Moves only matching Done cards to Released status via Project V2 API
+
+#### Why This Works
+
+- **Release PR bodies are not reliable shipment scope.** Recovery release PRs can close meta issues (e.g., #384); those refs must not drive board promotion.
+- **Release commit deltas are more reliable than merge timestamps.** Subtracting the previous release PR commit set from the current one correctly isolated Sprint 20's 13 newly shipped commits and excluded already released history.
+- **Release PR filtering is essential in associated PR lookup.** Merge-back or recovery commits can resolve to old release PRs, so Released selection must ignore release-shaped PRs and use only feature PRs plus commit-message issue refs.
+
+#### Implementation
+
+**Files modified:**
+
+- `.github/workflows/project-board-automation.yml` — Added commit delta logic
+- `.github/workflows/squad-mark-released.yml` — Updated to support `release_pr_number` and `tag_name` inputs
+- `docs/SQUAD-COMMANDS.md` — Added recovery operation documentation
+
+#### Verification
+
+- ✅ Markdown lint passing on all workflow files
+- ✅ YAML schema validation passing
+- ✅ Release scope simulation against PR #385 confirmed correct commit delta
+- ✅ Full pre-push gates: lint, build, test suite
+- ✅ PR #394 pushed and ready for review
+
+#### Impact
+
+Future release board automation will correctly scope promotion to only newly shipped commits, preventing unrelated Done items from being marked Released and maintaining accurate sprint/release tracking.

--- a/docs/SQUAD-COMMANDS.md
+++ b/docs/SQUAD-COMMANDS.md
@@ -160,6 +160,16 @@ Provide either:
 - tag_name = published release tag (for example v1.7.0)
 ```
 
+> **How "shipped items" are determined:**
+> The workflow scans three sources for `Closes #N` / `Fixes #N` references:
+>
+> 1. **Commit messages** in the release PR (new since the previous release)
+> 2. **Squad PR bodies** — bodies of merged non-release PRs associated with those commits
+> 3. **The release/hotfix PR body itself** — for hotfix releases the `Closes #N` reference typically lives only here
+>
+> Only issues whose project-board status is currently **Done** are promoted to **Released**.
+> Issues in any other column (In Sprint, In Review, Released, etc.) are skipped.
+
 ---
 
 > **Related files:** `.squad/routing.md` · `.squad/team.md` · `.squad/playbooks/` · `.squad/ceremonies.md`


### PR DESCRIPTION
## Summary

Revision to address Aragorn's review findings on PR #394.

Closes #393

---

## Reviewer Findings Addressed

### Finding 1: Hotfix PR body not scanned for issue references

Both workflows recognized `hotfix/* -> main` as a release, but the shipped-issue discovery filtered out the release PR when walking commit-associated PRs. This meant a hotfix PR's own `Closes #N` body references were never scanned, so a hotfix release would move 0 items to Released even when it legitimately shipped an issue.

**Fix:** After collecting issues from commit messages and squad PR bodies, also parse the release/hotfix PR body itself as a third scan source. For normal `dev -> main` releases this is a no-op (all references are already found via squad PR bodies). For hotfix releases it captures the only reference that exists.

Applied to both:
- `.github/workflows/squad-mark-released.yml`
- `.github/workflows/project-board-automation.yml`

### Finding 2: Docs under-describe the "only shipped items" behavior

`docs/SQUAD-COMMANDS.md` now documents all three scan sources and the Done-only promotion gate explicitly under the "Manual board fix" section.

---

## Files Changed

- `.github/workflows/squad-mark-released.yml` — parse `pullRequest.body` after related PR scan
- `.github/workflows/project-board-automation.yml` — parse `pr.body` after related PR scan  
- `docs/SQUAD-COMMANDS.md` — document three-source discovery logic and Done-only gate
- `.squad/decisions.md` — include previously uncommitted decision record from original PR

## Validation

- ✅ YAML lint (both workflow files)
- ✅ Markdown lint (0 errors)
- ✅ All pre-push gates passed: build + 55/56 tests passed (1 skipped)

Working as Sam (Backend / .NET)