### PR TITLE
fix(auth): bypass OIDC challenge when placeholder Auth0 config is active (#396)

### DIFF
--- a/.squad/agents/gandalf/history.md
+++ b/.squad/agents/gandalf/history.md
@@ -93,7 +93,10 @@ Security findings:
 
 **Key Findings:**
 
-1. **[HIGH] Open Redirect in `/Account/Login`** — `returnUrl` query parameter is passed directly to `WithRedirectUri(returnUrl ?? "/")` in `Program.cs:111` with no local-path validation. An attacker could craft `/Account/Login?returnUrl=https://evil.com` to redirect a user to a phishing site after login. Fix: validate `returnUrl` is a relative/local path before use (e.g., `LocalRedirect` or `Uri.IsWellFormedUriString` check).
+1. **[HIGH] Open Redirect in `/Account/Login`** — `returnUrl` parameter is passed directly to
+   `WithRedirectUri(returnUrl ?? "/")` in `Program.cs:111` with no local-path validation.
+   An attacker could craft `/Account/Login?returnUrl=https://evil.com` to redirect after login.
+   Fix: validate `returnUrl` is a relative/local path (e.g., `Uri.IsWellFormedUriString` check).
 
 2. **[MEDIUM] Potential NullReferenceException in `OnTokenValidated` handler** — `Program.cs:46` captures `options.Events.OnTokenValidated` before the PostConfigure, but Auth0 SDK may set this to `null`. The line `await existingOnTokenValidated(context)` will throw `NullReferenceException` if null, breaking all logins. Fix: guard with `if (existingOnTokenValidated != null)`.
 
@@ -216,3 +219,50 @@ Resolved 7 add/add conflicts in `.squad/skills/` by accepting `origin/dev` versi
 - webapp-testing/SKILL.md
 
 **Learning:** Add/add conflicts in skill files result from parallel imports. The `origin/dev` versions are authoritative when adapted for MyBlog conventions (file paths, ownership rules, real examples).
+
+### Issue #396 — Fix Local Login Failure with Placeholder Auth0 Config — 2026-05-14
+
+**Branch:** `squad/396-fix-local-login-placeholder-auth0`
+**PR:** Opens against `dev`
+
+**Problem:** In Development/Testing, missing Auth0 credentials caused `Program.cs` to fall
+back to `test.auth0.com` / `test-client-id`. Navigating to `/Account/Login` then triggered
+a real OIDC discovery call against that non-existent domain, producing `IDX20803` timeout.
+
+**Fix applied (Program.cs):**
+
+1. **`isPlaceholderAuth0Config` flag** — set to `true` only when the `else if` branch
+   activates (Dev/Testing, no real credentials). Developers who supply real user secrets are
+   unaffected; the flag stays `false` and the live OIDC flow is preserved.
+
+2. **`/Account/Login` short-circuit** — when `isPlaceholderAuth0Config` is `true`, the
+   endpoint redirects to `/test/login` instead of issuing a `ChallengeAsync` to the
+   placeholder domain. The test-only cookie login completes instantly.
+
+3. **`existingOnTokenValidated` null guard** — added `if (existingOnTokenValidated != null)`
+   before invoking the captured delegate. Without this guard any login where the Auth0 SDK
+   left that delegate null would throw a `NullReferenceException` on token validation.
+
+**Docs updated:** `docs/AUTH0_SETUP.md` — new troubleshooting entry for the `IDX20803`
+timeout pattern, explaining the auto-redirect and how to enable real Auth0 login locally.
+
+**Security test scenarios specified for Gimli:**
+
+1. `GET /Account/Login` when `isPlaceholderAuth0Config = true` → assert 302 redirect to `/test/login`, no OIDC challenge issued.
+2. `GET /Account/Login` when real Auth0 credentials are configured → assert OIDC challenge is issued (302 to Auth0 domain), `/test/login` is NOT called.
+3. `GET /Account/Login` in Production environment without credentials → assert `InvalidOperationException` is thrown at startup (not a redirect).
+4. `GET /test/login` in Development → assert cookie set, redirect to `/`, user is authenticated.
+5. `GET /test/login` in Production → assert 404 (endpoint not registered outside Dev/Testing).
+6. `OnTokenValidated` with null prior handler → assert no `NullReferenceException`; role claims are added normally.
+
+**Decision record:** `.squad/decisions/inbox/gandalf-auth0-placeholder-login.md`
+
+**Key learnings:**
+
+- Placeholder fallback values (`test.auth0.com`) are safe for DI registration but MUST be
+  guarded at the request boundary — the OIDC discovery call fires at request time, not at
+  startup, so startup guards alone are insufficient.
+- A boolean flag captures intent cleanly without duplicating environment checks across
+  multiple handlers; the closure captures it safely in a top-level statement program.
+- The `existingOnTokenValidated` null-guard is a recurring pattern when wrapping
+  Auth0 SDK event delegates — always check for null before invoking captured delegates.

--- a/.squad/agents/gimli/history.md
+++ b/.squad/agents/gimli/history.md
@@ -237,7 +237,9 @@ and conventions.
 ### Key Learnings
 
 1. **MyBlog's testing stack is mature and battle-tested:**
-    - Integration tests: MongoDbFixture + collection isolation working well (9 tests)
+
+   - Integration tests: MongoDbFixture + collection isolation working well (9 tests)
+
 ## Session: PR #385 Re-review — Clear Category Fix (2026-05-24)
 
 ### Task
@@ -272,29 +274,39 @@ regression is now adequately covered for release by both handler and bUnit tests
   true)` keeps the edit to a single `Version++`. The current handler comment
   explains the concurrency risk, but that invariant is not yet locked down by a
   dedicated test.
-   - Unit tests: 59 tests with 91.64% line coverage, all handlers + domain + components covered
-   - Architecture tests: VSA + layer rules enforced
-   - bUnit component tests: Clean auth mocking pattern with TestAuthorizationService
 
-2. **Patterns extraction requires grounding in real code:**
+### Additional Test Coverage Context
+
+- Unit tests: 59 tests with 91.64% line coverage, all handlers + domain +
+  components covered
+- Architecture tests: VSA + layer rules enforced
+- bUnit component tests: Clean auth mocking pattern with
+  TestAuthorizationService
+
+1. **Patterns extraction requires grounding in real code:**
+
    - Cannot document intent without seeing actual implementations
    - Real examples > abstract rules (code > explanation)
    - Test classes show the patterns better than generic guidance
 
-3. **Three distinct testing domains with different conventions:**
+2. **Three distinct testing domains with different conventions:**
+
    - **Integration**: Fixture + collection + per-test isolation
    - **Unit**: AAA + mocking + assertions, split by entity/handler/component
    - **Component**: bUnit with auth context + claim assertions
 
-4. **File headers are critical for team consistency:**
+3. **File headers are critical for team consistency:**
+
    - Every test file MUST have the 7-line block (charter rule #6)
    - This was flagged in PR #2 review — ALL test files were missing headers
    - Now documented explicitly in unit-test-conventions skill
 
-5. **No new skills created for existing patterns:**
+4. **No new skills created for existing patterns:**
+
    - testcontainers and webapp-testing were already good patterns
    - Refinement (not creation) is the right approach for 70–80% patterns
-   - Only created unit-test-conventions because it was extractable from 4+ test files and not documented
+   - Only created unit-test-conventions because it was extractable from 4+
+     test files and not documented
 
 ### Outcomes
 
@@ -1478,10 +1490,48 @@ Audit Sprint 20 for leftover Guid ID usage in domain/persistence/CQRS paths, har
 3. **Non-CQRS residual Guid usage remains in UI fallback code:** `src/Web/Features/BlogPosts/Create/Create.razor` still generates a dev-only author id with `Guid.NewGuid()`. This is outside the audited domain/persistence/CQRS layers, but it is still a leftover Guid-based code path.
 4. **Branch health blocker unrelated to my test changes:** local non-CI builds still try to run `npm install` from `src/Web/Web.csproj`; this environment has no `node`/`npm`, so raw non-`CI=true` builds fail before test execution.
 5. **Quality gate blocker still open:** `CI=true dotnet build MyBlog.slnx` passes, but the solution does **not** meet issue #363's `no warnings` acceptance bar because existing analyzer warnings remain across Architecture/Web/AppHost test projects.
-6. **Exploratory production bug observed:** editing a blog post while sending a category value still triggers a real concurrency failure because the entity version increments in multiple places before persistence. I did not codify that as a failing test because the charter for this round forbids fixing production code; Sam should investigate `BlogPost.AssignCategory` + `EditBlogPostHandler`/repository version handling.
+6. **Exploratory production bug observed:** editing a blog post while sending a
+   category value still triggers a real concurrency failure because the entity
+   version increments in multiple places before persistence. I did not codify
+   that as a failing test because the charter for this round forbids fixing
+   production code; Sam should investigate `BlogPost.AssignCategory` +
+   `EditBlogPostHandler`/repository version handling.
 
 ### Learnings
 
 1. The ObjectId migration broke bUnit fastest at DTO construction sites; UI tests needed contract updates before meaningful hardening work could continue.
 2. The right end-to-end proof for this branch is mixed: bUnit for stringify-at-edge, Mongo integration tests for CQRS/repository roundtrips, and AppHost tests for seed/runtime behavior.
 3. For Sprint 20, deterministic seed coverage should check both the primary seeded category ID and the foreign keys on seeded posts; primary document IDs still need product work.
+
+## 2026-05-25 — Issue #396 Login Fallback Test Coverage
+
+### Task
+
+Add the missing automated coverage for PR #397 so placeholder Auth0
+configuration in Testing redirects `/Account/Login` to the local
+`/test/login` endpoint instead of attempting an external OIDC challenge.
+
+### Work Done
+
+- Added `tests/AppHost.Tests/Tests/Auth/LoginFallbackTests.cs` to request
+  `/Account/Login` with redirects disabled and assert the runtime response stays
+  local.
+- Added `tests/Architecture.Tests/AuthFallbackContractTests.cs` to pin the
+  source contract that the placeholder-config short-circuit appears before
+  `ChallengeAsync` while preserving the real Auth0 challenge path.
+
+### Validation
+
+- `dotnet build MyBlog.slnx --configuration Release` ✅
+- `dotnet test tests/Architecture.Tests/Architecture.Tests.csproj --configuration Release` ✅
+- `dotnet test tests/AppHost.Tests/AppHost.Tests.csproj --configuration Release` ✅
+- `dotnet test tests/Architecture.Tests/Architecture.Tests.csproj --configuration Release --no-build --nologo --logger 'console;verbosity=minimal'` ✅
+- `dotnet test tests/AppHost.Tests/AppHost.Tests.csproj --configuration Release --no-build --nologo --logger 'console;verbosity=minimal'` ✅
+
+### Learnings
+
+1. The highest-value proof here is split across layers: AppHost verifies the
+   observable redirect, while the architecture contract guards the source-order
+   short-circuit that prevents accidental regression back to external OIDC.
+2. For auth fallback behavior, disabling redirects in the runtime test is the
+   simplest way to prove the app never leaves the local test harness.

--- a/.squad/agents/gimli/history.md
+++ b/.squad/agents/gimli/history.md
@@ -1535,3 +1535,46 @@ configuration in Testing redirects `/Account/Login` to the local
    short-circuit that prevents accidental regression back to external OIDC.
 2. For auth fallback behavior, disabling redirects in the runtime test is the
    simplest way to prove the app never leaves the local test harness.
+
+## 2026-05-25 — PR #397 Auth0 Login Test Isolation
+
+### Task
+
+Revise the AppHost coverage for issue #396 / PR #397 so the login fallback test
+stays deterministic in CI even when the runner exposes real Auth0 environment
+values.
+
+### Work Done
+
+- Reproduced the failure mode locally by running `LoginFallbackTests` with
+  ambient `Auth0__Domain`, `Auth0__ClientId`, and `Auth0__ClientSecret`
+  variables set.
+- Updated the shared AppHost Testing fixtures to clear those Auth0 values on the
+  spawned `web` resource, so the Testing host always exercises the placeholder
+  branch intentionally instead of inheriting parent-process secrets.
+- Renamed the fallback test to describe the controlled placeholder-config setup
+  rather than assuming the process has no Auth0 secrets at all.
+
+### Validation
+
+- `Auth0__Domain=ci-real.auth0.com Auth0__ClientId=ci-real-client Auth0__ClientSecret=ci-real-secret dotnet test tests/AppHost.Tests/AppHost.Tests.csproj --configuration Release --filter 'FullyQualifiedName~LoginFallbackTests' --nologo --logger 'console;verbosity=minimal'` ✅
+- `dotnet test tests/Architecture.Tests/Architecture.Tests.csproj --configuration Release --nologo --logger 'console;verbosity=minimal'` ✅
+- `dotnet restore MyBlog.slnx` ✅
+- `dotnet format MyBlog.slnx --verify-no-changes` ✅
+- `dotnet build MyBlog.slnx --configuration Release --no-restore` ✅
+- `dotnet test tests/Architecture.Tests/Architecture.Tests.csproj --configuration Release --no-build --nologo --logger 'console;verbosity=minimal'` ✅
+- `dotnet test tests/Domain.Tests/Domain.Tests.csproj --configuration Release --no-build --nologo --logger 'console;verbosity=minimal'` ✅
+- `dotnet test tests/Web.Tests/Web.Tests.csproj --configuration Release --no-build --nologo --logger 'console;verbosity=minimal'` ✅
+- `dotnet test tests/Web.Tests.Bunit/Web.Tests.Bunit.csproj --configuration Release --no-build --nologo --logger 'console;verbosity=minimal'` ✅
+- `dotnet test tests/Web.Tests.Integration/Web.Tests.Integration.csproj --configuration Release --no-build --nologo --logger 'console;verbosity=minimal'` ✅
+- `dotnet test tests/AppHost.Tests/AppHost.Tests.csproj --configuration Release --no-build --nologo --logger 'console;verbosity=minimal'` ✅
+
+### Learnings
+
+1. AppHost runtime tests cannot assume a clean parent environment in CI; if the
+   behavior under test depends on missing secrets, the fixture must override the
+   child resource explicitly.
+2. For this login split, the best safety net is layered: AppHost proves the
+   observable `/test/login` redirect under isolated placeholder config, while
+   the architecture contract preserves the real OIDC challenge branch when valid
+   Auth0 settings exist.

--- a/docs/AUTH0_SETUP.md
+++ b/docs/AUTH0_SETUP.md
@@ -297,6 +297,30 @@ exports.onExecutePostLogin = async (event, api) => {
 
 ---
 
+### Login times out with `IDX20803` / `test.auth0.com` in Development
+
+**Cause**: Auth0 credentials are not configured locally, so the app falls back to the
+placeholder domain `test.auth0.com`. Clicking **Login** then triggers a real OpenID Connect
+discovery call against that non-existent domain, which hangs until timeout
+(`IDX20803: Unable to obtain configuration from … test.auth0.com`).
+
+**Fix**: This is the expected fallback path. When no credentials are configured in
+Development or Testing, `/Account/Login` redirects straight to `/test/login`
+(the cookie-based test login endpoint) instead of performing an OIDC challenge.
+No action is required — simply click Login and you will be signed in as `Test User`.
+
+To use real Auth0 login locally, set your user secrets:
+
+```bash
+dotnet user-secrets set "Auth0:Domain"        "your-tenant.us.auth0.com" --project src/Web
+dotnet user-secrets set "Auth0:ClientId"      "YOUR_CLIENT_ID"           --project src/Web
+dotnet user-secrets set "Auth0:ClientSecret"  "YOUR_CLIENT_SECRET"       --project src/Web
+```
+
+Once set, the app detects real credentials and routes `/Account/Login` to Auth0 Universal Login.
+
+---
+
 ### Application starts but login redirects to wrong port
 
 **Cause**: Running under the `http` profile instead of `https`.

--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -46,7 +46,11 @@ builder.Services.AddRazorComponents()
 var auth0Domain = builder.Configuration["Auth0:Domain"];
 var auth0ClientId = builder.Configuration["Auth0:ClientId"];
 
-// In Development/Testing, provide mock values; in Production, require real credentials
+// In Development/Testing, provide mock values; in Production, require real credentials.
+// isPlaceholderAuth0Config stays false when real credentials ARE configured in Dev/Testing,
+// preserving the live Auth0 flow for developers who have set up their user secrets.
+var isPlaceholderAuth0Config = false;
+
 if (!builder.Environment.IsDevelopment() && !builder.Environment.IsEnvironment("Testing"))
 {
 	if (string.IsNullOrEmpty(auth0Domain) || string.IsNullOrEmpty(auth0ClientId))
@@ -60,9 +64,11 @@ if (!builder.Environment.IsDevelopment() && !builder.Environment.IsEnvironment("
 }
 else if (string.IsNullOrWhiteSpace(auth0Domain) || string.IsNullOrWhiteSpace(auth0ClientId))
 {
-	// Development/Testing: Use test/mock values if not configured
+	// Development/Testing without real Auth0 credentials: use placeholder values and flag
+	// so /Account/Login bypasses the OIDC discovery call (which would timeout against test.auth0.com).
 	auth0Domain = "test.auth0.com";
 	auth0ClientId = "test-client-id";
+	isPlaceholderAuth0Config = true;
 }
 
 var auth0RoleClaimTypes = RoleClaimsHelper.GetRoleClaimTypes(builder.Configuration);
@@ -83,7 +89,10 @@ builder.Services.PostConfigure<OpenIdConnectOptions>(Auth0Constants.Authenticati
 	var existingOnTokenValidated = options.Events.OnTokenValidated;
 	options.Events.OnTokenValidated = async context =>
 	{
-		await existingOnTokenValidated(context).ConfigureAwait(false);
+		if (existingOnTokenValidated != null)
+		{
+			await existingOnTokenValidated(context).ConfigureAwait(false);
+		}
 
 		if (context.Principal?.Identity is not ClaimsIdentity identity)
 		{
@@ -172,6 +181,16 @@ app.MapGet("/Account/Login", async (HttpContext ctx, string? returnUrl) =>
 			&& Uri.IsWellFormedUriString(returnUrl, UriKind.Relative)
 			? returnUrl
 			: "/";
+
+	// In Development/Testing with no real Auth0 credentials configured, bypass the OIDC
+	// discovery call — which would time out against the placeholder domain — and redirect
+	// straight to the test login endpoint instead.
+	if (isPlaceholderAuth0Config)
+	{
+		ctx.Response.Redirect("/test/login");
+		return;
+	}
+
 	var props = new LoginAuthenticationPropertiesBuilder()
 			.WithRedirectUri(safeReturn)
 			.Build();

--- a/tests/AppHost.Tests/Infrastructure/AspireManager.cs
+++ b/tests/AppHost.Tests/Infrastructure/AspireManager.cs
@@ -60,6 +60,11 @@ public class AspireManager : IAsyncLifetime
 		// value is applied at subprocess launch time, after DCP finishes its own setup.
 		_logger.LogInformation("Injecting ASPNETCORE_ENVIRONMENT=Testing into web resource...");
 		SetWebEnvironmentVariable(builder, "ASPNETCORE_ENVIRONMENT", "Testing");
+		_logger.LogInformation(
+			"Clearing Auth0 environment variables inside the web resource so AppHost tests stay deterministic even when the parent process has real secrets configured.");
+		SetWebEnvironmentVariable(builder, "Auth0__Domain", string.Empty);
+		SetWebEnvironmentVariable(builder, "Auth0__ClientId", string.Empty);
+		SetWebEnvironmentVariable(builder, "Auth0__ClientSecret", string.Empty);
 
 		if (ShouldUseFixedWebPort())
 		{

--- a/tests/AppHost.Tests/Infrastructure/ClearCommandAppFixture.cs
+++ b/tests/AppHost.Tests/Infrastructure/ClearCommandAppFixture.cs
@@ -45,6 +45,9 @@ public sealed class ClearCommandAppFixture : IAsyncLifetime
 		// Inject the Testing env var directly into the web resource annotation so DCP
 		// uses the correct value when launching the child process.
 		SetWebEnvironmentVariable(Builder, "ASPNETCORE_ENVIRONMENT", "Testing");
+		SetWebEnvironmentVariable(Builder, "Auth0__Domain", string.Empty);
+		SetWebEnvironmentVariable(Builder, "Auth0__ClientId", string.Empty);
+		SetWebEnvironmentVariable(Builder, "Auth0__ClientSecret", string.Empty);
 
 		App = await Builder.BuildAsync();
 		await App.StartAsync();

--- a/tests/AppHost.Tests/Tests/Auth/LoginFallbackTests.cs
+++ b/tests/AppHost.Tests/Tests/Auth/LoginFallbackTests.cs
@@ -1,0 +1,44 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     LoginFallbackTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  AppHost.Tests
+//=======================================================
+
+using AppHost.Tests.Infrastructure;
+
+using FluentAssertions;
+
+namespace AppHost.Tests;
+
+[Collection(AppHostTestCollection.Name)]
+public sealed class LoginFallbackTests(AspireManager aspireManager)
+{
+	[Fact]
+	public async Task AccountLogin_InTestingWithoutAuth0Secrets_RedirectsToLocalTestLogin()
+	{
+		// Arrange
+		var endpoint = aspireManager.App?.GetEndpoint("web", "https")
+			?? throw new InvalidOperationException("The web endpoint was not available for AppHost tests.");
+
+		using var handler = new HttpClientHandler
+		{
+			AllowAutoRedirect = false,
+			ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+		};
+		using var client = new HttpClient(handler) { BaseAddress = endpoint };
+
+		// Act
+		using var response = await client.GetAsync(
+			new Uri("/Account/Login?returnUrl=/profile", UriKind.Relative),
+			TestContext.Current.CancellationToken);
+
+		// Assert
+		response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+		response.Headers.Location.Should().NotBeNull();
+		response.Headers.Location!.ToString().Should().StartWith("/test/login");
+		response.Headers.Location!.ToString().Should().NotContain("test.auth0.com");
+	}
+}

--- a/tests/AppHost.Tests/Tests/Auth/LoginFallbackTests.cs
+++ b/tests/AppHost.Tests/Tests/Auth/LoginFallbackTests.cs
@@ -17,7 +17,7 @@ namespace AppHost.Tests;
 public sealed class LoginFallbackTests(AspireManager aspireManager)
 {
 	[Fact]
-	public async Task AccountLogin_InTestingWithoutAuth0Secrets_RedirectsToLocalTestLogin()
+	public async Task AccountLogin_InTestingWithPlaceholderAuth0Config_RedirectsToLocalTestLogin()
 	{
 		// Arrange
 		var endpoint = aspireManager.App?.GetEndpoint("web", "https")

--- a/tests/Architecture.Tests/AuthFallbackContractTests.cs
+++ b/tests/Architecture.Tests/AuthFallbackContractTests.cs
@@ -1,0 +1,54 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     AuthFallbackContractTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Architecture.Tests
+//=======================================================
+
+namespace MyBlog.Architecture.Tests;
+
+public sealed class AuthFallbackContractTests
+{
+	private static readonly string RepoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../"));
+
+	[Fact]
+	public void AccountLogin_Should_ShortCircuitPlaceholderAuth0Config_BeforeOidcChallenge()
+	{
+		// Arrange
+		var loginHandlerSource = ExtractLoginHandler(ReadRepoFile("src/Web/Program.cs"));
+		var placeholderGuardIndex = loginHandlerSource.IndexOf("if (isPlaceholderAuth0Config)", StringComparison.Ordinal);
+		var localRedirectIndex = loginHandlerSource.IndexOf("ctx.Response.Redirect(\"/test/login\")", StringComparison.Ordinal);
+		var challengeIndex = loginHandlerSource.IndexOf(
+			"await ctx.ChallengeAsync(Auth0Constants.AuthenticationScheme, props).ConfigureAwait(false);",
+			StringComparison.Ordinal);
+
+		// Act / Assert
+		placeholderGuardIndex.Should().BeGreaterThanOrEqualTo(
+			0,
+			because: "the login endpoint must detect placeholder Auth0 settings before trying OIDC");
+		localRedirectIndex.Should().BeGreaterThan(
+			placeholderGuardIndex,
+			because: "placeholder Auth0 settings in Development/Testing should redirect to the local test login endpoint");
+		challengeIndex.Should().BeGreaterThan(
+			localRedirectIndex,
+			because: "real Auth0 credentials must still use the normal OIDC challenge flow");
+	}
+
+	private static string ExtractLoginHandler(string programSource)
+	{
+		var start = programSource.IndexOf("app.MapGet(\"/Account/Login\"", StringComparison.Ordinal);
+		start.Should().BeGreaterThanOrEqualTo(0, because: "Program.cs should map the login endpoint");
+
+		var end = programSource.IndexOf("}).AllowAnonymous();", start, StringComparison.Ordinal);
+		end.Should().BeGreaterThan(start, because: "the login endpoint should remain explicitly anonymous");
+
+		return programSource[start..end];
+	}
+
+	private static string ReadRepoFile(string relativePath)
+	{
+		return File.ReadAllText(Path.Combine(RepoRoot, relativePath));
+	}
+}


### PR DESCRIPTION
## Summary

Closes #396

Working as **Gandalf** (Security Officer)

### Problem

In Development/Testing with no real Auth0 credentials configured, `Program.cs` falls back to the placeholder domain `test.auth0.com`. Navigating to `/Account/Login` then triggers a real OIDC discovery call against that non-existent domain, producing `IDX20803: Unable to obtain configuration from … test.auth0.com` after a full timeout.

### Fix

**`isPlaceholderAuth0Config` flag** — set to `true` only when placeholder values are active. Developers with real user-secrets configured are completely unaffected; the flag stays `false` and the Auth0 Universal Login flow is preserved.

**`/Account/Login` short-circuit** — when the flag is `true`, the endpoint redirects immediately to `/test/login` (the existing cookie-based test login) instead of issuing a `ChallengeAsync` to the placeholder domain.

**`existingOnTokenValidated` null guard** — added `if (existingOnTokenValidated != null)` before invoking the captured delegate (PR #2 audit finding — latent `NullReferenceException` on every real login when Auth0 SDK leaves the delegate null).

### Files changed

| File | Change |
|---|---|
| `src/Web/Program.cs` | Flag, null-guard, `/Account/Login` short-circuit |
| `docs/AUTH0_SETUP.md` | New troubleshooting entry: IDX20803 timeout pattern |
| `.squad/agents/gandalf/history.md` | Key learnings appended |

### Security test scenarios for Gimli

1. `GET /Account/Login` when `isPlaceholderAuth0Config = true` → assert 302 to `/test/login`, no OIDC challenge issued.
2. `GET /Account/Login` when real Auth0 credentials are configured → assert OIDC challenge (302 to Auth0 domain), `/test/login` NOT called.
3. Production startup without credentials → assert `InvalidOperationException` is thrown.
4. `GET /test/login` in Development → assert cookie set, redirect to `/`, user authenticated.
5. `GET /test/login` in Production → assert 404 (endpoint not registered).
6. `OnTokenValidated` with null prior handler → assert no `NullReferenceException`; role claims added normally.

### Pre-push gates

All 7 gates passed locally (build Release ✅, 420 unit tests ✅, 56 integration/E2E tests ✅).