### PR TITLE
[Sprint 20] Review and land current app tweaks

### DIFF
--- a/docs/AUTH0_SETUP.md
+++ b/docs/AUTH0_SETUP.md
@@ -297,19 +297,14 @@ exports.onExecutePostLogin = async (event, api) => {
 
 ---
 
-### Login times out with `IDX20803` / `test.auth0.com` in Development
+### Development fails to start with `test.auth0.com` or other placeholder Auth0 settings
 
-**Cause**: Auth0 credentials are not configured locally, so the app falls back to the
-placeholder domain `test.auth0.com`. Clicking **Login** then triggers a real OpenID Connect
-discovery call against that non-existent domain, which hangs until timeout
-(`IDX20803: Unable to obtain configuration from … test.auth0.com`).
+**Cause**: The local cookie-based `Test User` login is reserved for the `Testing`
+environment used by AppHost and Playwright automation. Normal `Development`
+requires real Auth0 credentials. Placeholder values such as `test.auth0.com` or
+`test-client-id` are treated as invalid outside `Testing`.
 
-**Fix**: This is the expected fallback path. When no credentials are configured in
-Development or Testing, `/Account/Login` redirects straight to `/test/login`
-(the cookie-based test login endpoint) instead of performing an OIDC challenge.
-No action is required — simply click Login and you will be signed in as `Test User`.
-
-To use real Auth0 login locally, set your user secrets:
+**Fix**: Set your user secrets for the Web project:
 
 ```bash
 dotnet user-secrets set "Auth0:Domain"        "your-tenant.us.auth0.com" --project src/Web
@@ -317,7 +312,12 @@ dotnet user-secrets set "Auth0:ClientId"      "YOUR_CLIENT_ID"           --proje
 dotnet user-secrets set "Auth0:ClientSecret"  "YOUR_CLIENT_SECRET"       --project src/Web
 ```
 
-Once set, the app detects real credentials and routes `/Account/Login` to Auth0 Universal Login.
+Once set, the app routes `/Account/Login` to Auth0 Universal Login and `/Account/Logout`
+signs out through Auth0.
+
+If you are unexpectedly signed in as `Test User`, verify that the app is not running
+with `ASPNETCORE_ENVIRONMENT=Testing` and that you did not navigate directly to
+`/test/login`.
 
 ---
 

--- a/src/AppHost/AppHost.cs
+++ b/src/AppHost/AppHost.cs
@@ -7,6 +7,8 @@
 //Project Name :  AppHost
 //=======================================================
 
+using MyBlog.AppHost;
+
 var builder = DistributedApplication.CreateBuilder(args);
 
 var mongo = builder.AddMongoDB("mongodb")

--- a/src/AppHost/MongoDbResourceBuilderExtensions.cs
+++ b/src/AppHost/MongoDbResourceBuilderExtensions.cs
@@ -50,6 +50,8 @@ internal static partial class MongoDbResourceBuilderExtensions
 	[LoggerMessage(Level = LogLevel.Information, Message = "Seed MyBlog data complete: 7 categories upserted + {Count} blog post(s) inserted.")]
 	private static partial void LogSeedComplete(ILogger logger, int count);
 
+	private static readonly string[] LegacyCollectionsToDrop = ["posts", "tags"];
+
 	[LoggerMessage(Level = LogLevel.Warning, Message = "Show MyBlog stats skipped on {ResourceName} — a database operation is already in progress.")]
 	private static partial void LogStatsSkipped(ILogger logger, string resourceName);
 
@@ -229,6 +231,21 @@ internal static partial class MongoDbResourceBuilderExtensions
 
 				var client = new MongoClient(connectionString);
 				var database = client.GetDatabase(databaseName);
+				var collectionNames = await (await database.ListCollectionNamesAsync(cancellationToken: context.CancellationToken).ConfigureAwait(false))
+					.ToListAsync(context.CancellationToken)
+					.ConfigureAwait(false);
+
+				var droppedLegacyCollections = new List<string>();
+				foreach (var legacyCollectionName in LegacyCollectionsToDrop)
+				{
+					if (!collectionNames.Contains(legacyCollectionName, StringComparer.Ordinal))
+					{
+						continue;
+					}
+
+					await database.DropCollectionAsync(legacyCollectionName, context.CancellationToken).ConfigureAwait(false);
+					droppedLegacyCollections.Add(legacyCollectionName);
+				}
 
 				var categoriesCollection = database.GetCollection<BsonDocument>("categories");
 				var postsCollection = database.GetCollection<BsonDocument>("blogposts");
@@ -318,6 +335,9 @@ new()
 				{
 					Success = true,
 					Message = $"categories: 7 upserted (ASP.NET Core, Blazor Server, Blazor WebAssembly, C#, EF Core, .NET MAUI, Other); blogposts: {seedDocuments.Length} inserted (2 published, 1 draft)"
+						+ (droppedLegacyCollections.Count == 0
+							? string.Empty
+							: $"; dropped legacy collections: {string.Join(", ", droppedLegacyCollections)}")
 				};
 			}
 			finally

--- a/src/AppHost/MongoDbResourceBuilderExtensions.cs
+++ b/src/AppHost/MongoDbResourceBuilderExtensions.cs
@@ -16,12 +16,12 @@ using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
 using MongoDB.Driver;
 
-namespace Aspire.Hosting;
+namespace MyBlog.AppHost;
 
 internal static partial class MongoDbResourceBuilderExtensions
 {
 	// Shared semaphore — guards all three dev commands (Clear, Seed, Stats) so only one runs at a time.
-	private static readonly SemaphoreSlim _dbMutex = new(1, 1);
+	private static readonly SemaphoreSlim DbMutex = new(1, 1);
 
 	[LoggerMessage(Level = LogLevel.Warning, Message = "Clear MyBlog data skipped on {ResourceName} — a clear operation is already in progress.")]
 	private static partial void LogClearSkipped(ILogger logger, string resourceName);
@@ -90,7 +90,7 @@ internal static partial class MongoDbResourceBuilderExtensions
 		executeCommand: async context =>
 		{
 			// AC2: Non-blocking acquire — return immediately if another clear is already in flight.
-			if (!await _dbMutex.WaitAsync(0).ConfigureAwait(false))
+			if (!await DbMutex.WaitAsync(0).ConfigureAwait(false))
 			{
 				LogClearSkipped(context.Logger, context.ResourceName);
 
@@ -171,7 +171,7 @@ internal static partial class MongoDbResourceBuilderExtensions
 			}
 			finally
 			{
-				_dbMutex.Release();
+				DbMutex.Release();
 			}
 		},
 		new CommandOptions
@@ -199,7 +199,7 @@ internal static partial class MongoDbResourceBuilderExtensions
 		"🌱 Seed MyBlog Data",
 		executeCommand: async context =>
 		{
-			if (!await _dbMutex.WaitAsync(0).ConfigureAwait(false))
+			if (!await DbMutex.WaitAsync(0).ConfigureAwait(false))
 			{
 				LogSeedSkipped(context.Logger, context.ResourceName);
 
@@ -342,7 +342,7 @@ new()
 			}
 			finally
 			{
-				_dbMutex.Release();
+				DbMutex.Release();
 			}
 		},
 		new CommandOptions
@@ -365,7 +365,7 @@ new()
 		"📊 Show MyBlog Stats",
 		executeCommand: async context =>
 		{
-			if (!await _dbMutex.WaitAsync(0).ConfigureAwait(false))
+			if (!await DbMutex.WaitAsync(0).ConfigureAwait(false))
 			{
 				LogStatsSkipped(context.Logger, context.ResourceName);
 
@@ -427,7 +427,7 @@ new()
 			}
 			finally
 			{
-				_dbMutex.Release();
+				DbMutex.Release();
 			}
 		},
 		new CommandOptions

--- a/src/Web/Features/UserManagement/ManageRoles.razor
+++ b/src/Web/Features/UserManagement/ManageRoles.razor
@@ -21,9 +21,10 @@ else
 
 	@if (_availableRoles.Any())
 	{
-		<p>Available roles: @string.Join(", ", _availableRoles.Select(r =>
-																			r.Name))</p>
-		}
+		<p>Available roles: @string.Join(
+			", ",
+			_availableRoles.Select(role => role.Name))</p>
+	}
 
 		<div class="table-wrapper">
 			<table class="data-table">
