### PR TITLE
fix(auth): preserve returnUrl in local fallback login

### DIFF
--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -187,7 +187,7 @@ app.MapGet("/Account/Login", async (HttpContext ctx, string? returnUrl) =>
 	// straight to the test login endpoint instead.
 	if (isPlaceholderAuth0Config)
 	{
-		ctx.Response.Redirect("/test/login");
+		ctx.Response.Redirect($"/test/login?returnUrl={Uri.EscapeDataString(safeReturn)}");
 		return;
 	}
 
@@ -219,9 +219,13 @@ app.MapDefaultEndpoints();
 app.Run();
 
 [ExcludeFromCodeCoverage(Justification = "Test-only endpoint for E2E testing")]
-static async Task MapTestLoginEndpoint(HttpContext ctx, string? role)
+static async Task MapTestLoginEndpoint(HttpContext ctx, string? role, string? returnUrl)
 {
 	var roleValue = string.IsNullOrWhiteSpace(role) ? "user" : role;
+	var safeReturn = !string.IsNullOrEmpty(returnUrl)
+			&& Uri.IsWellFormedUriString(returnUrl, UriKind.Relative)
+			? returnUrl
+			: "/";
 
 	// Create claims for the test user
 	var claims = new List<Claim>
@@ -241,7 +245,7 @@ static async Task MapTestLoginEndpoint(HttpContext ctx, string? role)
 		IsPersistent = true,
 	}).ConfigureAwait(false);
 
-	ctx.Response.Redirect("/");
+	ctx.Response.Redirect(safeReturn);
 }
 
 // Exclude the compiler-generated Program class (top-level bootstrap statements) from coverage.

--- a/tests/AppHost.Tests/Tests/Auth/LoginFallbackTests.cs
+++ b/tests/AppHost.Tests/Tests/Auth/LoginFallbackTests.cs
@@ -17,7 +17,7 @@ namespace AppHost.Tests;
 public sealed class LoginFallbackTests(AspireManager aspireManager)
 {
 	[Fact]
-	public async Task AccountLogin_InTestingWithPlaceholderAuth0Config_RedirectsToLocalTestLogin()
+	public async Task AccountLogin_InTestingWithPlaceholderAuth0Config_RedirectsToLocalTestLoginWithReturnUrl()
 	{
 		// Arrange
 		var endpoint = aspireManager.App?.GetEndpoint("web", "https")
@@ -38,7 +38,32 @@ public sealed class LoginFallbackTests(AspireManager aspireManager)
 		// Assert
 		response.StatusCode.Should().Be(HttpStatusCode.Redirect);
 		response.Headers.Location.Should().NotBeNull();
-		response.Headers.Location!.ToString().Should().StartWith("/test/login");
+		response.Headers.Location!.ToString().Should().Be("/test/login?returnUrl=%2Fprofile");
 		response.Headers.Location!.ToString().Should().NotContain("test.auth0.com");
+	}
+
+	[Fact]
+	public async Task TestLogin_InTestingWithReturnUrl_RedirectsBackToRequestedPage()
+	{
+		// Arrange
+		var endpoint = aspireManager.App?.GetEndpoint("web", "https")
+			?? throw new InvalidOperationException("The web endpoint was not available for AppHost tests.");
+
+		using var handler = new HttpClientHandler
+		{
+			AllowAutoRedirect = false,
+			ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+		};
+		using var client = new HttpClient(handler) { BaseAddress = endpoint };
+
+		// Act
+		using var response = await client.GetAsync(
+			new Uri("/test/login?returnUrl=/profile", UriKind.Relative),
+			TestContext.Current.CancellationToken);
+
+		// Assert
+		response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+		response.Headers.Location.Should().NotBeNull();
+		response.Headers.Location!.ToString().Should().Be("/profile");
 	}
 }

--- a/tests/Architecture.Tests/AuthFallbackContractTests.cs
+++ b/tests/Architecture.Tests/AuthFallbackContractTests.cs
@@ -19,7 +19,9 @@ public sealed class AuthFallbackContractTests
 		// Arrange
 		var loginHandlerSource = ExtractLoginHandler(ReadRepoFile("src/Web/Program.cs"));
 		var placeholderGuardIndex = loginHandlerSource.IndexOf("if (isPlaceholderAuth0Config)", StringComparison.Ordinal);
-		var localRedirectIndex = loginHandlerSource.IndexOf("ctx.Response.Redirect(\"/test/login\")", StringComparison.Ordinal);
+		var localRedirectIndex = loginHandlerSource.IndexOf(
+			"ctx.Response.Redirect($\"/test/login?returnUrl={Uri.EscapeDataString(safeReturn)}\")",
+			StringComparison.Ordinal);
 		var challengeIndex = loginHandlerSource.IndexOf(
 			"await ctx.ChallengeAsync(Auth0Constants.AuthenticationScheme, props).ConfigureAwait(false);",
 			StringComparison.Ordinal);


### PR DESCRIPTION
## Summary
- preserve the validated `returnUrl` when placeholder Auth0 config redirects `/Account/Login` to `/test/login`
- teach the local test-login endpoint to honor the same safe relative return path
- strengthen AppHost and architecture coverage for the fallback redirect contract

## Context
- follow-up to merged PR #397

Closes #398
Working as Gandalf (Security / Auth)