@@ -49,7 +50,7 @@ else
 									if (hasRole)
 									{
 										<button
-											class="inline-block px-3 py-1 text-sm rounded border border-green-600 text-green-600 hover:bg-green-50 dark:hover:bg-green-900/20 transition mr-1 mb-1"
+											class="@ActiveRoleButtonClass"
 											@onclick="() => RemoveRole(user.UserId, role.Id)">
 											@role.Name: Active (Remove)
 										</button>
@@ -57,7 +58,7 @@ else
 									else
 									{
 										<button
-											class="inline-block px-3 py-1 text-sm rounded border border-red-600 text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 transition mr-1 mb-1"
+											class="@InactiveRoleButtonClass"
 											@onclick="() => AssignRole(user.UserId, role.Id)">
 											@role.Name: Inactive (Add)
 										</button>
@@ -72,6 +73,14 @@ else
 	}
 
 @code {
+	private const string ActiveRoleButtonClass =
+		"inline-block px-3 py-1 text-sm rounded border border-green-600 text-green-600 " +
+		"hover:bg-green-50 dark:hover:bg-green-900/20 transition mr-1 mb-1";
+
+	private const string InactiveRoleButtonClass =
+		"inline-block px-3 py-1 text-sm rounded border border-red-600 text-red-600 " +
+		"hover:bg-red-50 dark:hover:bg-red-900/20 transition mr-1 mb-1";
+
 	private IReadOnlyList<UserWithRolesDto> _users = [];
 	private IReadOnlyList<RoleDto> _availableRoles = [];
 	private bool _loading = true;

--- a/src/Web/Features/UserManagement/ManageRoles.razor
+++ b/src/Web/Features/UserManagement/ManageRoles.razor
@@ -22,7 +22,7 @@ else
 	@if (_availableRoles.Any())
 	{
 		<p>Available roles: @string.Join(", ", _availableRoles.Select(r =>
-										r.Name))</p>
+																			r.Name))</p>
 		}
 
 		<div class="table-wrapper">
@@ -43,21 +43,25 @@ else
 							<td>@user.Email</td>
 							<td>@string.Join(", ", user.Roles)</td>
 							<td>
-								@foreach (var role in _availableRoles.Where(r => !user.Roles.Contains(r.Name)))
+								@foreach (var role in _availableRoles)
 								{
-									<button
-										class="inline-block px-3 py-1 text-sm rounded border border-green-600 text-green-600 hover:bg-green-50 dark:hover:bg-green-900/20 transition mr-1 mb-1"
-										@onclick="() => AssignRole(user.UserId, role.Id)">
-										+ @role.Name
-									</button>
-								}
-								@foreach (var role in _availableRoles.Where(r => user.Roles.Contains(r.Name)))
-								{
-									<button
-										class="inline-block px-3 py-1 text-sm rounded border border-red-600 text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 transition mr-1 mb-1"
-										@onclick="() => RemoveRole(user.UserId, role.Id)">
-										- @role.Name
-									</button>
+									var hasRole = user.Roles.Contains(role.Name);
+									if (hasRole)
+									{
+										<button
+											class="inline-block px-3 py-1 text-sm rounded border border-green-600 text-green-600 hover:bg-green-50 dark:hover:bg-green-900/20 transition mr-1 mb-1"
+											@onclick="() => RemoveRole(user.UserId, role.Id)">
+											@role.Name: Active (Remove)
+										</button>
+									}
+									else
+									{
+										<button
+											class="inline-block px-3 py-1 text-sm rounded border border-red-600 text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 transition mr-1 mb-1"
+											@onclick="() => AssignRole(user.UserId, role.Id)">
+											@role.Name: Inactive (Add)
+										</button>
+									}
 								}
 							</td>
 						</tr>
@@ -85,7 +89,9 @@ else
 		if (usersResult.Success) _users = usersResult.Value!;
 		else _error = usersResult.Error;
 
-		if (rolesResult.Success) _availableRoles = rolesResult.Value!;
+		if (rolesResult.Success) _availableRoles = rolesResult.Value!
+			.OrderBy(static role => role.Name, StringComparer.OrdinalIgnoreCase)
+			.ToArray();
 		else _error ??= rolesResult.Error;
 
 		_loading = false;

--- a/src/Web/Features/UserManagement/ManageRoles.razor
+++ b/src/Web/Features/UserManagement/ManageRoles.razor
@@ -22,9 +22,9 @@ else
 	@if (_availableRoles.Any())
 	{
 		<p>Available roles: @string.Join(
-			", ",
-			_availableRoles.Select(role => role.Name))</p>
-	}
+						", ",
+						_availableRoles.Select(role => role.Name))</p>
+		}
 
 		<div class="table-wrapper">
 			<table class="data-table">
@@ -49,17 +49,13 @@ else
 									var hasRole = user.Roles.Contains(role.Name);
 									if (hasRole)
 									{
-										<button
-											class="@ActiveRoleButtonClass"
-											@onclick="() => RemoveRole(user.UserId, role.Id)">
+										<button class="@ActiveRoleButtonClass" @onclick="() => RemoveRole(user.UserId, role.Id)">
 											@role.Name: Active (Remove)
 										</button>
 									}
 									else
 									{
-										<button
-											class="@InactiveRoleButtonClass"
-											@onclick="() => AssignRole(user.UserId, role.Id)">
+										<button class="@InactiveRoleButtonClass" @onclick="() => AssignRole(user.UserId, role.Id)">
 											@role.Name: Inactive (Add)
 										</button>
 									}

--- a/src/Web/Features/UserManagement/UserManagementHandler.cs
+++ b/src/Web/Features/UserManagement/UserManagementHandler.cs
@@ -178,10 +178,22 @@ IRequestHandler<GetAvailableRolesQuery, Result<IReadOnlyList<RoleDto>>>
 
 	private async Task<ManagementApiClient> GetManagementClientAsync(CancellationToken cancellationToken)
 	{
-		var domain = GetRequiredManagementSetting("Auth0Management:Domain", "Auth0:ManagementApiDomain");
-		var clientId = GetRequiredManagementSetting("Auth0Management:ClientId", "Auth0:ManagementApiClientId");
-		var clientSecret = GetRequiredManagementSetting("Auth0Management:ClientSecret", "Auth0:ManagementApiClientSecret");
-		var audience = GetOptionalManagementSetting("Auth0Management:Audience", "Auth0:ManagementApiAudience")
+		var domain = GetRequiredManagementSetting(
+			"Auth0Management:Domain",
+			"Auth0:ManagementApiDomain",
+			"Auth0:Auth0Management:Domain");
+		var clientId = GetRequiredManagementSetting(
+			"Auth0Management:ClientId",
+			"Auth0:ManagementApiClientId",
+			"Auth0:Auth0Management:ClientId");
+		var clientSecret = GetRequiredManagementSetting(
+			"Auth0Management:ClientSecret",
+			"Auth0:ManagementApiClientSecret",
+			"Auth0:Auth0Management:ClientSecret");
+		var audience = GetOptionalManagementSetting(
+			"Auth0Management:Audience",
+			"Auth0:ManagementApiAudience",
+			"Auth0:Auth0Management:Audience")
 				?? $"https://{domain}/api/v2/";
 
 		using var httpClient = httpClientFactory.CreateClient();
@@ -206,9 +218,14 @@ IRequestHandler<GetAvailableRolesQuery, Result<IReadOnlyList<RoleDto>>>
 		clientOptions: new ClientOptions { BaseUrl = $"https://{domain}/api/v2" });
 	}
 
-	private string GetRequiredManagementSetting(string primaryKey, string legacyKey)
+	private string GetRequiredManagementSetting(string primaryKey, string legacyKey, params string[] additionalKeys)
 	{
-		return GetOptionalManagementSetting(primaryKey, legacyKey)
+		var keys = new string[additionalKeys.Length + 2];
+		keys[0] = primaryKey;
+		keys[1] = legacyKey;
+		additionalKeys.CopyTo(keys, 2);
+
+		return GetOptionalManagementSetting(keys)
 				?? throw new InvalidOperationException(
 					$"{primaryKey} not configured. {legacyKey} not configured.");
 	}

--- a/src/Web/Features/UserManagement/UserManagementHandler.cs
+++ b/src/Web/Features/UserManagement/UserManagementHandler.cs
@@ -226,7 +226,7 @@ IRequestHandler<GetAvailableRolesQuery, Result<IReadOnlyList<RoleDto>>>
 
 		return GetOptionalManagementSetting(keys)
 				?? throw new InvalidOperationException(
-					$"{primaryKey} not configured. {legacyKey} not configured.");
+					string.Join(" ", Array.ConvertAll(keys, key => $"{key} not configured.")));
 	}
 
 	private string? GetOptionalManagementSetting(params string[] keys)

--- a/src/Web/Features/UserManagement/UserManagementHandler.cs
+++ b/src/Web/Features/UserManagement/UserManagementHandler.cs
@@ -13,7 +13,6 @@ using Auth0.ManagementApi;
 using Auth0.ManagementApi.Users;
 
 using MyBlog.Domain.Abstractions;
-using MyBlog.Web.Infrastructure.Caching;
 
 namespace MyBlog.Web.Features.UserManagement;
 
@@ -53,7 +52,7 @@ IRequestHandler<GetAvailableRolesQuery, Result<IReadOnlyList<RoleDto>>>
 				}
 				return result;
 			}, cancellationToken).ConfigureAwait(false);
-			return Result.Ok<IReadOnlyList<UserWithRolesDto>>(users);
+			return Result.Ok(users);
 		}
 		catch (OperationCanceledException)
 		{
@@ -154,7 +153,7 @@ IRequestHandler<GetAvailableRolesQuery, Result<IReadOnlyList<RoleDto>>>
 				}
 				return result;
 			}, cancellationToken).ConfigureAwait(false);
-			return Result.Ok<IReadOnlyList<RoleDto>>(roles);
+			return Result.Ok(roles);
 		}
 		catch (OperationCanceledException)
 		{

--- a/src/Web/Infrastructure/Caching/BlogPostCacheService.cs
+++ b/src/Web/Infrastructure/Caching/BlogPostCacheService.cs
@@ -38,7 +38,14 @@ internal sealed class BlogPostCacheService(
 	{
 		// L1 hit (synchronous — no heap allocation)
 		if (localCache.TryGetValue(BlogPostCacheKeys.All, out List<BlogPostDto>? cached) && cached is not null)
-			return cached;
+		{
+			if (cached.Count > 0)
+			{
+				return cached;
+			}
+
+			localCache.Remove(BlogPostCacheKeys.All);
+		}
 
 		// L2 hit
 		var bytes = await distributedCache.GetAsync(BlogPostCacheKeys.All, ct).ConfigureAwait(false);
@@ -47,10 +54,15 @@ internal sealed class BlogPostCacheService(
 			try
 			{
 				var fromRedis = JsonSerializer.Deserialize<List<BlogPostDto>>(bytes, JsonOpts);
-				if (fromRedis is not null)
+				if (fromRedis is { Count: > 0 })
 				{
 					localCache.Set(BlogPostCacheKeys.All, fromRedis, LocalOpts);
 					return fromRedis;
+				}
+
+				if (fromRedis is not null)
+				{
+					await distributedCache.RemoveAsync(BlogPostCacheKeys.All, CancellationToken.None).ConfigureAwait(false);
 				}
 			}
 			catch (JsonException)
@@ -63,13 +75,18 @@ internal sealed class BlogPostCacheService(
 		// DB via caller-supplied fetch
 		var result = await fetch().ConfigureAwait(false);
 		var list = result as List<BlogPostDto> ?? result.ToList();
+		if (list.Count == 0)
+		{
+			return list;
+		}
+
 		localCache.Set(BlogPostCacheKeys.All, list, LocalOpts);
 		await distributedCache.SetAsync(
 			BlogPostCacheKeys.All,
 			JsonSerializer.SerializeToUtf8Bytes(list, JsonOpts),
 			RedisOpts,
 			ct).ConfigureAwait(false);
-		return result;
+		return list;
 	}
 
 	public async ValueTask<BlogPostDto?> GetOrFetchByIdAsync(

--- a/src/Web/Infrastructure/Caching/BlogPostCacheService.cs
+++ b/src/Web/Infrastructure/Caching/BlogPostCacheService.cs
@@ -9,8 +9,6 @@
 
 using System.Text.Json;
 
-using MyBlog.Web.Data;
-
 namespace MyBlog.Web.Infrastructure.Caching;
 
 internal sealed class BlogPostCacheService(

--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -97,7 +97,10 @@ builder.Services.PostConfigure<OpenIdConnectOptions>(Auth0Constants.Authenticati
 	var existingOnTokenValidated = options.Events.OnTokenValidated;
 	options.Events.OnTokenValidated = async context =>
 	{
-		await existingOnTokenValidated(context).ConfigureAwait(false);
+		if (existingOnTokenValidated is not null)
+		{
+			await existingOnTokenValidated(context).ConfigureAwait(false);
+		}
 
 		if (context.Principal?.Identity is not ClaimsIdentity identity)
 		{

--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -42,42 +42,50 @@ builder.AddServiceDefaults();
 builder.Services.AddRazorComponents()
 		.AddInteractiveServerComponents();
 
-// Auth0 authentication — required only in Production
+// Auth0 authentication — real credentials required outside the Testing environment.
 var auth0Domain = builder.Configuration["Auth0:Domain"];
 var auth0ClientId = builder.Configuration["Auth0:ClientId"];
+var auth0ClientSecret = builder.Configuration["Auth0:ClientSecret"];
+var isTestingEnvironment = builder.Environment.IsEnvironment("Testing");
+var usesLocalTestLoginFallback = Auth0ConfigurationHelper.ShouldUseLocalTestLogin(
+	isTestingEnvironment,
+	auth0Domain,
+	auth0ClientId,
+	auth0ClientSecret);
 
-// In Development/Testing, provide mock values; in Production, require real credentials.
-// isPlaceholderAuth0Config stays false when real credentials ARE configured in Dev/Testing,
-// preserving the live Auth0 flow for developers who have set up their user secrets.
-var isPlaceholderAuth0Config = false;
-
-if (!builder.Environment.IsDevelopment() && !builder.Environment.IsEnvironment("Testing"))
+// The local cookie-based test login exists only for the Testing environment that powers
+// AppHost and browser automation. Development and Production must use real Auth0 settings.
+if (!isTestingEnvironment)
 {
-	if (string.IsNullOrEmpty(auth0Domain) || string.IsNullOrEmpty(auth0ClientId))
+	if (Auth0ConfigurationHelper.UsesPlaceholderWebAppLogin(auth0Domain, auth0ClientId, auth0ClientSecret))
 	{
 		throw new InvalidOperationException(
-				"Auth0 configuration is missing or incomplete. Set these user secrets for the Web project:\n" +
+				"Auth0 configuration is missing or using placeholder values. The Web project requires real Auth0 credentials outside the Testing environment. Set these user secrets for the Web project:\n" +
 				"  dotnet user-secrets set \"Auth0:Domain\" \"<your-tenant>.auth0.com\" --project src/Web\n" +
 				"  dotnet user-secrets set \"Auth0:ClientId\" \"<your-client-id>\" --project src/Web\n" +
 				"  dotnet user-secrets set \"Auth0:ClientSecret\" \"<your-client-secret>\" --project src/Web");
 	}
 }
-else if (string.IsNullOrWhiteSpace(auth0Domain) || string.IsNullOrWhiteSpace(auth0ClientId))
+else if (usesLocalTestLoginFallback)
 {
-	// Development/Testing without real Auth0 credentials: use placeholder values and flag
-	// so /Account/Login bypasses the OIDC discovery call (which would timeout against test.auth0.com).
+	// Testing without real Auth0 credentials: use placeholder values and flag so the
+	// AppHost and Playwright test harness can short-circuit to the local cookie login.
 	auth0Domain = "test.auth0.com";
 	auth0ClientId = "test-client-id";
-	isPlaceholderAuth0Config = true;
+	auth0ClientSecret = "test-client-secret";
 }
+
+var resolvedAuth0Domain = auth0Domain ?? throw new InvalidOperationException("Auth0 domain was not resolved.");
+var resolvedAuth0ClientId = auth0ClientId ?? throw new InvalidOperationException("Auth0 client ID was not resolved.");
+var resolvedAuth0ClientSecret = auth0ClientSecret ?? throw new InvalidOperationException("Auth0 client secret was not resolved.");
 
 var auth0RoleClaimTypes = RoleClaimsHelper.GetRoleClaimTypes(builder.Configuration);
 
 builder.Services.AddAuth0WebAppAuthentication(opts =>
 {
-	opts.Domain = auth0Domain;
-	opts.ClientId = auth0ClientId;
-	opts.ClientSecret = builder.Configuration["Auth0:ClientSecret"];
+	opts.Domain = resolvedAuth0Domain;
+	opts.ClientId = resolvedAuth0ClientId;
+	opts.ClientSecret = resolvedAuth0ClientSecret;
 	opts.Scope = "openid profile email";
 	opts.CallbackPath = "/signin-auth0";
 });
@@ -89,10 +97,7 @@ builder.Services.PostConfigure<OpenIdConnectOptions>(Auth0Constants.Authenticati
 	var existingOnTokenValidated = options.Events.OnTokenValidated;
 	options.Events.OnTokenValidated = async context =>
 	{
-		if (existingOnTokenValidated != null)
-		{
-			await existingOnTokenValidated(context).ConfigureAwait(false);
-		}
+		await existingOnTokenValidated(context).ConfigureAwait(false);
 
 		if (context.Principal?.Identity is not ClaimsIdentity identity)
 		{
@@ -182,10 +187,8 @@ app.MapGet("/Account/Login", async (HttpContext ctx, string? returnUrl) =>
 			? returnUrl
 			: "/";
 
-	// In Development/Testing with no real Auth0 credentials configured, bypass the OIDC
-	// discovery call — which would time out against the placeholder domain — and redirect
-	// straight to the test login endpoint instead.
-	if (isPlaceholderAuth0Config)
+	// Only the Testing environment may bypass Auth0 and use the local cookie-based test login.
+	if (usesLocalTestLoginFallback && app.Environment.IsEnvironment("Testing"))
 	{
 		ctx.Response.Redirect($"/test/login?returnUrl={Uri.EscapeDataString(safeReturn)}");
 		return;
@@ -206,8 +209,8 @@ app.MapGet("/Account/Logout", async ctx =>
 	await ctx.SignOutAsync().ConfigureAwait(false);
 }).RequireAuthorization();
 
-// Test-only login endpoint for E2E testing (Development/Testing environments only)
-if (app.Environment.IsDevelopment() || app.Environment.IsEnvironment("Testing"))
+// Test-only login endpoint for E2E testing (Testing environment only)
+if (app.Environment.IsEnvironment("Testing"))
 {
 	app.MapGet("/test/login", MapTestLoginEndpoint).AllowAnonymous();
 }

--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -233,10 +233,10 @@ static async Task MapTestLoginEndpoint(HttpContext ctx, string? role, string? re
 	// Create claims for the test user
 	var claims = new List<Claim>
 	{
-		new Claim(ClaimTypes.NameIdentifier, "test-user-id"),
-		new Claim(ClaimTypes.Name, "Test User"),
-		new Claim(ClaimTypes.Email, "test@example.com"),
-		new Claim(ClaimTypes.Role, roleValue),
+		new(ClaimTypes.NameIdentifier, "test-user-id"),
+		new(ClaimTypes.Name, "Test User"),
+		new(ClaimTypes.Email, "test@example.com"),
+		new(ClaimTypes.Role, roleValue),
 	};
 
 	var identity = new ClaimsIdentity(claims, "TestScheme");

--- a/src/Web/Security/Auth0ConfigurationHelper.cs
+++ b/src/Web/Security/Auth0ConfigurationHelper.cs
@@ -1,0 +1,45 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     Auth0ConfigurationHelper.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web
+//=======================================================
+
+namespace MyBlog.Web.Security;
+
+internal static class Auth0ConfigurationHelper
+{
+	private const string PlaceholderDomain = "test.auth0.com";
+	private const string PlaceholderClientId = "test-client-id";
+	private const string PlaceholderClientSecret = "test-client-secret";
+
+	public static bool UsesPlaceholderWebAppLogin(string? domain, string? clientId)
+	{
+		return string.IsNullOrWhiteSpace(domain)
+				|| string.IsNullOrWhiteSpace(clientId)
+				|| string.Equals(domain, PlaceholderDomain, StringComparison.OrdinalIgnoreCase)
+				|| string.Equals(clientId, PlaceholderClientId, StringComparison.OrdinalIgnoreCase);
+	}
+
+	public static bool UsesPlaceholderWebAppLogin(string? domain, string? clientId, string? clientSecret)
+	{
+		return string.IsNullOrWhiteSpace(domain)
+						|| string.IsNullOrWhiteSpace(clientId)
+						|| string.IsNullOrWhiteSpace(clientSecret)
+						|| string.Equals(domain, PlaceholderDomain, StringComparison.OrdinalIgnoreCase)
+						|| string.Equals(clientId, PlaceholderClientId, StringComparison.OrdinalIgnoreCase)
+						|| string.Equals(clientSecret, PlaceholderClientSecret, StringComparison.Ordinal);
+	}
+
+	public static bool ShouldUseLocalTestLogin(bool isTestingEnvironment, string? domain, string? clientId)
+	{
+		return isTestingEnvironment && UsesPlaceholderWebAppLogin(domain, clientId);
+	}
+
+	public static bool ShouldUseLocalTestLogin(bool isTestingEnvironment, string? domain, string? clientId, string? clientSecret)
+	{
+		return isTestingEnvironment && UsesPlaceholderWebAppLogin(domain, clientId, clientSecret);
+	}
+}

--- a/tests/AppHost.Tests/MongoSeedDataIntegrationTests.cs
+++ b/tests/AppHost.Tests/MongoSeedDataIntegrationTests.cs
@@ -7,11 +7,7 @@
 // Project Name :  AppHost.Tests
 // =============================================
 
-using System.Net;
-
 using AppHost.Tests.Infrastructure;
-
-using Aspire.Hosting;
 
 using FluentAssertions;
 
@@ -19,6 +15,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 using MongoDB.Bson;
 using MongoDB.Driver;
+
+using MongoDbResourceBuilderExtensions = MyBlog.AppHost.MongoDbResourceBuilderExtensions;
 
 namespace AppHost.Tests;
 
@@ -238,9 +236,9 @@ public sealed class MongoSeedDataIntegrationTests(ClearCommandAppFixture fixture
 		var annotation = GetAnnotation();
 		var expectedCategoryByTitle = new Dictionary<string, ObjectId>(StringComparer.Ordinal)
 		{
-			["Welcome to MyBlog"] = new ObjectId("677db9bd900ea4af1b500cb1"),
-			["Getting Started with .NET Aspire"] = new ObjectId("677db927900ea4af1b500cab"),
-			["Draft: MongoDB Performance Tips"] = new ObjectId("677db9bd900ea4af1b500cb1"),
+			["Welcome to MyBlog"] = new("677db9bd900ea4af1b500cb1"),
+			["Getting Started with .NET Aspire"] = new("677db927900ea4af1b500cab"),
+			["Draft: MongoDB Performance Tips"] = new("677db9bd900ea4af1b500cb1"),
 		};
 
 		// Act

--- a/tests/AppHost.Tests/MongoSeedDataIntegrationTests.cs
+++ b/tests/AppHost.Tests/MongoSeedDataIntegrationTests.cs
@@ -151,6 +151,40 @@ public sealed class MongoSeedDataIntegrationTests(ClearCommandAppFixture fixture
 	}
 
 	/// <summary>
+	/// Legacy collections from earlier schemas must be removed so the database converges on the
+	/// canonical MyBlog collection set: blogposts + categories.
+	/// </summary>
+	[Fact]
+	public async Task SeedMyBlogData_Drops_Legacy_Posts_And_Tags_Collections()
+	{
+		// Arrange
+		using var mongoClient = new MongoClient(fixture.MongoConnectionString);
+		await mongoClient.DropDatabaseAsync("myblog", TestContext.Current.CancellationToken);
+		var db = mongoClient.GetDatabase("myblog");
+		await db.CreateCollectionAsync("posts", cancellationToken: TestContext.Current.CancellationToken);
+		await db.CreateCollectionAsync("tags", cancellationToken: TestContext.Current.CancellationToken);
+		await db.GetCollection<BsonDocument>("posts")
+			.InsertOneAsync(new BsonDocument("n", 1), cancellationToken: TestContext.Current.CancellationToken);
+		await db.GetCollection<BsonDocument>("tags")
+			.InsertOneAsync(new BsonDocument("n", 1), cancellationToken: TestContext.Current.CancellationToken);
+
+		var annotation = GetAnnotation();
+
+		// Act
+		var result = await annotation.ExecuteCommand(MakeContext());
+
+		// Assert
+		result.Success.Should().BeTrue("seeding should normalize the database before inserting canonical documents");
+		var collectionNames = await (await db.ListCollectionNamesAsync(cancellationToken: TestContext.Current.CancellationToken))
+			.ToListAsync(TestContext.Current.CancellationToken);
+		collectionNames.Should().Contain("blogposts");
+		collectionNames.Should().Contain("categories");
+		collectionNames.Should().NotContain("posts", "legacy posts collection should be dropped during seed normalization");
+		collectionNames.Should().NotContain("tags", "legacy tags collection should be dropped during seed normalization");
+		result.Message.Should().Contain("dropped legacy collections: posts, tags");
+	}
+
+	/// <summary>
 	/// The seed command must always upsert the canonical seven categories with their
 	/// documented ObjectIds so downstream features can rely on stable category identities.
 	/// </summary>

--- a/tests/Architecture.Tests/Architecture.Tests.csproj
+++ b/tests/Architecture.Tests/Architecture.Tests.csproj
@@ -7,6 +7,7 @@
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
 		<RootNamespace>MyBlog.Architecture.Tests</RootNamespace>
+		<NoWarn>$(NoWarn);CA2007</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/tests/Architecture.Tests/AuthFallbackContractTests.cs
+++ b/tests/Architecture.Tests/AuthFallbackContractTests.cs
@@ -14,11 +14,13 @@ public sealed class AuthFallbackContractTests
 	private static readonly string RepoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../"));
 
 	[Fact]
-	public void AccountLogin_Should_ShortCircuitPlaceholderAuth0Config_BeforeOidcChallenge()
+	public void AccountLogin_Should_ShortCircuitPlaceholderAuth0Config_OnlyInTesting_BeforeOidcChallenge()
 	{
 		// Arrange
 		var loginHandlerSource = ExtractLoginHandler(ReadRepoFile("src/Web/Program.cs"));
-		var placeholderGuardIndex = loginHandlerSource.IndexOf("if (isPlaceholderAuth0Config)", StringComparison.Ordinal);
+		var placeholderGuardIndex = loginHandlerSource.IndexOf(
+			"if (usesLocalTestLoginFallback && app.Environment.IsEnvironment(\"Testing\"))",
+			StringComparison.Ordinal);
 		var localRedirectIndex = loginHandlerSource.IndexOf(
 			"ctx.Response.Redirect($\"/test/login?returnUrl={Uri.EscapeDataString(safeReturn)}\")",
 			StringComparison.Ordinal);
@@ -29,13 +31,40 @@ public sealed class AuthFallbackContractTests
 		// Act / Assert
 		placeholderGuardIndex.Should().BeGreaterThanOrEqualTo(
 			0,
-			because: "the login endpoint must detect placeholder Auth0 settings before trying OIDC");
+			because: "only the Testing environment may bypass Auth0 and short-circuit to the local test login");
 		localRedirectIndex.Should().BeGreaterThan(
 			placeholderGuardIndex,
-			because: "placeholder Auth0 settings in Development/Testing should redirect to the local test login endpoint");
+			because: "the Testing fallback must redirect to the local test login endpoint before issuing any OIDC challenge");
 		challengeIndex.Should().BeGreaterThan(
 			localRedirectIndex,
 			because: "real Auth0 credentials must still use the normal OIDC challenge flow");
+	}
+
+	[Fact]
+	public void TestLoginEndpoint_Should_Be_Registered_OnlyInTesting()
+	{
+		// Arrange
+		var programSource = ReadRepoFile("src/Web/Program.cs");
+		var testingGuardIndex = programSource.IndexOf(
+			"if (app.Environment.IsEnvironment(\"Testing\"))",
+			StringComparison.Ordinal);
+		var testLoginEndpointIndex = programSource.IndexOf(
+			"app.MapGet(\"/test/login\", MapTestLoginEndpoint).AllowAnonymous();",
+			StringComparison.Ordinal);
+		var legacyDevelopmentGuardIndex = programSource.IndexOf(
+			"if (app.Environment.IsDevelopment() || app.Environment.IsEnvironment(\"Testing\"))",
+			StringComparison.Ordinal);
+
+		// Act / Assert
+		testingGuardIndex.Should().BeGreaterThanOrEqualTo(
+			0,
+			because: "the local test login endpoint must be fenced to the Testing environment");
+		testLoginEndpointIndex.Should().BeGreaterThan(
+			testingGuardIndex,
+			because: "the Testing-only guard must wrap the local test login endpoint registration");
+		legacyDevelopmentGuardIndex.Should().BeLessThan(
+			0,
+			because: "Development should go through real Auth0 rather than the local test login endpoint");
 	}
 
 	private static string ExtractLoginHandler(string programSource)

--- a/tests/Architecture.Tests/AuthFallbackContractTests.cs
+++ b/tests/Architecture.Tests/AuthFallbackContractTests.cs
@@ -67,6 +67,27 @@ public sealed class AuthFallbackContractTests
 			because: "Development should go through real Auth0 rather than the local test login endpoint");
 	}
 
+	[Fact]
+	public void OidcTokenValidatedHook_Should_NullGuard_ExistingDelegate_Before_Invoking_It()
+	{
+		// Arrange
+		var programSource = ReadRepoFile("src/Web/Program.cs");
+		var nullGuardIndex = programSource.IndexOf(
+			"if (existingOnTokenValidated is not null)",
+			StringComparison.Ordinal);
+		var callbackInvokeIndex = programSource.IndexOf(
+			"await existingOnTokenValidated(context).ConfigureAwait(false);",
+			StringComparison.Ordinal);
+
+		// Act / Assert
+		nullGuardIndex.Should().BeGreaterThanOrEqualTo(
+			0,
+			because: "the Auth0 SDK may leave the original token-validated callback unset");
+		callbackInvokeIndex.Should().BeGreaterThan(
+			nullGuardIndex,
+			because: "the wrapped token-validated callback must only invoke the original delegate after a null guard");
+	}
+
 	private static string ExtractLoginHandler(string programSource)
 	{
 		var start = programSource.IndexOf("app.MapGet(\"/Account/Login\"", StringComparison.Ordinal);

--- a/tests/Domain.Tests/Domain.Tests.csproj
+++ b/tests/Domain.Tests/Domain.Tests.csproj
@@ -7,6 +7,7 @@
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
 		<RootNamespace>MyBlog.Domain.Tests</RootNamespace>
+		<NoWarn>$(NoWarn);CA2007</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/tests/Web.Tests.Bunit/Components/RazorSmokeTests.cs
+++ b/tests/Web.Tests.Bunit/Components/RazorSmokeTests.cs
@@ -545,8 +545,9 @@ public class RazorSmokeTests : BunitContext
 				};
 		var roles = new[]
 		{
-						new RoleDto("role-admin", "Admin"),
-						new RoleDto("role-author", "Author")
+						new RoleDto("role-viewer", "Viewer"),
+						new RoleDto("role-author", "Author"),
+						new RoleDto("role-admin", "Admin")
 				};
 
 		sender.Send(Arg.Any<GetUsersWithRolesQuery>(), Arg.Any<CancellationToken>())
@@ -564,8 +565,56 @@ public class RazorSmokeTests : BunitContext
 
 		heading.TextContent.Trim().Should().Be("Manage User Roles");
 		heading.GetAttribute("class").Should().Contain("text-primary-900").And.Contain("dark:text-primary-50");
-		cut.Markup.Should().Contain("Available roles: Admin, Author");
+		cut.Markup.Should().Contain("Available roles: Admin, Author, Viewer");
 		cut.Markup.Should().Contain("admin@example.com");
+
+		var actionButtons = cut.FindAll("tbody button");
+		actionButtons.Select(button => button.TextContent.Trim()).Should().ContainInOrder(
+				"Admin: Active (Remove)",
+				"Author: Inactive (Add)",
+				"Viewer: Inactive (Add)");
+
+		var activeRoleButton = actionButtons.First(button => string.Equals(button.TextContent.Trim(), "Admin: Active (Remove)", StringComparison.Ordinal));
+		var inactiveRoleButton = actionButtons.First(button => string.Equals(button.TextContent.Trim(), "Author: Inactive (Add)", StringComparison.Ordinal));
+
+		activeRoleButton.GetAttribute("class").Should().Contain("border-green-600").And.Contain("text-green-600");
+		inactiveRoleButton.GetAttribute("class").Should().Contain("border-red-600").And.Contain("text-red-600");
+	}
+
+	[Fact]
+	public void ManageRolesSortsAvailableRolesCaseInsensitively()
+	{
+		// Arrange
+		var sender = Substitute.For<ISender>();
+		var users = new[]
+		{
+						new UserWithRolesDto("user-1", "admin@example.com", "Admin User", ["admin"])
+				};
+		var roles = new[]
+		{
+						new RoleDto("role-viewer", "viewer"),
+						new RoleDto("role-author", "Author"),
+						new RoleDto("role-admin", "admin")
+				};
+
+		sender.Send(Arg.Any<GetUsersWithRolesQuery>(), Arg.Any<CancellationToken>())
+				.Returns(Task.FromResult(Result.Ok<IReadOnlyList<UserWithRolesDto>>(users)));
+		sender.Send(Arg.Any<GetAvailableRolesQuery>(), Arg.Any<CancellationToken>())
+				.Returns(Task.FromResult(Result.Ok<IReadOnlyList<RoleDto>>(roles)));
+
+		Services.AddSingleton(sender);
+
+		// Act
+		var cut = RenderWithUser<ManageRoles>(CreatePrincipal("Admin User", ["Admin"]));
+
+		// Assert
+		cut.Markup.Should().Contain("Available roles: admin, Author, viewer");
+
+		var actionButtons = cut.FindAll("tbody button");
+		actionButtons.Select(button => button.TextContent.Trim()).Should().ContainInOrder(
+				"admin: Active (Remove)",
+				"Author: Inactive (Add)",
+				"viewer: Inactive (Add)");
 	}
 
 	[Fact]
@@ -648,7 +697,7 @@ public class RazorSmokeTests : BunitContext
 		// Act
 		var cut = RenderWithUser<ManageRoles>(CreatePrincipal("Admin User", ["Admin"]));
 
-		cut.FindAll("button").First(button => button.TextContent.Contains("+ Author")).Click();
+		cut.FindAll("button").First(button => string.Equals(button.TextContent.Trim(), "Author: Inactive (Add)", StringComparison.Ordinal)).Click();
 
 		// Assert
 		sender.Received(1).Send(Arg.Is<AssignRoleCommand>(command => command.UserId == "user-1" && command.RoleId == "role-author"), Arg.Any<CancellationToken>());
@@ -688,13 +737,13 @@ public class RazorSmokeTests : BunitContext
 		// Act
 		var cut = RenderWithUser<ManageRoles>(CreatePrincipal("Admin User", ["Admin"]));
 
-		cut.FindAll("button").First(button => button.TextContent.Contains("- Author")).Click();
+		cut.FindAll("button").First(button => string.Equals(button.TextContent.Trim(), "Author: Active (Remove)", StringComparison.Ordinal)).Click();
 
 		// Assert
 		sender.Received(1).Send(Arg.Is<RemoveRoleCommand>(command => command.UserId == "user-1" && command.RoleId == "role-author"), Arg.Any<CancellationToken>());
 		cut.WaitForAssertion(() =>
 		{
-			cut.Markup.Should().Contain("+ Author");
+			cut.Markup.Should().Contain("Author: Inactive (Add)");
 			cut.Markup.Should().Contain("<td>Admin</td>");
 		});
 	}

--- a/tests/Web.Tests.Bunit/Components/RazorSmokeTests.cs
+++ b/tests/Web.Tests.Bunit/Components/RazorSmokeTests.cs
@@ -226,7 +226,7 @@ public class RazorSmokeTests : BunitContext
 		// Arrange
 		var sender = Substitute.For<ISender>();
 		sender.Send(Arg.Any<GetBlogPostsQuery>(), Arg.Any<CancellationToken>())
-				.Returns(Task.FromResult(Result.Ok<IReadOnlyList<BlogPostDto>>(Array.Empty<BlogPostDto>())));
+				.Returns(Task.FromResult(Result.Ok<IReadOnlyList<BlogPostDto>>([])));
 
 		Services.AddSingleton(sender);
 
@@ -270,7 +270,7 @@ public class RazorSmokeTests : BunitContext
 		sender.Send(Arg.Any<GetBlogPostsQuery>(), Arg.Any<CancellationToken>())
 				.Returns(
 						Task.FromResult(Result.Ok<IReadOnlyList<BlogPostDto>>(posts)),
-						Task.FromResult(Result.Ok<IReadOnlyList<BlogPostDto>>(Array.Empty<BlogPostDto>())));
+						Task.FromResult(Result.Ok<IReadOnlyList<BlogPostDto>>([])));
 		sender.Send(Arg.Any<DeleteBlogPostCommand>(), Arg.Any<CancellationToken>())
 				.Returns(Task.FromResult(Result.Ok()));
 
@@ -381,10 +381,10 @@ public class RazorSmokeTests : BunitContext
 		// Act
 		var cut = RenderWithUser<Create>(CreatePrincipal("Alice", ["Author"]));
 
-		cut.FindAll("input")[0].Change("My title");
+		await cut.FindAll("input")[0].ChangeAsync("My title");
 		var textEditor = cut.FindComponent<TextEditor>();
 		await cut.InvokeAsync(() => textEditor.Instance.ContentChanged.InvokeAsync("Hello world"));
-		cut.Find("form").Submit();
+		await cut.Find("form").SubmitAsync();
 
 		// Assert
 		await sender.Received(1).Send(Arg.Is<CreateBlogPostCommand>(command =>
@@ -406,14 +406,14 @@ public class RazorSmokeTests : BunitContext
 		// Act
 		var cut = RenderWithUser<Create>(CreatePrincipal("Alice", ["Author"]));
 
-		cut.FindAll("input")[0].Change("My title");
+		await cut.FindAll("input")[0].ChangeAsync("My title");
 		var textEditor = cut.FindComponent<TextEditor>();
 		await cut.InvokeAsync(() => textEditor.Instance.ContentChanged.InvokeAsync("Hello world"));
-		cut.Find("form").Submit();
+		await cut.Find("form").SubmitAsync();
 
 		// Assert
 		cut.Markup.Should().Contain("Unable to create post.");
-		cut.Find("button.alert-dismiss").Click();
+		await cut.Find("button.alert-dismiss").ClickAsync();
 		cut.Markup.Should().NotContain("Unable to create post.");
 	}
 
@@ -638,8 +638,8 @@ public class RazorSmokeTests : BunitContext
 		// Assert
 		cut.Markup.Should().Contain("Loading users...");
 
-		usersTask.SetResult(Result.Ok<IReadOnlyList<UserWithRolesDto>>(Array.Empty<UserWithRolesDto>()));
-		rolesTask.SetResult(Result.Ok<IReadOnlyList<RoleDto>>(Array.Empty<RoleDto>()));
+		usersTask.SetResult(Result.Ok<IReadOnlyList<UserWithRolesDto>>([]));
+		rolesTask.SetResult(Result.Ok<IReadOnlyList<RoleDto>>([]));
 		cut.WaitForAssertion(() => cut.Markup.Should().Contain("Actions"));
 	}
 
@@ -651,7 +651,7 @@ public class RazorSmokeTests : BunitContext
 		sender.Send(Arg.Any<GetUsersWithRolesQuery>(), Arg.Any<CancellationToken>())
 				.Returns(Task.FromResult(Result.Fail<IReadOnlyList<UserWithRolesDto>>("Unable to load users.")));
 		sender.Send(Arg.Any<GetAvailableRolesQuery>(), Arg.Any<CancellationToken>())
-				.Returns(Task.FromResult(Result.Ok<IReadOnlyList<RoleDto>>(Array.Empty<RoleDto>())));
+				.Returns(Task.FromResult(Result.Ok<IReadOnlyList<RoleDto>>([])));
 
 		Services.AddSingleton(sender);
 

--- a/tests/Web.Tests.Bunit/Web.Tests.Bunit.csproj
+++ b/tests/Web.Tests.Bunit/Web.Tests.Bunit.csproj
@@ -7,6 +7,7 @@
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
 		<RootNamespace>Web</RootNamespace>
+		<NoWarn>$(NoWarn);CA2007</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/tests/Web.Tests.Integration/Infrastructure/RedisCachingCollection.cs
+++ b/tests/Web.Tests.Integration/Infrastructure/RedisCachingCollection.cs
@@ -11,6 +11,4 @@ namespace Web.Infrastructure;
 
 [CollectionDefinition("RedisCaching")]
 public sealed class RedisCachingCollection
-: ICollectionFixture<RedisFixture>
-{
-}
+: ICollectionFixture<RedisFixture>;

--- a/tests/Web.Tests.Integration/Web.Tests.Integration.csproj
+++ b/tests/Web.Tests.Integration/Web.Tests.Integration.csproj
@@ -7,6 +7,7 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <RootNamespace>Web</RootNamespace>
+    <NoWarn>$(NoWarn);CA2007</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Web.Tests/Handlers/UserManagementHandlerTests.cs
+++ b/tests/Web.Tests/Handlers/UserManagementHandlerTests.cs
@@ -83,6 +83,21 @@ public class UserManagementHandlerTests
 		result.Error.Should().Contain("Auth0:ManagementApiDomain not configured");
 	}
 
+	[Fact]
+	public async Task HandleGetUsersWithRolesDomainMissingReportsNestedFallbackKeyInErrorMessage()
+	{
+		// Arrange (none)
+
+		// Act
+		var result = await _handler.Handle(new GetUsersWithRolesQuery(), CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain("Auth0Management:Domain not configured");
+		result.Error.Should().Contain("Auth0:ManagementApiDomain not configured");
+		result.Error.Should().Contain("Auth0:Auth0Management:Domain not configured");
+	}
+
 	// ── ClientId missing ────────────────────────────────────────────────────────────────
 
 	[Fact]

--- a/tests/Web.Tests/Handlers/UserManagementHandlerTests.cs
+++ b/tests/Web.Tests/Handlers/UserManagementHandlerTests.cs
@@ -319,6 +319,29 @@ public class UserManagementHandlerTests
 		requestBody.RootElement.GetProperty("grant_type").GetString().Should().Be("client_credentials");
 	}
 
+	[Fact]
+	public async Task HandleGetAvailableRolesNestedAuth0ManagementKeysFallBackToNestedConfig()
+	{
+		// Arrange
+		using var httpHandler = new RecordingTokenHttpHandler("{\"access_token\":\"\"}");
+		using var httpClient = new HttpClient(httpHandler, disposeHandler: false);
+		var handler = BuildHandlerWithNestedAuth0ManagementKeys(new StaticHttpClientFactory(httpClient));
+
+		// Act
+		var result = await handler.Handle(new GetAvailableRolesQuery(), CancellationToken.None);
+		httpHandler.LastRequestBody.Should().NotBeNullOrWhiteSpace();
+		using var requestBody = JsonDocument.Parse(httpHandler.LastRequestBody!);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Be(InvalidAccessTokenError);
+		httpHandler.LastRequestUri.Should().Be(new Uri("https://nested.auth0.com/oauth/token"));
+		requestBody.RootElement.GetProperty("client_id").GetString().Should().Be("nested-client-id");
+		requestBody.RootElement.GetProperty("client_secret").GetString().Should().Be("nested-client-secret");
+		requestBody.RootElement.GetProperty("audience").GetString().Should().Be("https://nested.auth0.com/api/v2/");
+		requestBody.RootElement.GetProperty("grant_type").GetString().Should().Be("client_credentials");
+	}
+
 	[Theory]
 	[InlineData("{\"access_token\":\"\"}")]
 	[InlineData("{\"access_token\":\"   \"}")]
@@ -379,6 +402,15 @@ public class UserManagementHandlerTests
 		config["Auth0:ManagementApiDomain"].Returns("legacy.auth0.com");
 		config["Auth0:ManagementApiClientId"].Returns("legacy-client-id");
 		config["Auth0:ManagementApiClientSecret"].Returns("legacy-client-secret");
+		return new UserManagementHandler(config, httpFactory, BuildPassThroughCache());
+	}
+
+	private static UserManagementHandler BuildHandlerWithNestedAuth0ManagementKeys(IHttpClientFactory httpFactory)
+	{
+		var config = Substitute.For<IConfiguration>();
+		config["Auth0:Auth0Management:Domain"].Returns("nested.auth0.com");
+		config["Auth0:Auth0Management:ClientId"].Returns("nested-client-id");
+		config["Auth0:Auth0Management:ClientSecret"].Returns("nested-client-secret");
 		return new UserManagementHandler(config, httpFactory, BuildPassThroughCache());
 	}
 

--- a/tests/Web.Tests/Infrastructure/Caching/BlogPostCacheServiceTests.cs
+++ b/tests/Web.Tests/Infrastructure/Caching/BlogPostCacheServiceTests.cs
@@ -78,6 +78,65 @@ public class BlogPostCacheServiceTests : IDisposable
 	}
 
 	[Fact]
+	public async Task GetOrFetchAllAsync_L1Hit_WithEmptyList_RemovesStaleEntryAndFallsThroughToFetch()
+	{
+		// Arrange
+		_realLocalCache.Set(BlogPostCacheKeys.All, new List<BlogPostDto>());
+		_distributedCache.GetAsync(BlogPostCacheKeys.All, Arg.Any<CancellationToken>())
+			.Returns(Task.FromResult<byte[]?>(null));
+		_distributedCache.SetAsync(
+			Arg.Any<string>(), Arg.Any<byte[]>(), Arg.Any<DistributedCacheEntryOptions>(), Arg.Any<CancellationToken>())
+			.Returns(Task.CompletedTask);
+
+		var expected = MakeDtos();
+		var fetchCalled = false;
+
+		Task<IReadOnlyList<BlogPostDto>> fetch()
+		{
+			fetchCalled = true;
+			return Task.FromResult<IReadOnlyList<BlogPostDto>>(expected);
+		}
+
+		// Act
+		var result = await _sut.GetOrFetchAllAsync(fetch, CancellationToken.None);
+
+		// Assert
+		fetchCalled.Should().BeTrue();
+		result.Should().BeEquivalentTo(expected);
+	}
+
+	[Fact]
+	public async Task GetOrFetchAllAsync_L2Hit_WithEmptyList_RemovesStaleEntryAndFallsThroughToFetch()
+	{
+		// Arrange
+		var emptyBytes = JsonSerializer.SerializeToUtf8Bytes(new List<BlogPostDto>(), JsonOpts);
+		_distributedCache.GetAsync(BlogPostCacheKeys.All, Arg.Any<CancellationToken>())
+			.Returns(Task.FromResult<byte[]?>(emptyBytes));
+		_distributedCache.RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+			.Returns(Task.CompletedTask);
+		_distributedCache.SetAsync(
+			Arg.Any<string>(), Arg.Any<byte[]>(), Arg.Any<DistributedCacheEntryOptions>(), Arg.Any<CancellationToken>())
+			.Returns(Task.CompletedTask);
+
+		var expected = MakeDtos();
+		var fetchCalled = false;
+
+		Task<IReadOnlyList<BlogPostDto>> fetch()
+		{
+			fetchCalled = true;
+			return Task.FromResult<IReadOnlyList<BlogPostDto>>(expected);
+		}
+
+		// Act
+		var result = await _sut.GetOrFetchAllAsync(fetch, CancellationToken.None);
+
+		// Assert
+		fetchCalled.Should().BeTrue();
+		result.Should().BeEquivalentTo(expected);
+		await _distributedCache.Received().RemoveAsync(BlogPostCacheKeys.All, CancellationToken.None);
+	}
+
+	[Fact]
 	public async Task GetOrFetchAllAsync_L2JsonCorrupt_RemovesAndFallsThroughToFetch()
 	{
 		// Arrange
@@ -129,6 +188,28 @@ public class BlogPostCacheServiceTests : IDisposable
 		l1Val.Should().HaveCount(2);
 		await _distributedCache.Received().SetAsync(
 			BlogPostCacheKeys.All,
+			Arg.Any<byte[]>(),
+			Arg.Any<DistributedCacheEntryOptions>(),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task GetOrFetchAllAsync_FullMiss_WithEmptyFetchResult_DoesNotPopulateCache()
+	{
+		// Arrange
+		_distributedCache.GetAsync(BlogPostCacheKeys.All, Arg.Any<CancellationToken>())
+			.Returns(Task.FromResult<byte[]?>(null));
+
+		// Act
+		var result = await _sut.GetOrFetchAllAsync(
+			() => Task.FromResult<IReadOnlyList<BlogPostDto>>([]),
+			CancellationToken.None);
+
+		// Assert
+		result.Should().BeEmpty();
+		_realLocalCache.TryGetValue(BlogPostCacheKeys.All, out List<BlogPostDto>? _).Should().BeFalse();
+		await _distributedCache.DidNotReceive().SetAsync(
+			Arg.Any<string>(),
 			Arg.Any<byte[]>(),
 			Arg.Any<DistributedCacheEntryOptions>(),
 			Arg.Any<CancellationToken>());

--- a/tests/Web.Tests/Infrastructure/Caching/BlogPostCacheServiceTests.cs
+++ b/tests/Web.Tests/Infrastructure/Caching/BlogPostCacheServiceTests.cs
@@ -9,8 +9,6 @@
 
 using System.Text.Json;
 
-using Microsoft.Extensions.Caching.Memory;
-
 namespace Web.Infrastructure.Caching;
 
 public class BlogPostCacheServiceTests : IDisposable
@@ -44,10 +42,10 @@ public class BlogPostCacheServiceTests : IDisposable
 		_realLocalCache.Set(BlogPostCacheKeys.All, cachedList);
 
 		var fetchCalled = false;
-		Task<IReadOnlyList<BlogPostDto>> fetch() { fetchCalled = true; return Task.FromResult<IReadOnlyList<BlogPostDto>>([]); }
+		Task<IReadOnlyList<BlogPostDto>> Fetch() { fetchCalled = true; return Task.FromResult<IReadOnlyList<BlogPostDto>>([]); }
 
 		// Act
-		var result = await _sut.GetOrFetchAllAsync(fetch, CancellationToken.None);
+		var result = await _sut.GetOrFetchAllAsync(Fetch, CancellationToken.None);
 
 		// Assert
 		result.Should().HaveCount(2);
@@ -91,14 +89,14 @@ public class BlogPostCacheServiceTests : IDisposable
 		var expected = MakeDtos();
 		var fetchCalled = false;
 
-		Task<IReadOnlyList<BlogPostDto>> fetch()
+		Task<IReadOnlyList<BlogPostDto>> Fetch()
 		{
 			fetchCalled = true;
 			return Task.FromResult<IReadOnlyList<BlogPostDto>>(expected);
 		}
 
 		// Act
-		var result = await _sut.GetOrFetchAllAsync(fetch, CancellationToken.None);
+		var result = await _sut.GetOrFetchAllAsync(Fetch, CancellationToken.None);
 
 		// Assert
 		fetchCalled.Should().BeTrue();
@@ -121,14 +119,14 @@ public class BlogPostCacheServiceTests : IDisposable
 		var expected = MakeDtos();
 		var fetchCalled = false;
 
-		Task<IReadOnlyList<BlogPostDto>> fetch()
+		Task<IReadOnlyList<BlogPostDto>> Fetch()
 		{
 			fetchCalled = true;
 			return Task.FromResult<IReadOnlyList<BlogPostDto>>(expected);
 		}
 
 		// Act
-		var result = await _sut.GetOrFetchAllAsync(fetch, CancellationToken.None);
+		var result = await _sut.GetOrFetchAllAsync(Fetch, CancellationToken.None);
 
 		// Assert
 		fetchCalled.Should().BeTrue();
@@ -151,14 +149,14 @@ public class BlogPostCacheServiceTests : IDisposable
 
 		var expected = MakeDtos();
 		var fetchCalled = false;
-		Task<IReadOnlyList<BlogPostDto>> fetch()
+		Task<IReadOnlyList<BlogPostDto>> Fetch()
 		{
 			fetchCalled = true;
 			return Task.FromResult<IReadOnlyList<BlogPostDto>>(expected);
 		}
 
 		// Act
-		var result = await _sut.GetOrFetchAllAsync(fetch, CancellationToken.None);
+		var result = await _sut.GetOrFetchAllAsync(Fetch, CancellationToken.None);
 
 		// Assert
 		fetchCalled.Should().BeTrue();
@@ -231,7 +229,7 @@ public class BlogPostCacheServiceTests : IDisposable
 
 		// Assert
 		result.Should().NotBeNull();
-		result!.Id.Should().Be(id);
+		result.Id.Should().Be(id);
 		await _distributedCache.DidNotReceive().GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
 	}
 
@@ -251,7 +249,7 @@ public class BlogPostCacheServiceTests : IDisposable
 
 		// Assert
 		result.Should().NotBeNull();
-		result!.Id.Should().Be(id);
+		result.Id.Should().Be(id);
 		_realLocalCache.TryGetValue(key, out BlogPostDto? l1Val).Should().BeTrue();
 		l1Val!.Id.Should().Be(id);
 	}
@@ -273,10 +271,10 @@ public class BlogPostCacheServiceTests : IDisposable
 
 		var dto = new BlogPostDto(id, "T", "C", string.Empty, "A", string.Empty, [], DateTime.UtcNow, null, false, null);
 		var fetchCalled = false;
-		Task<BlogPostDto?> fetch() { fetchCalled = true; return Task.FromResult<BlogPostDto?>(dto); }
+		Task<BlogPostDto?> Fetch() { fetchCalled = true; return Task.FromResult<BlogPostDto?>(dto); }
 
 		// Act
-		var result = await _sut.GetOrFetchByIdAsync(id, fetch, CancellationToken.None);
+		var result = await _sut.GetOrFetchByIdAsync(id, Fetch, CancellationToken.None);
 
 		// Assert
 		fetchCalled.Should().BeTrue();

--- a/tests/Web.Tests/Security/Auth0ConfigurationHelperTests.cs
+++ b/tests/Web.Tests/Security/Auth0ConfigurationHelperTests.cs
@@ -1,0 +1,100 @@
+//=======================================================
+//Copyright (c) 2026. All rights reserved.
+//File Name :     Auth0ConfigurationHelperTests.cs
+//Company :       mpaulosky
+//Author :        Matthew Paulosky
+//Solution Name : MyBlog
+//Project Name :  Web.Tests
+//=======================================================
+
+using MyBlog.Web.Security;
+
+namespace Web.Security;
+
+public sealed class Auth0ConfigurationHelperTests
+{
+	[Theory]
+	[InlineData(null, "real-client-id")]
+	[InlineData("", "real-client-id")]
+	[InlineData("real-tenant.auth0.com", null)]
+	[InlineData("real-tenant.auth0.com", "")]
+	[InlineData("test.auth0.com", "real-client-id")]
+	[InlineData("TEST.AUTH0.COM", "real-client-id")]
+	[InlineData("real-tenant.auth0.com", "test-client-id")]
+	[InlineData("real-tenant.auth0.com", "TEST-CLIENT-ID")]
+	[InlineData("test.auth0.com", "test-client-id")]
+	[InlineData("TEST.AUTH0.COM", "TEST-CLIENT-ID")]
+	public void UsesPlaceholderWebAppLogin_ReturnsTrue_ForMissingOrKnownPlaceholderValues(string? domain, string? clientId)
+	{
+		// Act
+		var result = Auth0ConfigurationHelper.UsesPlaceholderWebAppLogin(domain, clientId);
+
+		// Assert
+		result.Should().BeTrue();
+	}
+
+	[Theory]
+	[InlineData(null, "real-client-id", "real-client-secret")]
+	[InlineData("", "real-client-id", "real-client-secret")]
+	[InlineData("real-tenant.auth0.com", null, "real-client-secret")]
+	[InlineData("real-tenant.auth0.com", "", "real-client-secret")]
+	[InlineData("real-tenant.auth0.com", "real-client-id", null)]
+	[InlineData("real-tenant.auth0.com", "real-client-id", "")]
+	[InlineData("test.auth0.com", "real-client-id", "real-client-secret")]
+	[InlineData("TEST.AUTH0.COM", "real-client-id", "real-client-secret")]
+	[InlineData("real-tenant.auth0.com", "test-client-id", "real-client-secret")]
+	[InlineData("real-tenant.auth0.com", "TEST-CLIENT-ID", "real-client-secret")]
+	[InlineData("real-tenant.auth0.com", "real-client-id", "test-client-secret")]
+	public void UsesPlaceholderWebAppLogin_WithClientSecret_ReturnsTrue_ForMissingOrKnownPlaceholderValues(
+			string? domain,
+			string? clientId,
+			string? clientSecret)
+	{
+		// Act
+		var result = Auth0ConfigurationHelper.UsesPlaceholderWebAppLogin(domain, clientId, clientSecret);
+
+		// Assert
+		result.Should().BeTrue();
+	}
+
+	[Theory]
+	[InlineData("tenant.auth0.com", "client-id", "client-secret")]
+	[InlineData("TENANT.AUTH0.COM", "CLIENT-ID", "client-secret")]
+	[InlineData("tenant.auth0.com", "client-id", "TEST-CLIENT-SECRET")]
+	public void UsesPlaceholderWebAppLogin_WithClientSecret_ReturnsFalse_ForRealAuth0Settings(
+			string domain,
+			string clientId,
+			string clientSecret)
+	{
+		// Act
+		var result = Auth0ConfigurationHelper.UsesPlaceholderWebAppLogin(domain, clientId, clientSecret);
+
+		// Assert
+		result.Should().BeFalse();
+	}
+
+	[Theory]
+	[InlineData(true, "test.auth0.com", "test-client-id", "test-client-secret", true)]
+	[InlineData(true, "TEST.AUTH0.COM", "TEST-CLIENT-ID", "test-client-secret", true)]
+	[InlineData(true, "tenant.auth0.com", "client-id", null, true)]
+	[InlineData(true, "tenant.auth0.com", "client-id", "client-secret", false)]
+	[InlineData(false, "test.auth0.com", "test-client-id", "test-client-secret", false)]
+	[InlineData(false, "tenant.auth0.com", "client-id", null, false)]
+	public void ShouldUseLocalTestLogin_WithClientSecret_ReturnsExpectedValue(
+			bool isTestingEnvironment,
+			string? domain,
+			string? clientId,
+			string? clientSecret,
+			bool expected)
+	{
+		// Act
+		var result = Auth0ConfigurationHelper.ShouldUseLocalTestLogin(
+				isTestingEnvironment,
+				domain,
+				clientId,
+				clientSecret);
+
+		// Assert
+		result.Should().Be(expected);
+	}
+}

--- a/tests/Web.Tests/Web.Tests.csproj
+++ b/tests/Web.Tests/Web.Tests.csproj
@@ -7,6 +7,7 @@
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
 		<RootNamespace>Web</RootNamespace>
+		<NoWarn>$(NoWarn);CA2007</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Closes #400

Working as Sam (Backend / .NET)

## Summary
- harden Auth0 startup and Testing-only fallback behavior with explicit helper coverage
- keep Manage Roles buttons state-colored and alphabetically ordered while clarifying active/inactive action text
- normalize stale cache and legacy Mongo collection behavior with focused test coverage
- suppress `CA2007` in the xUnit test projects where it was still noisy

## Validation
- `dotnet test tests/Domain.Tests/Domain.Tests.csproj -c Release`
- `dotnet test tests/Web.Tests/Web.Tests.csproj -c Release`
- `dotnet test tests/Web.Tests.Bunit/Web.Tests.Bunit.csproj -c Release`
- `dotnet test tests/Architecture.Tests/Architecture.Tests.csproj -c Release`
- `dotnet test tests/Web.Tests.Integration/Web.Tests.Integration.csproj -c Release`
- `dotnet test tests/AppHost.Tests/AppHost.Tests.csproj -c Release`
